### PR TITLE
Add POSITION to pcie_slot.

### DIFF
--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -1830,6 +1830,9 @@
 			<id>CLASS</id>
 			<default>CONNECTOR</default>
 		</attribute>
+        <attribute>
+            <id>POSITION</id>
+        </attribute>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>


### PR DESCRIPTION
The pcie slot connector needs a position so OpenBMC
can build it into the inventory.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>