### PR TITLE
Updates to Lagrange XML

### DIFF
--- a/parts/module-module-lagrange.xml
+++ b/parts/module-module-lagrange.xml
@@ -1,7 +1,7 @@
 <partInstance>
 <version>2.1</version>
 <targetInstances>
-  <targetPart>
+<targetPart>
     <id>module-module-lagrange</id>
     <attribute>
       <id>POSITION</id>
@@ -11,16 +11,16 @@
       <id>TYPE</id>
       <default>NA</default>
     </attribute>
-    <child_id>p9_proc_m</child_id>
+    <child_id>p9_proc_l</child_id>
     <instance_name>module</instance_name>
     <is_root>true</is_root>
     <parent>card</parent>
     <parent_type>socket-proc_socket-68mm</parent_type>
     <position>0</position>
     <type>module-module-lagrange</type>
-  </targetPart>
+</targetPart>
 <targetPart>
-  <id>p9_proc_m</id>
+  <id>p9_proc_l</id>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>FABRIC</default>
@@ -70,7 +70,7 @@
     <default>
       <field>
         <id>i2cMasterPath</id>
-        <value>/sys-0/node-0/motherboard-0/proc_socket-0/module-0/p9_proc_m/i2c-master-prom3-sbe-backup/</value>
+        <value>/sys-0/node-0/motherboard-0/proc_socket-0/module-0/p9_proc_l/i2c-master-prom3-sbe-backup/</value>
       </field>
       <field>
         <id>port</id>
@@ -111,7 +111,7 @@
     <default>
       <field>
         <id>i2cMasterPath</id>
-        <value>/sys-0/node-0/motherboard-0/proc_socket-0/module-0/p9_proc_m/i2c-master-prom1-sbe-primary/</value>
+        <value>/sys-0/node-0/motherboard-0/proc_socket-0/module-0/p9_proc_l/i2c-master-prom1-sbe-primary/</value>
       </field>
       <field>
         <id>port</id>
@@ -152,7 +152,7 @@
     <default>
       <field>
         <id>i2cMasterPath</id>
-        <value>/sys-0/node-0/motherboard-0/proc_socket-0/module-0/p9_proc_m/i2c-master-prom2-mvpd-backup/</value>
+        <value>/sys-0/node-0/motherboard-0/proc_socket-0/module-0/p9_proc_l/i2c-master-prom2-mvpd-backup/</value>
       </field>
       <field>
         <id>port</id>
@@ -193,7 +193,7 @@
     <default>
       <field>
         <id>i2cMasterPath</id>
-        <value>/sys-0/node-0/motherboard-0/proc_socket-0/module-0/p9_proc_m/i2c-master-prom0-mvpd-primary/</value>
+        <value>/sys-0/node-0/motherboard-0/proc_socket-0/module-0/p9_proc_l/i2c-master-prom0-mvpd-primary/</value>
       </field>
       <field>
         <id>port</id>
@@ -459,15 +459,15 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_NUM_IOP</id>
-    <default>2</default>
+    <default>3</default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_NUM_LANES</id>
-    <default>24</default>
+    <default>48</default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_NUM_PHB</id>
-    <default>3</default>
+    <default>6</default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_REFCLOCK_ENABLE</id>
@@ -583,14 +583,9 @@
   <child_id>pec0</child_id>
   <child_id>pec1</child_id>
   <child_id>pec2</child_id>
-  <child_id>obus0</child_id>
-  <child_id>obus3</child_id>
   <child_id>nvbus0</child_id>
   <child_id>nvbus1</child_id>
   <child_id>nvbus2</child_id>
-  <child_id>nvbus3</child_id>
-  <child_id>nvbus4</child_id>
-  <child_id>nvbus5</child_id>
   <child_id>ppe0</child_id>
   <child_id>ppe10</child_id>
   <child_id>ppe11</child_id>
