### PR TITLE
Changes for OpenBMC LED support.

### DIFF
--- a/attribute_types_obmc.xml
+++ b/attribute_types_obmc.xml
@@ -81,4 +81,18 @@
         <readable/>
     </attribute>
 
+    <attribute>
+        <id>CONTROL_GROUPS</id>
+        <description>Contains information about which control groups an LED
+                     belongs to. A row in the array specifies the group name
+                     and properties for this LED in that group.
+                     GroupName, BlinkFreqHz(0 = on solid), DutyCycle(0-100)
+        </description>
+        <simpleType>
+            <string>
+            </string>
+        <array>16,3</array>
+        </simpleType>
+    </attribute>
+
 </attributes>

--- a/parts/card-daughtercard.xml
+++ b/parts/card-daughtercard.xml
@@ -20,7 +20,36 @@
     <parent_type>connector-usb-generic</parent_type>
     <parent_type>connector-hmc-generic</parent_type>
     <parent_type>connector-uart-generic</parent_type>
+    <child_id>led_assoc_child</child_id>
     <position>-1</position>
     <type>card-daughtercard</type>
+  </targetPart>
+  <targetPart>
+    <id>led_assoc_child</id>
+    <attribute>
+      <id>ASSOCIATION_TYPE</id>
+      <default>LED</default>
+    </attribute>
+    <attribute>
+      <id>BUS_TYPE</id>
+      <default>LOGICAL_ASSOCIATION</default>
+    </attribute>
+    <attribute>
+      <id>CHIP_UNIT</id>
+      <default>0</default>
+    </attribute>
+    <attribute>
+      <id>DIRECTION</id>
+      <default>IN</default>
+    </attribute>
+    <attribute>
+      <id>TYPE</id>
+      <default>NA</default>
+    </attribute>
+    <instance_name>led_assoc_child</instance_name>
+    <is_root>false</is_root>
+    <parent>unit</parent>
+    <position>-1</position>
+    <type>unit-logic_assoc-generic</type>
   </targetPart>
 </partInstance>

--- a/parts/led-led-generic.xml
+++ b/parts/led-led-generic.xml
@@ -45,6 +45,27 @@
         <id>ON_STATE</id>
         <default>0</default>
     </attribute>
+    <attribute>
+        <id>CONTROL_GROUPS</id>
+        <default>
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50,
+        NA,0,50
+        </default>
+    </attribute>
     <child_id>led_enable</child_id>
     <child_id>generic-logic-assoc</child_id>
     <instance_name>led</instance_name>


### PR DESCRIPTION
1) Give daughter card a logical-association target
2) Add CONTROL_GROUPS attribute, and add to the LED part.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>