### PR TITLE
BMC wiring fixes

### DIFF
--- a/parts/chip-bmc-ast2500.xml
+++ b/parts/chip-bmc-ast2500.xml
@@ -36826,7 +36826,7 @@
 	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
-		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
+		<default>txd1,rxd1,nrts1,ndtr1,ndsr1,ncts1,ndcd1,nri1</default>
 	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
@@ -38349,7 +38349,7 @@
 	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
-		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
+		<default>txd2,rxd2,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>

--- a/parts/led-led-generic.xml
+++ b/parts/led-led-generic.xml
@@ -6,12 +6,44 @@
       <default>GREEN</default>
     </attribute>
     <attribute>
+      <id>LED_TYPE</id>
+	  <default>NA</default>
+	</attribute>
+    <attribute>
       <id>MRW_TYPE</id>
       <default>LED</default>
     </attribute>
     <attribute>
       <id>TYPE</id>
       <default>NA</default>
+    </attribute>
+    <attribute>
+        <id>BLINK_ROLLUP</id>
+        <default></default>
+    </attribute>
+    <attribute>
+        <id>VIEW_REAR</id>
+        <default></default>
+    </attribute>
+    <attribute>
+        <id>VIEW_FRONT</id>
+        <default></default>
+    </attribute>
+    <attribute>
+        <id>VIEW_INTERNAL</id>
+        <default></default>
+    </attribute>
+    <attribute>
+        <id>FUNCTION</id>
+        <default></default>
+    </attribute>
+    <attribute>
+        <id>BLINK_RATE</id>
+        <default></default>
+    </attribute>
+    <attribute>
+        <id>ON_STATE</id>
+        <default>0</default>
     </attribute>
     <child_id>led_enable</child_id>
     <child_id>generic-logic-assoc</child_id>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -2828,56 +2828,6 @@
 		</attribute>
 	</targetType>
 	<targetType>
-		<id>led-led-generic</id>
-		<parent>base</parent>
-		<parent_type>card-motherboard</parent_type>
-		<parent_type>card-daughtercard</parent_type>
-		<attribute>
-			<id>TYPE</id>
-			<default>NA</default>
-		</attribute>
-		<attribute>
-			<id>MRW_TYPE</id>
-			<default>LED</default>
-		</attribute>
-		<attribute>
-			<id>LED_TYPE</id>
-			<default>NA</default>
-		</attribute>
-		<attribute>
-			<id>LED_COLOR</id>
-			<default>GREEN</default>
-		</attribute>
-		<attribute>
-			<id>BLINK_ROLLUP</id>
-			<default></default>
-		</attribute>
-		<attribute>
-			<id>VIEW_REAR</id>
-			<default></default>
-		</attribute>
-		<attribute>
-			<id>VIEW_FRONT</id>
-			<default></default>
-		</attribute>
-		<attribute>
-			<id>VIEW_INTERNAL</id>
-			<default></default>
-		</attribute>
-		<attribute>
-			<id>FUNCTION</id>
-			<default></default>
-		</attribute>
-		<attribute>
-			<id>BLINK_RATE</id>
-			<default></default>
-		</attribute>
-		<attribute>
-			<id>ON_STATE</id>
-			<default>0</default>
-		</attribute>
-	</targetType>
-	<targetType>
 		<id>unit-spcn-master</id>
 		<parent>unit</parent>
 		<attribute>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -4680,6 +4680,10 @@
 			<id>DIRECTION</id>
 			<default>IN</default>
 		</attribute>
+        <attribute>
+			<id>BUS_TYPE</id>
+			<default>U750</default>
+		</attribute>
 	</targetType>
 <!-- End APSS units -->
 


### PR DESCRIPTION
1)  Add pinctrl functions for uarts, needed by kernel in BMC device tree
2) Add bus_type attribute to apss uart slave so it can be connected to the BMC.