@@ -657,10 +652,10 @@
   <child_id>perv53</child_id>
   <child_id>perv54</child_id>
   <child_id>perv55</child_id>
-  <child_id>xbus0</child_id>
+  <child_id>xbus1</child_id>
+  <child_id>xbus2</child_id>
   <child_id>mcbist0</child_id>
   <child_id>mcbist1</child_id>
-  <child_id>pci_configs_power9</child_id>
   <child_id>fsi-slave-0</child_id>
   <child_id>fsi-slave-1</child_id>
   <child_id>fsi-cm-0</child_id>
@@ -693,15 +688,9 @@
   <child_id>psi-slave</child_id>
   <child_id>spi-master</child_id>
   <child_id>proc_fru_assoc</child_id>
-  <hidden_child_id>xbus1</hidden_child_id>
-  <hidden_child_id>xbus2</hidden_child_id>
-  <hidden_child_id>p9_pci-0</hidden_child_id>
-  <hidden_child_id>p9_pci-1</hidden_child_id>
-  <hidden_child_id>p9_pci-2</hidden_child_id>
-  <hidden_child_id>p9_pci-3</hidden_child_id>
   <hidden_child_id>cpu_temp_sensor</hidden_child_id>
   <hidden_child_id>cpu_func_sensor</hidden_child_id>
-  <instance_name>p9_proc_m</instance_name>
+  <instance_name>p9_proc_l</instance_name>
   <is_root>false</is_root>
   <position></position>
   <type>chip-processor-nimbus</type>
@@ -5314,6 +5303,16 @@
 </targetPart>
 <targetPart>
   <id>pec0</id>
+  <type>unit-pec-power9</type>
+  <is_root>false</is_root>
+  <instance_name>pec0</instance_name>
+  <position>-1</position>
+  <parent>unit</parent>
+  <child_id>pec0_x16_config</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -5321,6 +5320,10 @@
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5335,62 +5338,160 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+  	</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_CONFIG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_SWAP</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOVALID_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_M_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_REFCLOCK_ENABLE</id>
     <default>0xE0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5404,14 +5505,128 @@
     <id>TYPE</id>
     <default>PEC</default>
   </attribute>
-  <child_id>phb0</child_id>
-  <instance_name>pec0</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pec-power9</type>
 </targetPart>
 <targetPart>
-  <id>phb0</id>
+  <id>pec0_x16_config</id>
+  <type>unit-pciconfigs-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>pec0_x16_config</instance_name>
+  <position>-1</position>
+  <parent>unit</parent>
+  <child_id>phb0_x16</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>phb0_x16</id>
+  <type>unit-phb-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb0_x16</instance_name>
+  <position>-1</position>
+  <parent>unit-phb-power9</parent>
+  <child_id>phb0_x16_pci</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -5419,6 +5634,10 @@
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5433,33 +5652,31 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
@@ -5470,33 +5687,61 @@
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
   </attribute>
   <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PROC_PCIE_NUM_LANES</id>
-    <default>32</default>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5510,13 +5755,155 @@
     <id>TYPE</id>
     <default>PHB</default>
   </attribute>
-  <instance_name>phb0</instance_name>
+</targetPart>
+<targetPart>
+  <id>phb0_x16_pci</id>
+  <type>unit-pci-nimbus</type>
   <is_root>false</is_root>
+  <instance_name>phb0_x16_pci</instance_name>
   <position>-1</position>
-  <type>unit-phb-nimbus</type>
+  <parent>unit-pci-power9</parent>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_SET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>16</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
 </targetPart>
 <targetPart>
   <id>pec1</id>
+  <type>unit-pec-power9</type>
+  <is_root>false</is_root>
+  <instance_name>pec1</instance_name>
+  <position>-1</position>
+  <parent>unit</parent>
+  <child_id>pec1_x8_x8_config</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -5524,6 +5911,10 @@
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5538,62 +5929,160 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+  	</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_CONFIG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_SWAP</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOVALID_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_M_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_REFCLOCK_ENABLE</id>
     <default>0xE0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5607,15 +6096,129 @@
     <id>TYPE</id>
     <default>PEC</default>
   </attribute>
