### PR TITLE
Add a BATTERY class to CLASS enumeration

### DIFF
--- a/attribute_types.xml
+++ b/attribute_types.xml
@@ -67,8 +67,12 @@
         <value>7</value>
     </enumerator>
     <enumerator>
-        <name>MAX</name>
+        <name>BATTERY</name>
         <value>8</value>
+    </enumerator>
+    <enumerator>
+        <name>MAX</name>
+        <value>9</value>
     </enumerator>
     <default>NA</default>
 </enumerationType>


### PR DESCRIPTION
The FSP needs to be able to uniquely identify a Battery part. Since the battery does not fit any of of the existing target classes in the CLASS enum, I added a new value to represent it.
