### PR TITLE
Fix 2 P9 issues.

### DIFF
--- a/attribute_types.xml
+++ b/attribute_types.xml
@@ -20250,6 +20250,7 @@ Measured in GB</description>
     <writeable/>
 </attribute>
 
+<!--
 <enumerationType>
     <id>FAPI_POS</id>
     <description>Enumeration defining special FAPI_POS values</description>
@@ -20259,6 +20260,7 @@ Measured in GB</description>
     </enumerator>
     <default>NA</default>
 </enumerationType>
+-->
 
 <attribute>
     <id>FAPI_POS</id>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -3579,7 +3579,7 @@
     <parent>unit</parent>
     <attribute>
         <id>TYPE</id>
-        <default>NVBUS</default>
+        <default>NV</default>
     </attribute>
     <attribute><id>DECONFIG_GARDABLE</id><default>1</default></attribute>
 </targetType>


### PR DESCRIPTION
1.  Change NVBUS to NV to match enumeration (issue #4)
2.  Comment out the FAPI_POS enumerator (issue #5)

I don't see any system XML using these items yet.  Without these fixes, Targets.pm will fail.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>