-  <child_id>phb1</child_id>
-  <child_id>phb2</child_id>
-  <instance_name>pec1</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pec-power9</type>
 </targetPart>
 <targetPart>
-  <id>phb1</id>
+  <id>pec1_x8_x8_config</id>
+  <type>unit-pciconfigs-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>pec1_x8_x8_config</instance_name>
+  <position>-1</position>
+  <parent>unit</parent>
+  <child_id>phb1_x8</child_id>
+  <child_id>phb2_x8</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>phb1_x8</id>
+  <type>unit-phb-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb1_x8</instance_name>
+  <position>-1</position>
+  <parent>unit-phb-power9</parent>
+  <child_id>phb1_x8_pci</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -5623,6 +6226,10 @@
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5637,33 +6244,31 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
@@ -5674,33 +6279,61 @@
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
   </attribute>
   <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PROC_PCIE_NUM_LANES</id>
-    <default>32</default>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5714,13 +6347,155 @@
     <id>TYPE</id>
     <default>PHB</default>
   </attribute>
-  <instance_name>phb1</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-phb-nimbus</type>
 </targetPart>
 <targetPart>
-  <id>phb2</id>
+  <id>phb1_x8_pci</id>
+  <type>unit-pci-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb1_x8_pci</instance_name>
+  <position>-1</position>
+  <parent>unit-pci-power9</parent>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_SET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>8</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>phb2_x8</id>
+  <type>unit-phb-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb2_x8</instance_name>
+  <position>-1</position>
+  <parent>unit-phb-power9</parent>
+  <child_id>phb2_x8_pci</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -5728,6 +6503,10 @@
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5742,33 +6521,31 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
@@ -5779,33 +6556,61 @@
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
   </attribute>
   <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PROC_PCIE_NUM_LANES</id>
-    <default>32</default>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5819,13 +6624,157 @@
     <id>TYPE</id>
     <default>PHB</default>
   </attribute>
-  <instance_name>phb2</instance_name>
+</targetPart>
+<targetPart>
+  <id>phb2_x8_pci</id>
+  <type>unit-pci-nimbus</type>
   <is_root>false</is_root>
+  <instance_name>phb2_x8_pci</instance_name>
   <position>-1</position>
-  <type>unit-phb-nimbus</type>
+  <parent>unit-pci-power9</parent>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_SET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>8</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
 </targetPart>
 <targetPart>
   <id>pec2</id>
+  <type>unit-pec-power9</type>
+  <is_root>false</is_root>
+  <instance_name>pec2</instance_name>
+  <position>-1</position>
+  <parent>unit</parent>
+  <child_id>pec2_x16_config</child_id>
+  <child_id>pec2_x8_x8_config</child_id>
+  <child_id>pec2_x8_x4_x4_config</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -5833,6 +6782,10 @@
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5847,62 +6800,160 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+  	</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_CONFIG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_SWAP</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOVALID_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_M_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_REFCLOCK_ENABLE</id>
     <default>0xE0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5916,16 +6967,128 @@
     <id>TYPE</id>
     <default>PEC</default>
   </attribute>
-  <child_id>phb3</child_id>
-  <child_id>phb4</child_id>
-  <child_id>phb5</child_id>
-  <instance_name>pec2</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pec-power9</type>
 </targetPart>
 <targetPart>
-  <id>phb3</id>
+  <id>pec2_x16_config</id>
+  <type>unit-pciconfigs-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>pec2_x16_config</instance_name>
+  <position>-1</position>
+  <parent>unit</parent>
+  <child_id>phb3_x16</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>phb3_x16</id>
+  <type>unit-phb-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb3_x16</instance_name>
+  <position>-1</position>
+  <parent>unit-phb-power9</parent>
+  <child_id>phb3_x16_pci</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -5933,6 +7096,10 @@
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5947,33 +7114,31 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
@@ -5984,33 +7149,61 @@
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
   </attribute>
   <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PROC_PCIE_NUM_LANES</id>
-    <default>32</default>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -6024,13 +7217,265 @@
     <id>TYPE</id>
     <default>PHB</default>
   </attribute>
-  <instance_name>phb3</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-phb-nimbus</type>
 </targetPart>
 <targetPart>
-  <id>phb4</id>
+  <id>phb3_x16_pci</id>
+  <type>unit-pci-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb3_x16_pci</instance_name>
+  <position>-1</position>
+  <parent>unit-pci-power9</parent>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_SET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>16</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>pec2_x8_x8_config</id>
+  <type>unit-pciconfigs-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>pec2_x8_x8_config</instance_name>
+  <position>-1</position>
+  <parent>unit</parent>
+  <child_id>phb3_x8</child_id>
+  <child_id>phb4_x8</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>phb3_x8</id>
+  <type>unit-phb-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb3_x8</instance_name>
+  <position>-1</position>
+  <parent>unit-phb-power9</parent>
+  <child_id>phb3_x8_pci</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -6038,6 +7483,287 @@
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>phb3_x8_pci</id>
+  <type>unit-pci-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb3_x8_pci</instance_name>
+  <position>-1</position>
+  <parent>unit-pci-power9</parent>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_SET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>8</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>phb4_x8</id>
+  <type>unit-phb-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb4_x8</instance_name>
+  <position>-1</position>
+  <parent>unit-phb-power9</parent>
+  <child_id>phb4_x8_pci</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -6052,33 +7778,31 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
@@ -6089,33 +7813,61 @@
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
   </attribute>
   <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PROC_PCIE_NUM_LANES</id>
-    <default>32</default>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -6129,13 +7881,266 @@
     <id>TYPE</id>
     <default>PHB</default>
   </attribute>
-  <instance_name>phb4</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-phb-nimbus</type>
 </targetPart>
 <targetPart>
-  <id>phb5</id>
+  <id>phb4_x8_pci</id>
+  <type>unit-pci-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb4_x8_pci</instance_name>
+  <position>-1</position>
+  <parent>unit-pci-power9</parent>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_SET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>8</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>pec2_x8_x4_x4_config</id>
+  <type>unit-pciconfigs-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>pec2_x8_x4_x4_config</instance_name>
+  <position>-1</position>
+  <parent>unit</parent>
+  <child_id>phb3_x8</child_id>
+  <child_id>phb4_x4</child_id>
+  <child_id>phb5_x4</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>phb4_x4</id>
+  <type>unit-phb-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb4_x4</instance_name>
+  <position>-1</position>
+  <parent>unit-phb-power9</parent>
+  <child_id>phb4_x4_pci</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -6145,8 +8150,12 @@
     <default>IO</default>
   </attribute>
   <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>CHIP_UNIT</id>
-    <default>5</default>
+    <default>4</default>
   </attribute>
   <attribute>
     <id>CLASS</id>
@@ -6157,33 +8166,31 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
@@ -6194,33 +8201,61 @@
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
   </attribute>
   <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PROC_PCIE_NUM_LANES</id>
-    <default>32</default>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -6234,24 +8269,170 @@
     <id>TYPE</id>
     <default>PHB</default>
   </attribute>
-  <instance_name>phb5</instance_name>
+</targetPart>
+<targetPart>
+  <id>phb4_x4_pci</id>
+  <type>unit-pci-nimbus</type>
   <is_root>false</is_root>
+  <instance_name>phb4_x4_pci</instance_name>
   <position>-1</position>
+  <parent>unit-pci-power9</parent>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_SET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+</targetPart>
+<targetPart>
+  <id>phb5_x4</id>
   <type>unit-phb-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>obus0</id>
+  <is_root>false</is_root>
+  <instance_name>phb5_x4</instance_name>
+  <position>-1</position>
+  <parent>unit-phb-power9</parent>
+  <child_id>phb5_x4_pci</child_id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
-    <default>FABRIC</default>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
-    <default>0</default>
+    <default>5</default>
   </attribute>
   <attribute>
     <id>CLASS</id>
@@ -6262,62 +8443,96 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -6329,26 +8544,31 @@
   </attribute>
   <attribute>
     <id>TYPE</id>
-    <default>OBUS</default>
+    <default>PHB</default>
   </attribute>
-  <instance_name>obus0</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-obus-nimbus</type>
 </targetPart>
 <targetPart>
-  <id>obus3</id>
+  <id>phb5_x4_pci</id>
+  <type>unit-pci-nimbus</type>
+  <is_root>false</is_root>
+  <instance_name>phb5_x4_pci</instance_name>
+  <position>-1</position>
+  <parent>unit-pci-power9</parent>
   <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
+    <id>AFFINITY_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>FABRIC</default>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
-    <default>3</default>
+    <default>5</default>
   </attribute>
   <attribute>
     <id>CLASS</id>
@@ -6356,82 +8576,112 @@
   </attribute>
   <attribute>
     <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
     <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
+      <field><id>deconfiguredByEid</id><value></value></field>
+      <field><id>poweredOn</id><value></value></field>
+      <field><id>present</id><value></value></field>
+      <field><id>functional</id><value></value></field>
+      <field><id>dumpfunctional</id><value></value></field>
+      <field><id>specdeconfig</id><value></value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_SET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PRIMARY_CAPABILITIES</id>
     <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
+      <field><id>supportsFsiScom</id><value>1</value></field>
+      <field><id>supportsXscom</id><value>1</value></field>
+      <field><id>supportsInbandScom</id><value>0</value></field>
+      <field><id>reserved</id><value>0</value></field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
-    <default>OBUS</default>
+    <default>PCI</default>
   </attribute>
-  <instance_name>obus3</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-obus-nimbus</type>
 </targetPart>
 <targetPart>
   <id>nvbus0</id>
@@ -6720,297 +8970,6 @@
     <default>NV</default>
   </attribute>
   <instance_name>nvbus2</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-nv-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>nvbus3</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>FABRIC</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>3</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>NV</default>
-  </attribute>
-  <instance_name>nvbus3</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-nv-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>nvbus4</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>FABRIC</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>NV</default>
-  </attribute>
-  <instance_name>nvbus4</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-nv-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>nvbus5</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>FABRIC</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>NV</default>
-  </attribute>
-  <instance_name>nvbus5</instance_name>
   <is_root>false</is_root>
   <position>-1</position>
   <type>unit-nv-nimbus</type>
@@ -13326,7 +15285,7 @@
   <type>unit-perv-nimbus</type>
 </targetPart>
 <targetPart>
-  <id>xbus0</id>
+  <id>xbus1</id>
   <attribute>
     <id>BUS_TYPE</id>
     <default>XBUS</default>
@@ -13337,7 +15296,7 @@
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
-    <default>0</default>
+    <default>1</default>
   </attribute>
   <attribute>
     <id>CLASS</id>
@@ -13429,7 +15388,116 @@
     <id>TYPE</id>
     <default>XBUS</default>
   </attribute>
-  <instance_name>xbus0</instance_name>
+  <instance_name>xbus1</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-xbus-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>xbus2</id>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>XBUS</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>FABRIC</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>INOUT</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>PEER_TARGET</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>XBUS</default>
+  </attribute>
+  <instance_name>xbus2</instance_name>
   <is_root>false</is_root>
   <position>-1</position>
   <type>unit-xbus-nimbus</type>
@@ -16379,1353 +18447,6 @@
   <is_root>false</is_root>
   <position>-1</position>
   <type>unit-dimm_port-power9</type>
-</targetPart>
-<targetPart>
-  <id>pci_configs_power9</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>VENICE</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>PCI_CONFIGS</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default></default>
-  </attribute>
-  <child_id>PEC0_x16:PEC1_x8x8:PEC2_x16</child_id>
-  <child_id>PEC0_x16:PEC1_x8x8:PEC2_x8x8</child_id>
-  <instance_name>pci_configs_power9</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pciconfigs-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC0_x16:PEC1_x8x8:PEC2_x16</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IO_CONFIG_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>PCI_CONFIG</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_CONFIG_NUM</id>
-    <default>0x00</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default></default>
-  </attribute>
-  <child_id>PEC0_x16</child_id>
-  <child_id>PEC1_CLK0_x8</child_id>
-  <child_id>PEC1_CLK1_x8</child_id>
-  <child_id>PEC2_x16</child_id>
-  <instance_name>PEC0_x16:PEC1_x8x8:PEC2_x16</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pciconfig0-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC0_x16</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default>0xFFFF</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>16</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-  <instance_name>PEC0_x16</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pci-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC1_CLK0_x8</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default>0xFF00</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-  <instance_name>PEC1_CLK0_x8</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pci-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC1_CLK1_x8</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default>0x00FF</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-  <instance_name>PEC1_CLK1_x8</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pci-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC2_x16</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default>0xFFFF</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>16</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>3</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-  <instance_name>PEC2_x16</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pci-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC0_x16:PEC1_x8x8:PEC2_x8x8</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IO_CONFIG_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>PCI_CONFIG</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_CONFIG_NUM</id>
-    <default>0x01</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default></default>
-  </attribute>
-  <child_id>PEC0_x16</child_id>
-  <child_id>PEC1_CLK0_x8</child_id>
-  <child_id>PEC1_CLK1_x8</child_id>
-  <child_id>PEC2_CLK0_x8</child_id>
-  <child_id>PEC2_CLK1_x8</child_id>
-  <instance_name>PEC0_x16:PEC1_x8x8:PEC2_x8x8</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pciconfig1-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC0_x16</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default>0xFFFF</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>16</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-  <instance_name>PEC0_x16</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pci-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC1_CLK0_x8</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default>0xFF00</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-  <instance_name>PEC1_CLK0_x8</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pci-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC1_CLK1_x8</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default>0x00FF</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-  <instance_name>PEC1_CLK1_x8</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pci-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC2_CLK0_x8</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default>0xFF00</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-  <instance_name>PEC2_CLK0_x8</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pci-nimbus</type>
-</targetPart>
-<targetPart>
-  <id>PEC2_CLK1_x8</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default>0x00FF</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-  <instance_name>PEC2_CLK1_x8</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-pci-nimbus</type>
 </targetPart>
 <targetPart>
   <id>fsi-slave-0</id>


### PR DESCRIPTION
- Change p9_proc_m to p9_proc_l
- Remove xbus0
- Add xbus1,2
- Remove nvbus3,4,5
- Remove p9_pci-0,1,2,3
- Remove obus0,3
- Add pec0_x16_config
- Add phb0_x16
- Add phb0_x16_pci
- Add pec1_x8_x8_config
- Add phb1_x8, phb2_x8
- Add phb1_x8_pci, phb2_x8_pci
- Add pec2_x16_config
- Add phb3_x16
- Add phb3_x16_pci
- Add pec2_x8_x8_config
- Add phb3_x8, phb4_x8
- Add phb3_x8_pci, phb4_x8_pci
- Add pec2_x8_x4_x4_config
- Add phb4_x4, phb5_x4
- Add phb4_x4_pci, phb5_x4_pci
- Correct IOP_NUM, PCIE_NUM_LANES, PHB_NUM
- Change PROC_PCIE_NUM_LANES to 48
- Change PROC_PCIE_NUM_PHB to 6
- Change PROC_PCIE_NUM_IOP to 3