### PR TITLE
Defined mrw versions of base, chip, unit & card in target_types_mrw.xml

### DIFF
--- a/attribute_types_mrw.xml
+++ b/attribute_types_mrw.xml
@@ -4345,6 +4345,7 @@
 		</field>
 		</complexType>
 		<readable />
+		<global />
 	</attribute>
 	<attribute>
 		<id>PORT</id>

--- a/parts/89LPC932.xml
+++ b/parts/89LPC932.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>89LPC932</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>89LPC932.i2c-0</child_id>
@@ -71,7 +71,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -123,7 +123,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.gpio-slave</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -175,7 +175,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.gpio-slave</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -227,7 +227,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.gpio-slave</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -279,7 +279,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.gpio-slave</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -331,7 +331,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.gpio-slave</instance_name>
 	<position>4</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -383,7 +383,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.gpio-slave</instance_name>
 	<position>5</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -435,7 +435,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.gpio-slave</instance_name>
 	<position>6</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -487,7 +487,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.gpio-slave</instance_name>
 	<position>7</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -539,7 +539,7 @@
 	<is_root>false</is_root>
 	<instance_name>89LPC932.gpio-master</instance_name>
 	<position>8</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/ANDGATE.xml
+++ b/parts/ANDGATE.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>ANDGATE</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>ANDGATE.gpio-master-0</child_id>
@@ -68,7 +68,7 @@
 	<is_root>false</is_root>
 	<instance_name>ANDGATE.gpio-master</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -134,7 +134,7 @@
 	<is_root>false</is_root>
 	<instance_name>ANDGATE.gpio-slave</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -200,7 +200,7 @@
 	<is_root>false</is_root>
 	<instance_name>ANDGATE.gpio-slave</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/BMP280.xml
+++ b/parts/BMP280.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>BMP280</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>BMP280.i2c-0</child_id>
@@ -66,7 +66,7 @@
 	<is_root>false</is_root>
 	<instance_name>BMP280.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>

--- a/parts/EPSON-MOSO.xml
+++ b/parts/EPSON-MOSO.xml
@@ -9,7 +9,7 @@
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<child_id>EPSON-MOSO.i2c-0</child_id>
 	<child_id>EPSON-MOSO.OUT0-0</child_id>
 	<child_id>EPSON-MOSO.OUT1-1</child_id>
@@ -67,7 +67,7 @@
 	<is_root>false</is_root>
 	<instance_name>EPSON-MOSO.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -119,7 +119,7 @@
 	<is_root>false</is_root>
 	<instance_name>EPSON-MOSO.OUT0</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -163,7 +163,7 @@
 	<is_root>false</is_root>
 	<instance_name>EPSON-MOSO.OUT1</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -207,7 +207,7 @@
 	<is_root>false</is_root>
 	<instance_name>EPSON-MOSO.OUT2</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -251,7 +251,7 @@
 	<is_root>false</is_root>
 	<instance_name>EPSON-MOSO.OUT3</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -295,7 +295,7 @@
 	<is_root>false</is_root>
 	<instance_name>EPSON-MOSO.vin</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>POWER</default>

--- a/parts/FAN_COUNTER_ROTATING.xml
+++ b/parts/FAN_COUNTER_ROTATING.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>FAN_COUNTER_ROTATING</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>FAN_COUNTER_ROTATING.pwm-0</child_id>
@@ -64,7 +64,7 @@
 	<is_root>false</is_root>
 	<instance_name>FAN_COUNTER_ROTATING.pwm</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>PWM</default>
@@ -124,7 +124,7 @@
 	<is_root>false</is_root>
 	<instance_name>FAN_COUNTER_ROTATING.tach</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>TACH</default>
@@ -224,7 +224,7 @@
 	<is_root>false</is_root>
 	<instance_name>FAN_COUNTER_ROTATING.tach</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>TACH</default>

--- a/parts/IDT9DBL04.xml
+++ b/parts/IDT9DBL04.xml
@@ -9,7 +9,7 @@
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<child_id>IDT9DBL04.i2c-0</child_id>
 	<child_id>IDT9DBL04.DIF0-0</child_id>
 	<child_id>IDT9DBL04.DIF1-1</child_id>
@@ -67,7 +67,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT9DBL04.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -119,7 +119,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT9DBL04.DIF0</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -163,7 +163,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT9DBL04.DIF1</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -251,7 +251,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT9DBL04.DIF3</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -295,7 +295,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT9DBL04.vin</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>POWER</default>

--- a/parts/IDT9FGS9093.xml
+++ b/parts/IDT9FGS9093.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>IDT09FGS9093</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>IDT09FGS9093.i2c-0</child_id>
@@ -71,7 +71,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -123,7 +123,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.REF0</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -167,7 +167,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.REF1</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -211,7 +211,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.OUT0</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -255,7 +255,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.OUT1</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -299,7 +299,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.OUT2</instance_name>
 	<position>4</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -343,7 +343,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.OUT3</instance_name>
 	<position>5</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>CLK</default>
@@ -387,7 +387,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.vin</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>POWER</default>
@@ -431,7 +431,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.OEA</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -571,7 +571,7 @@
 	<is_root>false</is_root>
 	<instance_name>IDT09FGS9093.OEB</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>

--- a/parts/IR35219.xml
+++ b/parts/IR35219.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>IR35219</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>IR35219.vout-0</child_id>
@@ -169,7 +169,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219.vout</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -281,7 +281,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -677,7 +677,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219.gpio</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -817,7 +817,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219.gpio</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -957,7 +957,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219.gpio</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -1097,7 +1097,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219.gpio</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -1237,7 +1237,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219.avs</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>

--- a/parts/IR35219_special.xml
+++ b/parts/IR35219_special.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>IR35219_special</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>IR35219_special.vout-0</child_id>
@@ -72,7 +72,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219_special.vout</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>POWER</default>
@@ -116,7 +116,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219_special.vout</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>POWER</default>
@@ -160,7 +160,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219_special.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -420,7 +420,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219_special.gpio</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -472,7 +472,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219_special.gpio</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -524,7 +524,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219_special.gpio</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -576,7 +576,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35219_special.gpio</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/IR35220.xml
+++ b/parts/IR35220.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>IR35220</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>IR35220.i2c-0</child_id>
@@ -63,7 +63,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35220.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -106,7 +106,7 @@
 	<is_root>false</is_root>
 	<instance_name>IR35220.gpio</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/NOR_FLASH.xml
+++ b/parts/NOR_FLASH.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>NOR_FLASH</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>NOR_FLASH.spi-slave-0</child_id>
@@ -63,7 +63,7 @@
 	<is_root>false</is_root>
 	<instance_name>NOR_FLASH.spi-slave</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>SPI</default>
@@ -111,7 +111,7 @@
 	<is_root>false</is_root>
 	<instance_name>NOR_FLASH.gpio-slave</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/ORGATE.xml
+++ b/parts/ORGATE.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>ORGATE</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>ORGATE.gpio-master-0</child_id>
@@ -56,7 +56,7 @@
 	<is_root>false</is_root>
 	<instance_name>ORGATE.gpio-master-0</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -122,7 +122,7 @@
 	<is_root>false</is_root>
 	<instance_name>ORGATE.gpio-slave-1</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -188,7 +188,7 @@
 	<is_root>false</is_root>
 	<instance_name>ORGATE.gpio-slave-2</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/PCA9551.xml
+++ b/parts/PCA9551.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>PCA9551</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>PCA9551.gpio-0</child_id>
@@ -75,7 +75,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.gpio</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -141,7 +141,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.gpio</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -207,7 +207,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.gpio</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -273,7 +273,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.gpio</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -339,7 +339,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.gpio</instance_name>
 	<position>4</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -405,7 +405,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.gpio</instance_name>
 	<position>5</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -471,7 +471,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.gpio</instance_name>
 	<position>6</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -537,7 +537,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.gpio</instance_name>
 	<position>7</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -603,7 +603,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -651,7 +651,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9551.RESET</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/PCA9552.xml
+++ b/parts/PCA9552.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>PCA9552</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>PCA9552.i2c-0</child_id>
@@ -82,7 +82,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -134,7 +134,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -186,7 +186,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -238,7 +238,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -290,7 +290,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -342,7 +342,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>4</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -394,7 +394,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>5</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -446,7 +446,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>6</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -498,7 +498,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>7</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -550,7 +550,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>8</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -602,7 +602,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>9</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -654,7 +654,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>10</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -706,7 +706,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>11</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -758,7 +758,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>12</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -810,7 +810,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>13</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -862,7 +862,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>14</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -914,7 +914,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9552.gpio</instance_name>
 	<position>15</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/PCA9554.xml
+++ b/parts/PCA9554.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>PCA9554</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>PCA9554.i2c-0</child_id>
@@ -75,7 +75,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -123,7 +123,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.gpio</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -189,7 +189,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.gpio</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -255,7 +255,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.gpio</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -321,7 +321,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.gpio</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -387,7 +387,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.gpio</instance_name>
 	<position>4</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -453,7 +453,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.gpio</instance_name>
 	<position>5</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -519,7 +519,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.gpio</instance_name>
 	<position>6</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -585,7 +585,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.gpio</instance_name>
 	<position>7</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -651,7 +651,7 @@
 	<is_root>false</is_root>
 	<instance_name>PCA9554.INT</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/PIC16F882.xml
+++ b/parts/PIC16F882.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>PIC16F882</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>PIC16F882.i2c-0</child_id>
@@ -78,7 +78,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -130,7 +130,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -182,7 +182,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -234,7 +234,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -286,7 +286,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -338,7 +338,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>4</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -390,7 +390,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>5</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -442,7 +442,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>6</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -494,7 +494,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>7</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -546,7 +546,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>8</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -598,7 +598,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>9</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -650,7 +650,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>10</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -702,7 +702,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>11</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -754,7 +754,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>12</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -806,7 +806,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>13</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -858,7 +858,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>14</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -910,7 +910,7 @@
 	<is_root>false</is_root>
 	<instance_name>PIC16F882.gpio</instance_name>
 	<position>15</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/PNOR_FLASH.xml
+++ b/parts/PNOR_FLASH.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>PNOR_FLASH</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>PNOR_FLASH.spi-slave-0</child_id>
@@ -63,7 +63,7 @@
 	<is_root>false</is_root>
 	<instance_name>PNOR_FLASH.spi-slave</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>SPI</default>
@@ -103,7 +103,7 @@
 	<is_root>false</is_root>
 	<instance_name>PNOR_FLASH.gpio-slave</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/POWER_SUPPLY.xml
+++ b/parts/POWER_SUPPLY.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>POWER_SUPPLY</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>POWER_SUPPLY.i2c-0</child_id>
@@ -15,12 +15,12 @@
 	<child_id>POWER_SUPPLY.vout-1</child_id>
 	<child_id>POWER_SUPPLY.pgood-0</child_id>
 	<child_id>POWER_SUPPLY.enable-0</child_id>
-	<child_id>POWER_SUPPLY.FSS-0</child_id>
-	<child_id>POWER_SUPPLY.RESET-1</child_id>
-	<child_id>POWER_SUPPLY.PS-KILL-2</child_id>
-	<child_id>POWER_SUPPLY.FAN-FULL-SPEED-3</child_id>
-	<child_id>POWER_SUPPLY.THROTTLE-4</child_id>
-	<child_id>POWER_SUPPLY.ALERT-5</child_id>
+	<child_id>POWER_SUPPLY.gpio-slave-0</child_id>
+	<child_id>POWER_SUPPLY.gpio-slave-1</child_id>
+	<child_id>POWER_SUPPLY.gpio-slave-2</child_id>
+	<child_id>POWER_SUPPLY.gpio-slave-3</child_id>
+	<child_id>POWER_SUPPLY.gpio-master-4</child_id>
+	<child_id>POWER_SUPPLY.gpio-master-5</child_id>
 	<attribute>
 		<id>CCIN</id>
 		<default></default>
@@ -72,7 +72,7 @@
 	<is_root>false</is_root>
 	<instance_name>POWER_SUPPLY.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -124,7 +124,7 @@
 	<is_root>false</is_root>
 	<instance_name>POWER_SUPPLY.vout</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>POWER</default>
@@ -168,7 +168,7 @@
 	<is_root>false</is_root>
 	<instance_name>POWER_SUPPLY.vout</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>POWER</default>
@@ -311,12 +311,12 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>POWER_SUPPLY.FSS-0</id>
+	<id>POWER_SUPPLY.gpio-slave-0</id>
 	<type>unit-gpio-generic</type>
 	<is_root>false</is_root>
-	<instance_name>POWER_SUPPLY.FSS</instance_name>
+	<instance_name>POWER_SUPPLY.gpio-slave</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -347,7 +347,7 @@
 	</attribute>
 	<attribute>
 		<id>PIN_NAME</id>
-		<default></default>
+		<default>fss</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -363,12 +363,12 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>POWER_SUPPLY.RESET-1</id>
+	<id>POWER_SUPPLY.gpio-slave-1</id>
 	<type>unit-gpio-generic</type>
 	<is_root>false</is_root>
-	<instance_name>POWER_SUPPLY.RESET</instance_name>
+	<instance_name>POWER_SUPPLY.gpio-slave</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -399,7 +399,7 @@
 	</attribute>
 	<attribute>
 		<id>PIN_NAME</id>
-		<default></default>
+		<default>reset</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -415,12 +415,12 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>POWER_SUPPLY.PS-KILL-2</id>
+	<id>POWER_SUPPLY.gpio-slave-2</id>
 	<type>unit-gpio-generic</type>
 	<is_root>false</is_root>
-	<instance_name>POWER_SUPPLY.PS-KILL</instance_name>
+	<instance_name>POWER_SUPPLY.gpio-slave</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -451,7 +451,7 @@
 	</attribute>
 	<attribute>
 		<id>PIN_NAME</id>
-		<default></default>
+		<default>ps-kill</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -467,12 +467,12 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>POWER_SUPPLY.FAN-FULL-SPEED-3</id>
+	<id>POWER_SUPPLY.gpio-slave-3</id>
 	<type>unit-gpio-generic</type>
 	<is_root>false</is_root>
-	<instance_name>POWER_SUPPLY.FAN-FULL-SPEED</instance_name>
+	<instance_name>POWER_SUPPLY.gpio-slave</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -503,7 +503,7 @@
 	</attribute>
 	<attribute>
 		<id>PIN_NAME</id>
-		<default></default>
+		<default>fan-full-speed</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -519,12 +519,12 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>POWER_SUPPLY.THROTTLE-4</id>
+	<id>POWER_SUPPLY.gpio-master-4</id>
 	<type>unit-gpio-generic</type>
 	<is_root>false</is_root>
-	<instance_name>POWER_SUPPLY.THROTTLE</instance_name>
+	<instance_name>POWER_SUPPLY.gpio-master</instance_name>
 	<position>4</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -555,7 +555,7 @@
 	</attribute>
 	<attribute>
 		<id>PIN_NAME</id>
-		<default></default>
+		<default>throttle</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -571,12 +571,12 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>POWER_SUPPLY.ALERT-5</id>
+	<id>POWER_SUPPLY.gpio-master-5</id>
 	<type>unit-gpio-generic</type>
 	<is_root>false</is_root>
-	<instance_name>POWER_SUPPLY.ALERT</instance_name>
+	<instance_name>POWER_SUPPLY.gpio-master</instance_name>
 	<position>5</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -607,7 +607,7 @@
 	</attribute>
 	<attribute>
 		<id>PIN_NAME</id>
-		<default></default>
+		<default>alert</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>

--- a/parts/RJ45_1PORT.xml
+++ b/parts/RJ45_1PORT.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>RJ45_1PORT</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>RJ45_1PORT.ethernet-0</child_id>
@@ -50,7 +50,7 @@
 	<is_root>false</is_root>
 	<instance_name>RJ45_1PORT.ethernet</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>ETHERNET</default>

--- a/parts/SEEPROM.xml
+++ b/parts/SEEPROM.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>SEEPROM</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>SEEPROM.i2c</child_id>
@@ -66,7 +66,7 @@
 	<is_root>false</is_root>
 	<instance_name>SEEPROM.i2c</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>

--- a/parts/SMARTCHIP.xml
+++ b/parts/SMARTCHIP.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>SMARTCHIP</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>SMARTCHIP.sc-0</child_id>
@@ -62,7 +62,7 @@
 	<is_root>false</is_root>
 	<instance_name>SMARTCHIP.sc</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>SC</default>

--- a/parts/SPIVID.xml
+++ b/parts/SPIVID.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>SPIVID</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>SPIVID.spi-slave-0</child_id>
@@ -65,7 +65,7 @@
 	<is_root>false</is_root>
 	<instance_name>SPIVID.spi-slave</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>SPI</default>
@@ -113,7 +113,7 @@
 	<is_root>false</is_root>
 	<instance_name>SPIVID.i2c-slave</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -165,7 +165,7 @@
 	<is_root>false</is_root>
 	<instance_name>SPIVID.gpio-master</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -217,7 +217,7 @@
 	<is_root>false</is_root>
 	<instance_name>SPIVID.power</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>POWER</default>

--- a/parts/SWITCH.xml
+++ b/parts/SWITCH.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>SWITCH</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>SWITCH.gpio-master-0</child_id>
@@ -62,7 +62,7 @@
 	<is_root>false</is_root>
 	<instance_name>SWITCH.gpio-master</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/TCA6408A.xml
+++ b/parts/TCA6408A.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>TCA6408A</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>TCA6408A.i2c-0</child_id>
@@ -62,7 +62,7 @@
 	<is_root>false</is_root>
 	<instance_name>TCA6408A.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>

--- a/parts/TMP275.xml
+++ b/parts/TMP275.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>TMP275</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>TMP275.i2c</child_id>
@@ -58,7 +58,7 @@
 	<is_root>false</is_root>
 	<instance_name>TMP275.i2c</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>

--- a/parts/TMP423A.xml
+++ b/parts/TMP423A.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>TMP423A</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>TMP423A.i2c</child_id>
@@ -58,7 +58,7 @@
 	<is_root>false</is_root>
 	<instance_name>TMP423A.i2c</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>

--- a/parts/TOD_BATTERY.xml
+++ b/parts/TOD_BATTERY.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>TOD_BATTERY</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>TOD_BATTERY.gpio-master-0</child_id>
@@ -63,7 +63,7 @@
 	<is_root>false</is_root>
 	<instance_name>TOD_BATTERY.gpio-master</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -115,7 +115,7 @@
 	<is_root>false</is_root>
 	<instance_name>TOD_BATTERY.gpio-slave</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/TPS544C25.xml
+++ b/parts/TPS544C25.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>TPS544C25</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>TPS544C25.vout-0</child_id>
@@ -70,7 +70,7 @@
 	<is_root>false</is_root>
 	<instance_name>TPS544C25.vout</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>POWER</default>
@@ -114,7 +114,7 @@
 	<is_root>false</is_root>
 	<instance_name>TPS544C25.i2c</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -157,7 +157,7 @@
 	<is_root>false</is_root>
 	<instance_name>TPS544C25.i2c</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
@@ -304,7 +304,7 @@
 	<is_root>false</is_root>
 	<instance_name>TPS544C25.gpio</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -356,7 +356,7 @@
 	<is_root>false</is_root>
 	<instance_name>TPS544C25.gpio</instance_name>
 	<position>1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -408,7 +408,7 @@
 	<is_root>false</is_root>
 	<instance_name>TPS544C25.gpio</instance_name>
 	<position>2</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>
@@ -460,7 +460,7 @@
 	<is_root>false</is_root>
 	<instance_name>TPS544C25.gpio</instance_name>
 	<position>3</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>GPIO</default>

--- a/parts/UART_1PORT.xml
+++ b/parts/UART_1PORT.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>UART_1PORT</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>UART_1PORT.uart-0</child_id>
@@ -50,7 +50,7 @@
 	<is_root>false</is_root>
 	<instance_name>UART_1PORT.uart</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>U750</default>

--- a/parts/USB2_1PORT.xml
+++ b/parts/USB2_1PORT.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>USB2_1PORT</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>USB2_1PORT.usb-0</child_id>
@@ -50,7 +50,7 @@
 	<is_root>false</is_root>
 	<instance_name>USB2_1PORT.usb</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>USB</default>

--- a/parts/USB2_2PORT.xml
+++ b/parts/USB2_2PORT.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>USB2_2PORT</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>USB2_2PORT.usb-0</child_id>
@@ -51,7 +51,7 @@
 	<is_root>false</is_root>
 	<instance_name>USB2_2PORT.usb</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>USB</default>

--- a/parts/USB3_1PORT.xml
+++ b/parts/USB3_1PORT.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>USB3_1PORT</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>USB3_1PORT.usb-0</child_id>
@@ -58,7 +58,7 @@
 	<is_root>false</is_root>
 	<instance_name>USB3_1PORT.usb</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>USB</default>

--- a/parts/apss.xml
+++ b/parts/apss.xml
@@ -8,7 +8,7 @@
 		<is_root>true</is_root>
 		<instance_name>apss</instance_name>
 		<position>-1</position>
-		<parent>chip</parent>
+		<parent>mrw-chip</parent>
 		<parent_type>card-motherboard</parent_type>
 		<parent_type>card-daughtercard</parent_type>		
 		<child_id>apss.ADCCH0</child_id>

--- a/parts/card-daughtercard.xml
+++ b/parts/card-daughtercard.xml
@@ -15,7 +15,7 @@
     </attribute>
     <instance_name>card</instance_name>
     <is_root>true</is_root>
-    <parent>card</parent>
+    <parent>mrw-card</parent>
     <parent_type>connector-card-generic</parent_type>
     <parent_type>connector-usb-generic</parent_type>
     <parent_type>connector-hmc-generic</parent_type>

--- a/parts/chip-apss-psoc.xml
+++ b/parts/chip-apss-psoc.xml
@@ -1411,7 +1411,7 @@
     <child_id>GPU_Sense</child_id>
     <instance_name>apss</instance_name>
     <is_root>true</is_root>
-    <parent>chip</parent>
+    <parent>mrw-chip</parent>
     <parent_type>sys-sys-power8</parent_type>
     <parent_type>sys-sys-power9</parent_type>
     <position>0</position>

--- a/parts/chip-gpioexp-generic.xml
+++ b/parts/chip-gpioexp-generic.xml
@@ -28,7 +28,7 @@
     <child_id>io1-7</child_id>
     <instance_name>gpio_expander</instance_name>
     <is_root>true</is_root>
-    <parent>chip</parent>
+    <parent>mrw-chip</parent>
     <parent_type>card-motherboard</parent_type>
     <parent_type>card-daughtercard</parent_type>
     <position>0</position>
@@ -65,7 +65,7 @@
     </attribute>
     <instance_name>i2c-slave</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-i2c-slave</type>
   </targetPart>
@@ -108,7 +108,7 @@
     </attribute>
     <instance_name>io-0</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -151,7 +151,7 @@
     </attribute>
     <instance_name>io-1</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -194,7 +194,7 @@
     </attribute>
     <instance_name>io-2</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -237,7 +237,7 @@
     </attribute>
     <instance_name>io-3</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -280,7 +280,7 @@
     </attribute>
     <instance_name>io-4</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -323,7 +323,7 @@
     </attribute>
     <instance_name>io-5</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -366,7 +366,7 @@
     </attribute>
     <instance_name>io-6</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -409,7 +409,7 @@
     </attribute>
     <instance_name>io-7</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -452,7 +452,7 @@
     </attribute>
     <instance_name>io1-0</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -495,7 +495,7 @@
     </attribute>
     <instance_name>io1-1</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -538,7 +538,7 @@
     </attribute>
     <instance_name>io1-2</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -581,7 +581,7 @@
     </attribute>
     <instance_name>io1-3</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -624,7 +624,7 @@
     </attribute>
     <instance_name>io1-4</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -667,7 +667,7 @@
     </attribute>
     <instance_name>io1-5</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -710,7 +710,7 @@
     </attribute>
     <instance_name>io1-6</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -753,7 +753,7 @@
     </attribute>
     <instance_name>io1-7</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>

--- a/parts/chip-planar_vpd-device.xml
+++ b/parts/chip-planar_vpd-device.xml
@@ -62,7 +62,7 @@
     </attribute>
     <instance_name>i2c-slave</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-i2c-slave</type>
   </targetPart>
@@ -90,7 +90,7 @@
     </attribute>
     <instance_name>vpd_assoc_parent</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-logic_assoc-generic</type>
   </targetPart>

--- a/parts/chip-uartslave.xml
+++ b/parts/chip-uartslave.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>chip-uartslave</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>chip-uartslave.uart-0</child_id>
@@ -50,7 +50,7 @@
 	<is_root>false</is_root>
 	<instance_name>chip-uartslave.uart</instance_name>
 	<position>0</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>U750</default>

--- a/parts/chip-vpd-device.xml
+++ b/parts/chip-vpd-device.xml
@@ -38,7 +38,7 @@
     <child_id>i2c-slave</child_id>
     <instance_name>vpdchip</instance_name>
     <is_root>true</is_root>
-    <parent>chip</parent>
+    <parent>mrw-chip</parent>
     <position>0</position>
     <type>chip-vpd-device</type>
   </targetPart>
@@ -73,7 +73,7 @@
     </attribute>
     <instance_name>i2c-slave</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-i2c-slave</type>
   </targetPart>

--- a/parts/chip-vreg-generic.xml
+++ b/parts/chip-vreg-generic.xml
@@ -19,7 +19,7 @@
     </attribute>
     <instance_name>avs</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-vreg_avs-generic</type>
   </targetPart>
@@ -40,7 +40,7 @@
     <child_id>avs</child_id>
     <instance_name>vreg</instance_name>
     <is_root>true</is_root>
-    <parent>chip</parent>
+    <parent>mrw-chip</parent>
     <parent_type>card-motherboard</parent_type>
     <parent_type>card-daughtercard</parent_type>
     <position>0</position>
@@ -77,7 +77,7 @@
     </attribute>
     <instance_name>i2c-slave</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-i2c-slave</type>
   </targetPart>
@@ -101,7 +101,7 @@
     </attribute>
     <instance_name>vout</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-vreg_vout-generic</type>
   </targetPart>
@@ -125,7 +125,7 @@
     </attribute>
     <instance_name>vreg_enable</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-vreg_enable-generic</type>
   </targetPart>
@@ -149,7 +149,7 @@
     </attribute>
     <instance_name>vreg_pgood</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-vreg_pgood-generic</type>
   </targetPart>

--- a/parts/cooling zone.xml
+++ b/parts/cooling zone.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>cooling-zone</instance_name>
 	<position>-1</position>
-        <parent>base</parent>
+        <parent>mrw-base</parent>
         <parent_type>enc-node-power9</parent_type>
 			<attribute>
 				<id>MRW_ID</id>

--- a/parts/dimm-thermal-sensor.xml
+++ b/parts/dimm-thermal-sensor.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>dimm-thermal-sensor</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>mrw-chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>dimm-thermal-sensor.i2c</child_id>
@@ -149,7 +149,7 @@
 	<is_root>false</is_root>
 	<instance_name>dimm-thermal-sensor.i2c</instance_name>
 	<position>-1</position>
-	<parent>unit</parent>
+	<parent>mrw-unit</parent>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>

--- a/parts/dummy-presence-generic.xml
+++ b/parts/dummy-presence-generic.xml
@@ -12,7 +12,7 @@
     <child_id>io-0</child_id>
     <instance_name>presence_detect</instance_name>
     <is_root>true</is_root>
-    <parent>chip</parent>
+    <parent>mrw-chip</parent>
     <parent_type>card-motherboard</parent_type>
     <parent_type>card-daughtercard</parent_type>
     <position>0</position>
@@ -57,7 +57,7 @@
     </attribute>
     <instance_name>io-0</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>

--- a/parts/fan-info.xml
+++ b/parts/fan-info.xml
@@ -7,7 +7,7 @@
 	<is_root>true</is_root>
 	<instance_name>fan-info</instance_name>
 	<position>-1</position>
-        <parent>base</parent>
+        <parent>mrw-base</parent>
         <parent_type>enc-node-power9</parent_type>
 			<attribute>
 				<id>MRW_ID</id>

--- a/parts/module-module-lagrange.xml
+++ b/parts/module-module-lagrange.xml
@@ -5430,23 +5430,11 @@
     <default></default>
   </attribute>
   <attribute>
-    <id>PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
-    <default></default>
-  </attribute>
-  <attribute>
     <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
     <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
     <default></default>
   </attribute>
   <attribute>
@@ -5458,19 +5446,11 @@
     <default></default>
   </attribute>
   <attribute>
-    <id>PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
-    <default></default>
-  </attribute>
-  <attribute>
     <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
     <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
     <default></default>
   </attribute>
   <attribute>
@@ -6021,23 +6001,11 @@
     <default></default>
   </attribute>
   <attribute>
-    <id>PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
-    <default></default>
-  </attribute>
-  <attribute>
     <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
     <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
     <default></default>
   </attribute>
   <attribute>
@@ -6049,19 +6017,11 @@
     <default></default>
   </attribute>
   <attribute>
-    <id>PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
-    <default></default>
-  </attribute>
-  <attribute>
     <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
     <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
     <default></default>
   </attribute>
   <attribute>
@@ -6892,23 +6852,11 @@
     <default></default>
   </attribute>
   <attribute>
-    <id>PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
-    <default></default>
-  </attribute>
-  <attribute>
     <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
     <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
     <default></default>
   </attribute>
   <attribute>
@@ -6920,19 +6868,11 @@
     <default></default>
   </attribute>
   <attribute>
-    <id>PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
-    <default></default>
-  </attribute>
-  <attribute>
     <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
     <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
     <default></default>
   </attribute>
   <attribute>

--- a/parts/module-module-lagrange.xml
+++ b/parts/module-module-lagrange.xml
@@ -2,25 +2,193 @@
 <version>2.1</version>
 <targetInstances>
 <targetPart>
-    <id>module-module-lagrange</id>
-    <attribute>
-      <id>POSITION</id>
-      <default>0</default>
-    </attribute>
-    <attribute>
-      <id>TYPE</id>
-      <default>NA</default>
-    </attribute>
-    <child_id>p9_proc_l</child_id>
-    <instance_name>module</instance_name>
-    <is_root>true</is_root>
-    <parent>card</parent>
-    <parent_type>socket-proc_socket-68mm</parent_type>
-    <position>0</position>
-    <type>module-module-lagrange</type>
+  <id>module-0</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CARD_TYPE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>CARD</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>LOCATION_CODE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>LOCATION_CODE_TYPE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>POSITION</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value></value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value></value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value></value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>RU_TYPE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>STANDBY_PLUGGABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <child_id>p9_proc_l</child_id>
+  <instance_name>module</instance_name>
+  <is_root>false</is_root>
+  <position>0</position>
+  <type>module-module-lagrange</type>
 </targetPart>
 <targetPart>
   <id>p9_proc_l</id>
+  <attribute>
+    <id>ADU_XSCOM_BAR_BASE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>ALTFSI_MASTER_CHIP</id>
+    <default>physical:sys-0</default>
+  </attribute>
+  <attribute>
+    <id>ALTFSI_MASTER_PORT</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>AVSBUS_FREQUENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>BACKUP_SEEPROM_SELECT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>BOOT_FREQ</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>BOOT_FREQUENCY_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>BOOT_FREQ_MHZ</id>
+    <default>2400</default>
+  </attribute>
+  <attribute>
+    <id>BOOT_FREQ_MULT</id>
+    <default>150</default>
+  </attribute>
+  <attribute>
+    <id>BRANCH_PIBMEM_ADDR</id>
+    <default>0</default>
+  </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>FABRIC</default>
@@ -30,12 +198,72 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>CHIP_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_POS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_REGIONS_TO_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_SELECTION</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_SELECTION_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHTM_CTRL_MARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHTM_CTRL_TRIG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHTM_HTMSC_MODE_CAPTURE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHTM_HTMSC_MODE_CONTENT_SEL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHTM_HTMSC_MODE_CORE_INSTR_STALL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CHTM_TRACE_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CLASS</id>
     <default>CHIP</default>
   </attribute>
   <attribute>
+    <id>CLOCK_PLL_MUX</id>
+    <default>0x8c010000</default>
+  </attribute>
+  <attribute>
+    <id>CLOCK_PLL_MUX0</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>CPM_INFLECTION_POINTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CPU_ATTR</id>
     <default>0x0000001D</default>
+  </attribute>
+  <attribute>
+    <id>CP_FILTER_BYPASS</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>DATA_CACHE_LINE_SIZE</id>
@@ -58,12 +286,56 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>DEVICE_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DO_MSS_TRAINING_BAD_BITS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>DO_MSS_VREF_DAC</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>DO_MSS_WR_VREF</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>DPLL_BYPASS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DUMMY_HEAP_ZERO_DEFAULT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DUMMY_RW</id>
     <default>5</default>
   </attribute>
   <attribute>
+    <id>DUMP_STOP_INFO_ENABLE_ERRORLOG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DUMP_STOP_INFO_SUPPRESS_ERROR_TRACE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>ECID</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EC_GARD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EEPROM_PAGE_ARRAY</id>
+    <default>2,2,2,2,2,2</default>
   </attribute>
   <attribute>
     <id>EEPROM_SBE_BACKUP_INFO</id>
@@ -78,7 +350,7 @@
       </field>
       <field>
         <id>devAddr</id>
-        <value>0xA2</value>
+        <value>0xA8</value>
       </field>
       <field>
         <id>engine</id>
@@ -119,7 +391,7 @@
       </field>
       <field>
         <id>devAddr</id>
-        <value>0xA2</value>
+        <value>0xA8</value>
       </field>
       <field>
         <id>engine</id>
@@ -156,7 +428,7 @@
       </field>
       <field>
         <id>port</id>
-        <value>1</value>
+        <value>2</value>
       </field>
       <field>
         <id>devAddr</id>
@@ -164,7 +436,7 @@
       </field>
       <field>
         <id>engine</id>
-        <value>0</value>
+        <value>1</value>
       </field>
       <field>
         <id>byteAddrOffset</id>
@@ -172,7 +444,7 @@
       </field>
       <field>
         <id>maxMemorySizeKB</id>
-        <value>0x40</value>
+        <value>0x80</value>
       </field>
       <field>
         <id>chipCount</id>
@@ -205,7 +477,7 @@
       </field>
       <field>
         <id>engine</id>
-        <value>0</value>
+        <value>1</value>
       </field>
       <field>
         <id>byteAddrOffset</id>
@@ -213,7 +485,7 @@
       </field>
       <field>
         <id>maxMemorySizeKB</id>
-        <value>0x40</value>
+        <value>0x80</value>
       </field>
       <field>
         <id>chipCount</id>
@@ -230,8 +502,72 @@
     </default>
   </attribute>
   <attribute>
+    <id>EQ_GARD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EXTERNAL_VRM_STEPDELAY</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>EXTERNAL_VRM_STEPSIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FABRIC_CHIP_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FABRIC_GROUP_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FABRIC_NODE_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>FREQ_BIAS_NOMINAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FREQ_BIAS_POWERSAVE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FREQ_BIAS_TURBO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FREQ_BIAS_ULTRATURBO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FRU_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>FSI_GP_REG_SCOM_ACCESS</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FSI_MASTER_CHIP</id>
+    <default>physical:sys-0</default>
+  </attribute>
+  <attribute>
+    <id>FSI_MASTER_MUTEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FSI_MASTER_PORT</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>FSI_MASTER_TYPE</id>
@@ -251,8 +587,167 @@
     </default>
   </attribute>
   <attribute>
+    <id>FSI_SCOM_MUTEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FSI_SLAVE_CASCADE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FSP_BAR_SIZE</id>
+    <default>0x0000000100000000</default>
+  </attribute>
+  <attribute>
     <id>FSP_BASE_ADDR</id>
-    <default>0,0x0006030100000000</default>
+    <default>0,0x0006030100000000,0x200000000000</default>
+  </attribute>
+  <attribute>
+    <id>FUNCTIONAL_EQ_EC_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FW_MODE_FLAGS_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HOMER_PHYS_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HOMER_VIRT_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HOT_PLUG_POWER_CONTROLLER_INFO</id>
+    <default>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+            </default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_CRESPFILT_INVERT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_CTRL_CHIP0_STOP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_CTRL_CHIP1_STOP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_CTRL_DBG0_STOP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_CTRL_DBG1_STOP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_CTRL_OTHER_DBG0_STOP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_CTRL_RUN_STOP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_CTRL_XSTOP_STOP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_FILT_CRESP_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_FILT_CRESP_PAT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_FILT_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_FILT_PAT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_IMA_PDBAR_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_IMA_PDBAR_SCOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_IMA_PDBAR_SPLIT_CORE_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_MEM_PRIORITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_MEM_SCOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_MODE_DIS_FORCE_GROUP_SCOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_MODE_DIS_TSTAMP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_MODE_MARKERS_ONLY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_MODE_SINGLE_TSTAMP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_MODE_VGTARGET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_MODE_WRAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_TSIZEFILT_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_TSIZEFILT_PAT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_TTYPEFILT_INVERT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_TTYPEFILT_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HTMSC_TTYPEFILT_PAT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -284,12 +779,68 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>HWP_CONTROL_FLAGS_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_BUS_DIV_NEST</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>I2C_BUS_DIV_REF</id>
+    <default>0x0003</default>
+  </attribute>
+  <attribute>
+    <id>I2C_BUS_DIV_REF_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>I2C_BUS_SPEED_ARRAY</id>
-    <default>400,400,400,400,400,400</default>
+    <default>1000,1000,0,0,400,400,400,400,400,0,0,0,400,400,0,0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_ENGINE_MUTEX_0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_ENGINE_MUTEX_1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_ENGINE_MUTEX_2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_ENGINE_MUTEX_3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_PAGE_MUTEX_0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_PAGE_MUTEX_1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_PAGE_MUTEX_2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_PAGE_MUTEX_3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_SLAVE_ADDRESS</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>I2C_SWITCHES</id>
@@ -325,8 +876,36 @@
     <default>32</default>
   </attribute>
   <attribute>
+    <id>IMT_BAR_SIZE</id>
+    <default>0x0000000000000000</default>
+  </attribute>
+  <attribute>
+    <id>IMT_BASE_ADDR</id>
+    <default>0xFFFFFFFFFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>INTP_BASE_ADDR</id>
     <default>0,0x0003FFFF80300000</default>
+  </attribute>
+  <attribute>
+    <id>IO_FILTER_BYPASS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>ISTEP_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>IS_SP_MODE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>L2_CACHE_ASSOC_SETS</id>
@@ -349,8 +928,44 @@
     <default>10240</default>
   </attribute>
   <attribute>
-    <id>LPC_BUS_ADDR</id>
+    <id>LEN_OF_SEEPROM_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>LPC_BASE_ADDR</id>
     <default></default>
+  </attribute>
+  <attribute>
+    <id>LPC_BUS_ADDR</id>
+    <default>0,0x0006030000000000,0x200000000000</default>
+  </attribute>
+  <attribute>
+    <id>MASTER_CORE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MASTER_EX</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MB_BIT_RATE_DIVISOR_PLL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MB_BIT_RATE_DIVISOR_REFCLK</id>
+    <default>133</default>
+  </attribute>
+  <attribute>
+    <id>MC_SYNC_MODE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>MEM_BASE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MIRROR_BASE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
@@ -365,7 +980,91 @@
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>MSS_FREQ</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MCS_GROUP_32</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_IPL_COMPLETE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>MSS_MEM_MC_IN_GROUP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NEST_MEM_X_O_PCI_BYPASS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NEST_VCS_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NEST_VDDR_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NEST_VDD_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NEST_VDN_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NEST_VIO_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_CTRL_MARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_CTRL_TRIG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_HTMSC_MODE_CAPTURE_ENABLE_FILTER_ALL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_HTMSC_MODE_CAPTURE_GENERATED_WRITES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_HTMSC_MODE_CAPTURE_LIMIT_MEM_ALLOCATION</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_HTMSC_MODE_CAPTURE_PMISC_ONLY_CMD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_HTMSC_MODE_CAPTURE_PRECISE_CRESP_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_HTMSC_MODE_CONTENT_SEL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_HTMSC_MODE_SYNC_STAMP_FORCE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_HTMSC_MODE_WRITETOIO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NHTM_TRACE_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>NODE_POS</id>
     <default>0</default>
   </attribute>
   <attribute>
@@ -373,24 +1072,60 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>NPU_MMIO_BAR_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>NVIDIA_NPU_PRIVILEGED_ADDR</id>
-    <default></default>
+    <default>0,0x0006030200000000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>NVIDIA_NPU_USER_REG_ADDR</id>
-    <default></default>
+    <default>0,0x0006030201000000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>NVIDIA_PHY0_REG_ADDR</id>
-    <default></default>
+    <default>0,0x0006030201200000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>NVIDIA_PHY1_REG_ADDR</id>
-    <default></default>
+    <default>0,0x0006030201400000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>NX_RNG_ADDR</id>
+    <default>0,0x00060302031D0000,0x200000000000</default>
+  </attribute>
+  <attribute>
+    <id>OBUS_RATIO_VALUE</id>
     <default></default>
+  </attribute>
+  <attribute>
+    <id>OCC_LFIR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PART_NUMBER</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PBAX_BRDCST_ID_VECTOR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PBAX_CHIPID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PBAX_GROUPID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PBA_LFIR</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>PCI_BASE_ADDRS_32</id>
@@ -401,40 +1136,376 @@
     <default>0x0</default>
   </attribute>
   <attribute>
+    <id>PFET_OFF_CONTROLS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>PHB_BASE_ADDRS</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>PHB_MMIO_ADDRS_32</id>
-    <default>
-            0x000604C000000000,0x000604C080000000,
-            0x000604C100000000,0x000604C180000000,
-            0x000604C200000000,0x000604C280000000,
-        </default>
+    <default>6,0x000600C000000000,0x200000000000,0,0x080000000</default>
   </attribute>
   <attribute>
     <id>PHB_MMIO_ADDRS_64</id>
-    <default>
-            0x0006040000000000,0x0006042000000000,
-            0x0006044000000000,0x0006046000000000,
-            0x0006048000000000,0x000604A000000000,
-        </default>
+    <default>6,0x0006000000000000,0x200000000000,0,0x2000000000</default>
   </attribute>
   <attribute>
     <id>PHB_REG_ADDRS</id>
-    <default>
-            0x000604C3C0000000,0x000604C3C0100000,
-            0x000604C3C0200000,0x000604C3C0300000,
-            0x000604C3C0400000,0x000604C3C0500000,
-        </default>
+    <default>6,0x000600C3C0000000,0x200000000000,0,0x100000</default>
   </attribute>
   <attribute>
     <id>PHB_XIVE_ESB_ADDRS</id>
-    <default>
-            0x000604C300000000,0x000604C320000000,
-            0x000604C340000000,0x000604C360000000,
-            0x000604C380000000,0x000604C3A0000000,
-        </default>
+    <default>6,0x000600C300000000,0x200000000000,0,0x20000000</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_AISS_TIMEOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_APSS_CHIP_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_EXTERNAL_VRM_STEPDELAY_RANGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_EXTERNAL_VRM_STEPDELAY_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_FIRINIT_DONE_ONCE_FLAG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_IVRMS_ENABLED</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_OCC_HEARTBEAT_TIME</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_OCC_LFIR_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PBAX_NODEID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_PBAX_RCV_RESERV_TIMEOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PBAX_SND_RESERV_TIMEOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PBAX_SND_RETRY_COUNT_OVERCOMMIT_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PBAX_SND_RETRY_THRESHOLD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PBA_FIR_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_CORE_DELAY0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_CORE_DELAY0_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_CORE_DELAY1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_CORE_DELAY1_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_CORE_SEQUENCE_DELAY_SELECT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_ECO_DELAY0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_ECO_DELAY0_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_ECO_DELAY1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_ECO_DELAY1_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_ECO_SEQUENCE_DELAY_SELECT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_CORE_DELAY0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_CORE_DELAY0_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_CORE_DELAY1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_CORE_DELAY1_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_CORE_SEQUENCE_DELAY_SELECT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_ECO_DELAY0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_ECO_DELAY0_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_ECO_DELAY1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_ECO_DELAY1_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_ECO_SEQUENCE_DELAY_SELECT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PMC_HANGPULSE_DIVIDER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PMC_LFIR_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_POWER_PROXY_TRACE_TIMER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PPT_TIMER_MATCH_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PPT_TIMER_TICK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PSTATE0_FREQUENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PSTATE_STEPSIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_PVSAFE_PSTATE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_FULL_CSB_PSTATE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_HFRHIGH_PSTATE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_HFRLOW_PSTATE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_LFRLOW_PSTATE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_LFRUPPER_PSTATE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SAFE_PSTATE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SLEEP_ENTRY</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_SLEEP_EXIT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_SLEEP_TYPE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_SLEEP_WINKLE_REQUEST_TIMEOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIPSS_CLOCK_DIVIDER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIPSS_CLOCK_PHASE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIPSS_CLOCK_POLARITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIPSS_FRAME_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIPSS_INTER_FRAME_DELAY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIPSS_INTER_FRAME_DELAY_SETTING</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIPSS_IN_COUNT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIPSS_IN_DELAY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIPSS_OUT_COUNT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_CLOCK_DIVIDER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_CLOCK_PHASE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_CLOCK_POLARITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_CRC_CHECK_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_CRC_GEN_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_CRC_POLYNOMIAL_ENABLES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_FRAME_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_INTERFRAME_DELAY_WRITE_STATUS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_INTERFRAME_DELAY_WRITE_STATUS_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_INTER_RETRY_DELAY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_INTER_RETRY_DELAY_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_IN_DELAY_FRAME1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_IN_DELAY_FRAME2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_MAJORITY_VOTE_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_MAX_RETRIES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_PORT_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_SPWUP_IGNORE_XSTOP_FLAG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PM_UNDERVOLTING_FREQ_MAXIMUM</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_UNDERVOLTING_FRQ_MINIMUM</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_WINKLE_ENTRY</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_WINKLE_EXIT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PM_WINKLE_TYPE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PNOR_I2C_ADDRESS_BYTES</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>POSITION</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -458,6 +1529,210 @@
     </default>
   </attribute>
   <attribute>
+    <id>PROC_CHTM_BAR_BASE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_CHTM_BAR_SIZES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_DCM_INSTALLED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_DPLL_DIVIDER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_A_ADDR_DIS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_A_AGGREGATE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_A_ATTACHED_CHIP_CNFG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_A_ATTACHED_CHIP_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_A_ATTACHED_LINK_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_A_LINK_DELAY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_GROUP_MASTER_CHIP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_OPTICS_CONFIG_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_SYSTEM_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_SYSTEM_MASTER_CHIP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_X_ADDR_DIS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_X_AGGREGATE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_X_ATTACHED_CHIP_CNFG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_X_ATTACHED_CHIP_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_X_ATTACHED_LINK_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_X_LINK_DELAY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_FSP_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_HW_TOPOLOGY</id>
+    <default>0x00000000</default>
+  </attribute>
+  <attribute>
+    <id>PROC_INT_CQ_IC_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_INT_CQ_PC_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_INT_CQ_TM1_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_INT_CQ_VC_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_L3_BAR1_REG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_L3_BAR2_REG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_L3_BAR_GROUP_MASK_REG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_MASTER_TYPE</id>
+    <default>NOT_MASTER</default>
+  </attribute>
+  <attribute>
+    <id>PROC_MEM_BASES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_MEM_BASES_ACK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_MEM_SIZES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_MEM_SIZES_ACK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_MIRROR_BASES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_MIRROR_BASES_ACK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_MIRROR_SIZES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_MIRROR_SIZES_ACK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_NHTM_BAR_BASE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_NHTM_BAR_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_NPU_MMIO_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_NPU_PHY0_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_NPU_PHY1_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_NX_RNG_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_NX_RNG_FAILED_INT_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_NX_RNG_FAILED_INT_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_OCC_SANDBOX_BASE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_OCC_SANDBOX_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PB_BNDY_DMIPLL_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PB_BNDY_DMIPLL_FOR_DCCAL_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NOT_F_LINK</id>
+    <default>1,1</default>
+  </attribute>
+  <attribute>
     <id>PROC_PCIE_NUM_IOP</id>
     <default>3</default>
   </attribute>
@@ -466,24 +1741,132 @@
     <default>48</default>
   </attribute>
   <attribute>
+    <id>PROC_PCIE_NUM_PEC</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
     <id>PROC_PCIE_NUM_PHB</id>
     <default>6</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PHB_ACTIVE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PROC_PCIE_REFCLOCK_ENABLE</id>
     <default>0xE0</default>
   </attribute>
   <attribute>
+    <id>PROC_PERV_BNDY_PLL_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PSI_BRIDGE_BAR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_R_DISTLOSS_VCS_UOHM</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_R_DISTLOSS_VDD_UOHM</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_R_DISTLOSS_VDN_UOHM</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_R_LOADLINE_VCS_UOHM</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_R_LOADLINE_VDD_UOHM</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_R_LOADLINE_VDN_UOHM</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_SBE_MASTER_CHIP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_SECURITY_SETUP_VECTOR</id>
+    <default>0x8000000080000000</default>
+  </attribute>
+  <attribute>
+    <id>PROC_SELECT_BOOT_SEEPROM_IMAGE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>PROC_VRM_VOFFSET_VCS_UV</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_VRM_VOFFSET_VDD_UV</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_VRM_VOFFSET_VDN_UV</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PSI_BRIDGE_BASE_ADDR</id>
-    <default>0,0x0006070203000000</default>
+    <default>0,0x0006030203000000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>PSI_HB_ESB_ADDR</id>
-    <default>0x00060302031C0000</default>
+    <default>0,0x00060302031C0000,0x200000000000</default>
+  </attribute>
+  <attribute>
+    <id>PSTATEGPE_BOOT_COPIER_IVPR_OFFSET</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>RNG_BAR_SIZE</id>
+    <default>0x000000000001000</default>
+  </attribute>
+  <attribute>
+    <id>RU_TYPE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SBE_FFDC_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SBE_INTERNAL_FFDC_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SBE_RUNTIME_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SBE_SEEPROM_I2C_ADDRESS_BYTES</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>SBE_SEEPROM_I2C_DEVICE_ADDRESS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SBE_SEEPROM_I2C_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCAN_MUTEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SCOM_IND_MUTEX</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>SCOM_SWITCHES</id>
@@ -511,8 +1894,76 @@
     </default>
   </attribute>
   <attribute>
+    <id>SCRATCH6_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH7_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SECUREBOOT_PROTECT_DECONFIGURED_TPM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SERIAL_NUMBER</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default>0x00000000</default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default>0x00001000</default>
+  </attribute>
+  <attribute>
+    <id>SS_FILTER_BYPASS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>START_PIBMEM_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>START_SEEPROM_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>STOPGPE_BOOT_COPIER_IVPR_OFFSET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SYSTEM_RESCLK_FREQ_REGIONS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SYSTEM_RESCLK_FREQ_REGION_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SYSTEM_RESCLK_L3_VALUE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SYSTEM_RESCLK_L3_VOLTAGE_THRESHOLD_MV</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SYSTEM_RESCLK_VALUE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TDP_RDP_CURRENT_FACTOR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TIME_BASE</id>
+    <default>0x800000</default>
   </attribute>
   <attribute>
     <id>TLB_DATA_ASSOC_SETS</id>
@@ -535,40 +1986,189 @@
     <default>128</default>
   </attribute>
   <attribute>
+    <id>TOD_CPU_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TOD_ROLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>TYPE</id>
     <default>PROC</default>
   </attribute>
   <attribute>
+    <id>UNIT_TEST_MCA_MEMORY_SIZES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>VAS_HYPERVISOR_WINDOW_CONTEXT_ADDR</id>
-    <default></default>
+    <default>0,0x0006013000000000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>VAS_USER_WINDOW_CONTEXT_ADDR</id>
-    <default></default>
+    <default>0,0x0006013100000000,0x200000000000</default>
+  </attribute>
+  <attribute>
+    <id>VCS_AVSBUS_BUSNUM</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>VCS_AVSBUS_RAIL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VCS_BOOT_VOLTAGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VCS_I2C_BUSNUM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VCS_I2C_RAIL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VDD_AVSBUS_BUSNUM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VDD_AVSBUS_RAIL</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>VDD_BOOT_VOLTAGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VDN_AVSBUS_BUSNUM</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>VDN_AVSBUS_RAIL</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>VDN_BOOT_VOLTAGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_EXT_VCS_BIAS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_EXT_VDD_BIAS_NOMINAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_EXT_VDD_BIAS_POWERSAVE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_EXT_VDD_BIAS_TURBO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_EXT_VDD_BIAS_ULTRATURBO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_EXT_VDN_BIAS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_INT_VDD_BIAS_NOMINAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_INT_VDD_BIAS_POWERSAVE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_INT_VDD_BIAS_TURBO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VOLTAGE_INT_VDD_BIAS_ULTRATURBO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_REC_NUM</id>
+    <default>0xFFFF</default>
+  </attribute>
+  <attribute>
+    <id>VPD_SWITCHES</id>
+    <default>
+      <field>
+        <id>pnorCacheValid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>pnorCacheValidRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>disableWriteToPnorRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>WAIT_N0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>WAIT_N1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>WAIT_N2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>WAIT_N3</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>XIVE_CONTROLLER_BAR_ADDR</id>
-    <default>0,0x0006030203100000</default>
+    <default>0,0x0006030203100000,0x200000000000</default>
+  </attribute>
+  <attribute>
+    <id>XIVE_HW_RESET</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>XIVE_PRESENTATION_BAR_ADDR</id>
-    <default></default>
+    <default>0,0x6030203180000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>XIVE_PRESENTATION_NVT_ADDR</id>
-    <default></default>
+    <default>0,0x0006012000000000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>XIVE_ROUTING_END_ADDR</id>
-    <default></default>
+    <default>0,0x0006011000000000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>XIVE_ROUTING_ESB_ADDR</id>
-    <default></default>
+    <default>0,0x0006010000000000,0x200000000000</default>
   </attribute>
   <attribute>
     <id>XIVE_THREAD_MGMT1_BAR_ADDR</id>
     <default>0x0006020000000000</default>
+  </attribute>
+  <attribute>
+    <id>XSCOM_BASE_ADDRESS</id>
+    <default>0,0x000603FC00000000,0x200000000000</default>
+  </attribute>
+  <attribute>
+    <id>XSCOM_VIRTUAL_ADDR</id>
+    <default></default>
   </attribute>
   <child_id>eq0</child_id>
   <child_id>eq1</child_id>
@@ -692,11 +2292,15 @@
   <hidden_child_id>cpu_func_sensor</hidden_child_id>
   <instance_name>p9_proc_l</instance_name>
   <is_root>false</is_root>
-  <position></position>
+  <position>-1</position>
   <type>chip-processor-nimbus</type>
 </targetPart>
 <targetPart>
   <id>eq0</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
@@ -704,6 +2308,10 @@
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x10</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -716,6 +2324,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -747,12 +2367,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>POUNDV_BUCKET_NUM</id>
@@ -784,12 +2432,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>QUAD_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SENSEADJ_STEP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -805,12 +2469,44 @@
 <targetPart>
   <id>ex0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x10</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -821,8 +2517,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -854,12 +2574,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -883,12 +2643,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -904,12 +2672,20 @@
 <targetPart>
   <id>core0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x20</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -920,8 +2696,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -953,12 +2753,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -982,12 +2814,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1004,12 +2844,20 @@
 <targetPart>
   <id>core1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x21</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1020,8 +2868,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1053,12 +2925,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -1082,12 +2986,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1104,12 +3016,44 @@
 <targetPart>
   <id>ex1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x10</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1120,8 +3064,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1153,12 +3121,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -1182,12 +3190,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1203,12 +3219,20 @@
 <targetPart>
   <id>core2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x22</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1219,8 +3243,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1252,12 +3300,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -1281,12 +3361,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1303,12 +3391,20 @@
 <targetPart>
   <id>core3</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x23</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1319,8 +3415,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1352,12 +3472,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -1381,12 +3533,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1403,12 +3563,20 @@
 <targetPart>
   <id>eq1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x11</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1421,6 +3589,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1452,12 +3632,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>POUNDV_BUCKET_NUM</id>
@@ -1489,12 +3697,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>QUAD_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SENSEADJ_STEP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1510,12 +3734,44 @@
 <targetPart>
   <id>ex2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x11</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1526,8 +3782,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1559,12 +3839,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -1588,12 +3908,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1609,12 +3937,20 @@
 <targetPart>
   <id>core4</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x24</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1625,8 +3961,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1658,12 +4018,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -1687,12 +4079,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1709,12 +4109,20 @@
 <targetPart>
   <id>core5</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x25</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1725,8 +4133,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1758,12 +4190,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -1787,12 +4251,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1809,12 +4281,44 @@
 <targetPart>
   <id>ex3</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x11</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1825,8 +4329,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1858,12 +4386,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -1887,12 +4455,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -1908,12 +4484,20 @@
 <targetPart>
   <id>core6</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x26</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -1924,8 +4508,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -1957,12 +4565,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -1986,12 +4626,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2008,12 +4656,20 @@
 <targetPart>
   <id>core7</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x27</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2024,8 +4680,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2057,12 +4737,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -2086,12 +4798,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2108,12 +4828,20 @@
 <targetPart>
   <id>eq2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x12</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2126,6 +4854,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2157,12 +4897,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>POUNDV_BUCKET_NUM</id>
@@ -2194,12 +4962,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>QUAD_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SENSEADJ_STEP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2215,12 +4999,44 @@
 <targetPart>
   <id>ex4</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x12</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2231,8 +5047,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2264,12 +5104,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -2293,12 +5173,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2314,12 +5202,20 @@
 <targetPart>
   <id>core8</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x28</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2330,8 +5226,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2363,12 +5283,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -2392,12 +5344,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2414,12 +5374,20 @@
 <targetPart>
   <id>core9</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x29</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2430,8 +5398,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2463,12 +5455,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -2492,12 +5516,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2514,12 +5546,44 @@
 <targetPart>
   <id>ex5</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x12</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2530,8 +5594,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2563,12 +5651,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -2592,12 +5720,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2613,12 +5749,20 @@
 <targetPart>
   <id>core10</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2A</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2629,8 +5773,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2662,12 +5830,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -2691,12 +5891,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2713,12 +5921,20 @@
 <targetPart>
   <id>core11</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2B</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2729,8 +5945,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2762,12 +6002,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -2791,12 +6063,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2813,12 +6093,20 @@
 <targetPart>
   <id>eq3</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x13</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2831,6 +6119,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2862,12 +6162,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>POUNDV_BUCKET_NUM</id>
@@ -2899,12 +6227,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>QUAD_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SENSEADJ_STEP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -2920,12 +6264,44 @@
 <targetPart>
   <id>ex6</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x13</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -2936,8 +6312,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -2969,12 +6369,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -2998,12 +6438,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3019,12 +6467,20 @@
 <targetPart>
   <id>core12</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2C</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3035,8 +6491,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3068,12 +6548,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -3097,12 +6609,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3119,12 +6639,20 @@
 <targetPart>
   <id>core13</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2D</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3135,8 +6663,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3168,12 +6720,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -3197,12 +6781,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3219,12 +6811,44 @@
 <targetPart>
   <id>ex7</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x13</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3235,8 +6859,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3268,12 +6916,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -3297,12 +6985,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3318,12 +7014,20 @@
 <targetPart>
   <id>core14</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2E</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3334,8 +7038,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3367,12 +7095,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -3396,12 +7156,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3418,12 +7186,20 @@
 <targetPart>
   <id>core15</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2F</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3434,8 +7210,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3467,12 +7267,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -3496,12 +7328,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3518,12 +7358,20 @@
 <targetPart>
   <id>eq4</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x14</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3536,6 +7384,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3567,12 +7427,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>POUNDV_BUCKET_NUM</id>
@@ -3604,12 +7492,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>QUAD_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SENSEADJ_STEP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3625,12 +7529,44 @@
 <targetPart>
   <id>ex8</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x14</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3641,8 +7577,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3674,12 +7634,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -3703,12 +7703,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3724,12 +7732,20 @@
 <targetPart>
   <id>core16</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x30</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3740,8 +7756,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3773,12 +7813,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -3802,12 +7874,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3824,12 +7904,20 @@
 <targetPart>
   <id>core17</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x31</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3840,8 +7928,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3873,12 +7985,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -3902,12 +8046,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -3924,12 +8076,44 @@
 <targetPart>
   <id>ex9</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x14</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -3940,8 +8124,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -3973,12 +8181,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -4002,12 +8250,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4023,12 +8279,20 @@
 <targetPart>
   <id>core18</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x32</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4039,8 +8303,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4072,12 +8360,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -4101,12 +8421,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4123,12 +8451,20 @@
 <targetPart>
   <id>core19</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x33</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4139,8 +8475,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4172,12 +8532,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -4201,12 +8593,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4223,12 +8623,20 @@
 <targetPart>
   <id>eq5</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x15</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4241,6 +8649,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4272,12 +8692,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>POUNDV_BUCKET_NUM</id>
@@ -4309,12 +8757,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>QUAD_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SENSEADJ_STEP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4330,12 +8794,44 @@
 <targetPart>
   <id>ex10</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x15</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4346,8 +8842,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4379,12 +8899,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -4408,12 +8968,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4429,12 +8997,20 @@
 <targetPart>
   <id>core20</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x34</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4445,8 +9021,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4478,12 +9078,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -4507,12 +9139,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4529,12 +9169,20 @@
 <targetPart>
   <id>core21</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x35</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4545,8 +9193,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4578,12 +9250,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -4607,12 +9311,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4629,12 +9341,44 @@
 <targetPart>
   <id>ex11</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>C0_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C0_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_EXEC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>C1_PC_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x15</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4645,8 +9389,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CME_LOCAL_FIRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4678,12 +9446,52 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L2_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASCLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>L3_HASPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -4707,12 +9515,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4728,12 +9544,20 @@
 <targetPart>
   <id>core22</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x36</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4744,8 +9568,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4777,12 +9625,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -4806,12 +9686,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4828,12 +9716,20 @@
 <targetPart>
   <id>core23</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>CPU</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x37</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4844,8 +9740,32 @@
     <default>UNIT</default>
   </attribute>
   <attribute>
+    <id>CORE_PPM_ERRMASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HBRT_HYP_ID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4877,12 +9797,44 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -4906,12 +9858,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>SPCWKUP_COUNT</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -4928,8 +9888,16 @@
 <targetPart>
   <id>occ</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -4942,6 +9910,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -4973,12 +9953,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>OCC_MASTER_CAPABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -5000,6 +10008,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5017,12 +10029,20 @@
 <targetPart>
   <id>capp0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>FABRIC</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5035,6 +10055,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -5066,12 +10098,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -5093,6 +10153,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5114,12 +10178,20 @@
 <targetPart>
   <id>capp1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>FABRIC</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5132,6 +10204,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -5163,12 +10247,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -5190,6 +10302,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5211,8 +10327,16 @@
 <targetPart>
   <id>sbe</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5225,6 +10349,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -5256,12 +10392,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -5283,6 +10443,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -5303,12 +10467,6 @@
 </targetPart>
 <targetPart>
   <id>pec0</id>
-  <type>unit-pec-power9</type>
-  <is_root>false</is_root>
-  <instance_name>pec0</instance_name>
-  <position>-1</position>
-  <parent>unit</parent>
-  <child_id>pec0_x16_config</child_id>
   <attribute>
     <id>AFFINITY_PATH</id>
     <default></default>
@@ -5323,7 +10481,7 @@
   </attribute>
   <attribute>
     <id>CHIPLET_ID</id>
-    <default></default>
+    <default>0xD</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -5339,3311 +10497,15 @@
   </attribute>
   <attribute>
     <id>FAPI_NAME</id>
-    <default></default>
+    <default>unknown</default>
   </attribute>
   <attribute>
     <id>FAPI_POS</id>
-    <default></default>
+    <default>0xFFFFFFFF</default>
   </attribute>
   <attribute>
     <id>HUID</id>
     <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-  	</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_IOP_CONFIG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_IOP_SWAP</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_IOVALID_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_M_CNTL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_REFCLOCK_ENABLE</id>
-    <default>0xE0</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PEC</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>pec0_x16_config</id>
-  <type>unit-pciconfigs-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>pec0_x16_config</instance_name>
-  <position>-1</position>
-  <parent>unit</parent>
-  <child_id>phb0_x16</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IO_CONFIG_SELECT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>PCI_CONFIGS</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default></default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb0_x16</id>
-  <type>unit-phb-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb0_x16</instance_name>
-  <position>-1</position>
-  <parent>unit-phb-power9</parent>
-  <child_id>phb0_x16_pci</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default>0x00000001</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_BASE_ADDR</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_SIZE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_NUM_LANES</id>
-    <default>48</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PHB</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb0_x16_pci</id>
-  <type>unit-pci-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb0_x16_pci</instance_name>
-  <position>-1</position>
-  <parent>unit-pci-power9</parent>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>16</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCHEMATIC_INTERFACE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>pec1</id>
-  <type>unit-pec-power9</type>
-  <is_root>false</is_root>
-  <instance_name>pec1</instance_name>
-  <position>-1</position>
-  <parent>unit</parent>
-  <child_id>pec1_x8_x8_config</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-  	</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_IOP_CONFIG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_IOP_SWAP</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_IOVALID_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_M_CNTL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_REFCLOCK_ENABLE</id>
-    <default>0xE0</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PEC</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>pec1_x8_x8_config</id>
-  <type>unit-pciconfigs-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>pec1_x8_x8_config</instance_name>
-  <position>-1</position>
-  <parent>unit</parent>
-  <child_id>phb1_x8</child_id>
-  <child_id>phb2_x8</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IO_CONFIG_SELECT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>PCI_CONFIGS</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default></default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb1_x8</id>
-  <type>unit-phb-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb1_x8</instance_name>
-  <position>-1</position>
-  <parent>unit-phb-power9</parent>
-  <child_id>phb1_x8_pci</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default>0x00000001</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_BASE_ADDR</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_SIZE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_NUM_LANES</id>
-    <default>48</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PHB</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb1_x8_pci</id>
-  <type>unit-pci-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb1_x8_pci</instance_name>
-  <position>-1</position>
-  <parent>unit-pci-power9</parent>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCHEMATIC_INTERFACE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb2_x8</id>
-  <type>unit-phb-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb2_x8</instance_name>
-  <position>-1</position>
-  <parent>unit-phb-power9</parent>
-  <child_id>phb2_x8_pci</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default>0x00000001</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_BASE_ADDR</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_SIZE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_NUM_LANES</id>
-    <default>48</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PHB</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb2_x8_pci</id>
-  <type>unit-pci-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb2_x8_pci</instance_name>
-  <position>-1</position>
-  <parent>unit-pci-power9</parent>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCHEMATIC_INTERFACE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>pec2</id>
-  <type>unit-pec-power9</type>
-  <is_root>false</is_root>
-  <instance_name>pec2</instance_name>
-  <position>-1</position>
-  <parent>unit</parent>
-  <child_id>pec2_x16_config</child_id>
-  <child_id>pec2_x8_x8_config</child_id>
-  <child_id>pec2_x8_x4_x4_config</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-  	</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_IOP_CONFIG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_IOP_SWAP</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_IOVALID_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_M_CNTL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_REFCLOCK_ENABLE</id>
-    <default>0xE0</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PEC</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>pec2_x16_config</id>
-  <type>unit-pciconfigs-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>pec2_x16_config</instance_name>
-  <position>-1</position>
-  <parent>unit</parent>
-  <child_id>phb3_x16</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IO_CONFIG_SELECT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>PCI_CONFIGS</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default></default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb3_x16</id>
-  <type>unit-phb-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb3_x16</instance_name>
-  <position>-1</position>
-  <parent>unit-phb-power9</parent>
-  <child_id>phb3_x16_pci</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>3</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default>0x00000001</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_BASE_ADDR</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_SIZE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_NUM_LANES</id>
-    <default>48</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PHB</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb3_x16_pci</id>
-  <type>unit-pci-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb3_x16_pci</instance_name>
-  <position>-1</position>
-  <parent>unit-pci-power9</parent>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>3</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>16</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>3</default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCHEMATIC_INTERFACE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>pec2_x8_x8_config</id>
-  <type>unit-pciconfigs-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>pec2_x8_x8_config</instance_name>
-  <position>-1</position>
-  <parent>unit</parent>
-  <child_id>phb3_x8</child_id>
-  <child_id>phb4_x8</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IO_CONFIG_SELECT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>PCI_CONFIGS</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default></default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb3_x8</id>
-  <type>unit-phb-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb3_x8</instance_name>
-  <position>-1</position>
-  <parent>unit-phb-power9</parent>
-  <child_id>phb3_x8_pci</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>3</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default>0x00000001</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_BASE_ADDR</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_SIZE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_NUM_LANES</id>
-    <default>48</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PHB</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb3_x8_pci</id>
-  <type>unit-pci-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb3_x8_pci</instance_name>
-  <position>-1</position>
-  <parent>unit-pci-power9</parent>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>3</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>3</default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCHEMATIC_INTERFACE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb4_x8</id>
-  <type>unit-phb-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb4_x8</instance_name>
-  <position>-1</position>
-  <parent>unit-phb-power9</parent>
-  <child_id>phb4_x8_pci</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default>0x00000001</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_BASE_ADDR</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_SIZE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_NUM_LANES</id>
-    <default>48</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PHB</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb4_x8_pci</id>
-  <type>unit-pci-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb4_x8_pci</instance_name>
-  <position>-1</position>
-  <parent>unit-pci-power9</parent>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>8</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCHEMATIC_INTERFACE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>pec2_x8_x4_x4_config</id>
-  <type>unit-pciconfigs-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>pec2_x8_x4_x4_config</instance_name>
-  <position>-1</position>
-  <parent>unit</parent>
-  <child_id>phb3_x8</child_id>
-  <child_id>phb4_x4</child_id>
-  <child_id>phb5_x4</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IO_CONFIG_SELECT</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>PCI_CONFIGS</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default></default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb4_x4</id>
-  <type>unit-phb-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb4_x4</instance_name>
-  <position>-1</position>
-  <parent>unit-phb-power9</parent>
-  <child_id>phb4_x4_pci</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default>0x00000001</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_BASE_ADDR</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_SIZE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_NUM_LANES</id>
-    <default>48</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PHB</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb4_x4_pci</id>
-  <type>unit-pci-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb4_x4_pci</instance_name>
-  <position>-1</position>
-  <parent>unit-pci-power9</parent>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCHEMATIC_INTERFACE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb5_x4</id>
-  <type>unit-phb-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb5_x4</instance_name>
-  <position>-1</position>
-  <parent>unit-phb-power9</parent>
-  <child_id>phb5_x4_pci</child_id>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>IO</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default>0x00000001</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PARENT_PERVASIVE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_BASE_ADDR</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_ENABLE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_BAR_SIZE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PROC_PCIE_NUM_LANES</id>
-    <default>48</default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PHB</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>phb5_x4_pci</id>
-  <type>unit-pci-nimbus</type>
-  <is_root>false</is_root>
-  <instance_name>phb5_x4_pci</instance_name>
-  <position>-1</position>
-  <parent>unit-pci-power9</parent>
-  <attribute>
-    <id>AFFINITY_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>PCIE</default>
-  </attribute>
-  <attribute>
-    <id>CHIPLET_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>DIRECTION</id>
-    <default>OUT</default>
-  </attribute>
-  <attribute>
-    <id>ENABLE_CAPI</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>FAPI_NAME</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>FAPI_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HUID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field><id>deconfiguredByEid</id><value></value></field>
-      <field><id>poweredOn</id><value></value></field>
-      <field><id>present</id><value></value></field>
-      <field><id>functional</id><value></value></field>
-      <field><id>dumpfunctional</id><value></value></field>
-      <field><id>specdeconfig</id><value></value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_FLAG</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>IOP_NUM</id>
-    <default>2</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRU_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>ORDINAL_ID</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_MASK</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PCIE_LANE_SET</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>PCIE_NUM_LANES</id>
-    <default>4</default>
-  </attribute>
-  <attribute>
-    <id>PHB_NUM</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>PHYS_PATH</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field><id>supportsFsiScom</id><value>1</value></field>
-      <field><id>supportsXscom</id><value>1</value></field>
-      <field><id>supportsInbandScom</id><value>0</value></field>
-      <field><id>reserved</id><value>0</value></field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>REL_POS</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCHEMATIC_INTERFACE</id>
-    <default></default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>PCI</default>
-  </attribute>
-</targetPart>
-<targetPart>
-  <id>nvbus0</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>FABRIC</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -8675,12 +10537,68 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
-    <default>NIMBUS</default>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL_NON_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_SWAP_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_SWAP_NON_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_LANE_MASK_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -8702,6 +10620,4769 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_CONFIG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_SWAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOVALID_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_M_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
+    <default>0xF8</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
+    <default>0xF8</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
+    <default>0x56,0x47,0x47,0x47</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_DFE_FDDC</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_INIT_GAIN</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_PK_INIT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_EXTEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_RST_FW</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_SIGDET_LVL</id>
+    <default>0x0B,0x0B,0x0B,0x0B</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
+    <default>0x0022</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
+    <default>0xAA7A</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
+    <default>0x2000</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_REFCLOCK_ENABLE</id>
+    <default>0xE0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PEC</default>
+  </attribute>
+  <child_id>pec0_x16_config</child_id>
+  <instance_name>pec0</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pec-power9</type>
+</targetPart>
+<targetPart>
+  <id>pec0_x16_config</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+  <child_id>phb0_x16</child_id>
+  <instance_name>pec0_x16_config</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pciconfigs-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb0_x16</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+  <child_id>phb0_x16_pci</child_id>
+  <instance_name>phb0_x16</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-phb-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb0_x16_pci</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default>0xFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_GROUP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>16</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+  <instance_name>phb0_x16_pci</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pci-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>pec1</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xE</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL_NON_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_SWAP_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_SWAP_NON_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_LANE_MASK_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_CONFIG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_SWAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOVALID_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_M_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
+    <default>0xF8</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
+    <default>0xF8</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
+    <default>0x56,0x47,0x47,0x47</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_DFE_FDDC</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_INIT_GAIN</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_PK_INIT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_EXTEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_RST_FW</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_SIGDET_LVL</id>
+    <default>0x0B,0x0B,0x0B,0x0B</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
+    <default>0x0022</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
+    <default>0xAA7A</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
+    <default>0x2000</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_REFCLOCK_ENABLE</id>
+    <default>0xE0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PEC</default>
+  </attribute>
+  <child_id>pec1_x8_x8_config</child_id>
+  <instance_name>pec1</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pec-power9</type>
+</targetPart>
+<targetPart>
+  <id>pec1_x8_x8_config</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+  <child_id>phb1_x8</child_id>
+  <child_id>phb2_x8</child_id>
+  <instance_name>pec1_x8_x8_config</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pciconfigs-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb1_x8</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+  <child_id>phb1_x8_pci</child_id>
+  <instance_name>phb1_x8</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-phb-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb1_x8_pci</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default>0xFF00</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_GROUP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>8</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+  <instance_name>phb1_x8_pci</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pci-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb2_x8</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+  <child_id>phb2_x8_pci</child_id>
+  <instance_name>phb2_x8</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-phb-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb2_x8_pci</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default>0x00FF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_GROUP</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>8</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+  <instance_name>phb2_x8_pci</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pci-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>pec2</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL_NON_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_SWAP_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_SWAP_NON_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_LANE_MASK_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_CONFIG</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOP_SWAP</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IOVALID_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_MASK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_M_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
+    <default>0xF8</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
+    <default>0xF8</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
+    <default>0x56,0x47,0x47,0x47</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_DFE_FDDC</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_INIT_GAIN</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_PK_INIT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_EXTEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_RST_FW</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_SIGDET_LVL</id>
+    <default>0x0B,0x0B,0x0B,0x0B</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
+    <default>0x0022</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
+    <default>0xAA7A</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
+    <default>0x2000</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_REFCLOCK_ENABLE</id>
+    <default>0xE0</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PEC</default>
+  </attribute>
+  <child_id>pec2_x16_config</child_id>
+  <child_id>pec2_x8_x8_config</child_id>
+  <child_id>pec2_x8_x4_x4_config</child_id>
+  <instance_name>pec2</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pec-power9</type>
+</targetPart>
+<targetPart>
+  <id>pec2_x16_config</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+  <child_id>phb3_x16</child_id>
+  <instance_name>pec2_x16_config</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pciconfigs-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb3_x16</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+  <child_id>phb3_x16_pci</child_id>
+  <instance_name>phb3_x16</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-phb-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb3_x16_pci</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default>0xFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_GROUP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>16</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+  <instance_name>phb3_x16_pci</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pci-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>pec2_x8_x8_config</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+  <child_id>phb3_x8</child_id>
+  <child_id>phb4_x8</child_id>
+  <instance_name>pec2_x8_x8_config</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pciconfigs-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb3_x8</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+  <child_id>phb3_x8_pci</child_id>
+  <instance_name>phb3_x8</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-phb-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb3_x8_pci</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default>0xFF00</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_GROUP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>8</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+  <instance_name>phb3_x8_pci</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pci-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb4_x8</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+  <child_id>phb4_x8_pci</child_id>
+  <instance_name>phb4_x8</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-phb-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb4_x8_pci</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default>0x00FF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_GROUP</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>8</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+  <instance_name>phb4_x8_pci</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pci-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>pec2_x8_x4_x4_config</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IO_CONFIG_SELECT</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>PCI_CONFIGS</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default></default>
+  </attribute>
+  <child_id>phb3_x8</child_id>
+  <child_id>phb4_x4</child_id>
+  <child_id>phb5_x4</child_id>
+  <instance_name>pec2_x8_x4_x4_config</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pciconfigs-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb3_x8</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+  <child_id>phb3_x8_pci</child_id>
+  <instance_name>phb3_x8</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-phb-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb3_x8_pci</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default>0xFF00</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_GROUP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>8</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+  <instance_name>phb3_x8_pci</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pci-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb4_x4</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+  <child_id>phb4_x4_pci</child_id>
+  <instance_name>phb4_x4</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-phb-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb4_x4_pci</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default>0x00F0</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_GROUP</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+  <instance_name>phb4_x4_pci</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pci-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb5_x4</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>IO</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <default>
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777,
+            0x7777,0x7777,0x7777,0x7777
+        </default>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <default>48</default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCRATCH_UINT8_1</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PHB</default>
+  </attribute>
+  <child_id>phb5_x4_pci</child_id>
+  <instance_name>phb5_x4</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-phb-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>phb5_x4_pci</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>PCIE</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>DIRECTION</id>
+    <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>ENABLE_CAPI</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IOP_NUM</id>
+    <default>2</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_MASK</id>
+    <default>0x000F</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_LANE_GROUP</id>
+    <default>3</default>
+  </attribute>
+  <attribute>
+    <id>PCIE_NUM_LANES</id>
+    <default>4</default>
+  </attribute>
+  <attribute>
+    <id>PHB_NUM</id>
+    <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_INDEX</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>SLCA_RID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <default>PCI</default>
+  </attribute>
+  <instance_name>phb5_x4_pci</instance_name>
+  <is_root>false</is_root>
+  <position>-1</position>
+  <type>unit-pci-nimbus</type>
+</targetPart>
+<targetPart>
+  <id>nvbus0</id>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <default>FABRIC</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x5</default>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>CLASS</id>
+    <default>UNIT</default>
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE</id>
+    <default>
+      <field>
+        <id>deconfiguredByEid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>poweredOn</id>
+        <value></value>
+      </field>
+      <field>
+        <id>present</id>
+        <value></value>
+      </field>
+      <field>
+        <id>functional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>dumpfunctional</id>
+        <value></value>
+      </field>
+      <field>
+        <id>specdeconfig</id>
+        <value></value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>MRW_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <default>
+      <field>
+        <id>supportsFsiScom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsXscom</id>
+        <value>1</value>
+      </field>
+      <field>
+        <id>supportsInbandScom</id>
+        <value>0</value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value>0</value>
+      </field>
+    </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -8723,12 +15404,20 @@
 <targetPart>
   <id>nvbus1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>FABRIC</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -8741,6 +15430,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -8772,12 +15473,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -8799,6 +15528,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -8820,12 +15553,20 @@
 <targetPart>
   <id>nvbus2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>FABRIC</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -8838,6 +15579,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -8869,12 +15622,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -8896,6 +15677,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -8917,8 +15702,16 @@
 <targetPart>
   <id>ppe0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -8931,6 +15724,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -8962,12 +15767,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -8989,6 +15818,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9010,8 +15843,16 @@
 <targetPart>
   <id>ppe10</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9024,6 +15865,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9055,12 +15908,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9082,6 +15959,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9103,8 +15984,16 @@
 <targetPart>
   <id>ppe11</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9117,6 +16006,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9148,12 +16049,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9175,6 +16100,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9196,8 +16125,16 @@
 <targetPart>
   <id>ppe12</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9210,6 +16147,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9241,12 +16190,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9268,6 +16241,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9289,8 +16266,16 @@
 <targetPart>
   <id>ppe13</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9303,6 +16288,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9334,12 +16331,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9361,6 +16382,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9382,8 +16407,16 @@
 <targetPart>
   <id>ppe20</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9396,6 +16429,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9427,12 +16472,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9454,6 +16523,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9475,8 +16548,16 @@
 <targetPart>
   <id>ppe21</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9489,6 +16570,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9520,12 +16613,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9547,6 +16664,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9568,8 +16689,16 @@
 <targetPart>
   <id>ppe22</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9582,6 +16711,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9613,12 +16754,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9640,6 +16805,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9661,8 +16830,16 @@
 <targetPart>
   <id>ppe23</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9675,6 +16852,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9706,12 +16895,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9733,6 +16946,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9754,8 +16971,16 @@
 <targetPart>
   <id>ppe24</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9768,6 +16993,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9799,12 +17036,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9826,6 +17087,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9847,8 +17112,16 @@
 <targetPart>
   <id>ppe25</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9861,6 +17134,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9892,12 +17177,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -9919,6 +17228,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -9940,8 +17253,16 @@
 <targetPart>
   <id>ppe30</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -9954,6 +17275,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -9985,12 +17318,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10012,6 +17369,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10033,8 +17394,16 @@
 <targetPart>
   <id>ppe31</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10047,6 +17416,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10078,12 +17459,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10105,6 +17510,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10126,8 +17535,16 @@
 <targetPart>
   <id>ppe32</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10140,6 +17557,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10171,12 +17600,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10198,6 +17651,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10219,8 +17676,16 @@
 <targetPart>
   <id>ppe33</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10233,6 +17698,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10264,12 +17741,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10291,6 +17792,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10312,8 +17817,16 @@
 <targetPart>
   <id>ppe34</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10326,6 +17839,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10357,12 +17882,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10384,6 +17933,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10405,8 +17958,16 @@
 <targetPart>
   <id>ppe35</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10419,6 +17980,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10450,12 +18023,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10477,6 +18074,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10498,8 +18099,16 @@
 <targetPart>
   <id>ppe40</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10512,6 +18121,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10543,12 +18164,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10570,6 +18215,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10591,8 +18240,16 @@
 <targetPart>
   <id>ppe41</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10605,6 +18262,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10636,12 +18305,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10663,6 +18356,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10684,8 +18381,16 @@
 <targetPart>
   <id>ppe42</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10698,6 +18403,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10729,12 +18446,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10756,6 +18497,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10777,8 +18522,16 @@
 <targetPart>
   <id>ppe43</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10791,6 +18544,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10822,12 +18587,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10849,6 +18638,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10870,8 +18663,16 @@
 <targetPart>
   <id>ppe45</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10884,6 +18685,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -10915,12 +18728,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -10942,6 +18779,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -10963,8 +18804,16 @@
 <targetPart>
   <id>ppe50</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -10977,6 +18826,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -11008,12 +18869,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11035,6 +18920,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -11056,8 +18945,16 @@
 <targetPart>
   <id>perv1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x1</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11072,6 +18969,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11101,16 +19010,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11134,12 +19067,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -11153,8 +19102,16 @@
 <targetPart>
   <id>perv2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11169,6 +19126,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11198,16 +19167,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11231,12 +19224,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -11250,8 +19259,16 @@
 <targetPart>
   <id>perv3</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x3</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11266,6 +19283,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11295,16 +19324,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11328,12 +19381,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -11347,8 +19416,16 @@
 <targetPart>
   <id>perv4</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x4</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11363,6 +19440,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11392,16 +19481,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11425,12 +19538,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -11444,8 +19573,16 @@
 <targetPart>
   <id>perv5</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x5</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11460,6 +19597,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11489,16 +19638,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11522,12 +19695,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -11541,8 +19730,16 @@
 <targetPart>
   <id>perv6</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x6</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11557,6 +19754,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11586,16 +19795,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11619,12 +19852,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -11638,8 +19887,16 @@
 <targetPart>
   <id>perv7</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x7</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11654,6 +19911,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11683,16 +19952,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11716,12 +20009,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -11735,8 +20044,16 @@
 <targetPart>
   <id>perv8</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x8</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11751,6 +20068,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11780,16 +20109,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11813,12 +20166,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -11832,8 +20201,16 @@
 <targetPart>
   <id>perv9</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x9</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11848,6 +20225,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11877,16 +20266,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -11910,12 +20323,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -11929,8 +20358,16 @@
 <targetPart>
   <id>perv12</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xC</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -11945,6 +20382,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -11974,16 +20423,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12007,12 +20480,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12026,8 +20515,16 @@
 <targetPart>
   <id>perv13</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xD</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12042,6 +20539,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12071,16 +20580,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12104,12 +20637,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12123,8 +20672,16 @@
 <targetPart>
   <id>perv14</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xE</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12139,6 +20696,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12168,16 +20737,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12201,12 +20794,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12220,8 +20829,16 @@
 <targetPart>
   <id>perv15</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12236,6 +20853,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12265,16 +20894,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12298,12 +20951,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12317,8 +20986,16 @@
 <targetPart>
   <id>perv16</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x10</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12333,6 +21010,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12362,16 +21051,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12395,12 +21108,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12414,8 +21143,16 @@
 <targetPart>
   <id>perv17</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x11</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12430,6 +21167,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12459,16 +21208,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12492,12 +21265,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12511,8 +21300,16 @@
 <targetPart>
   <id>perv18</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x12</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12527,6 +21324,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12556,16 +21365,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12589,12 +21422,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12608,8 +21457,16 @@
 <targetPart>
   <id>perv19</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x13</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12624,6 +21481,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12653,16 +21522,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12686,12 +21579,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12705,8 +21614,16 @@
 <targetPart>
   <id>perv20</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x14</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12721,6 +21638,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12750,16 +21679,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12783,12 +21736,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12802,8 +21771,16 @@
 <targetPart>
   <id>perv21</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x15</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12818,6 +21795,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12847,16 +21836,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12880,12 +21893,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12899,8 +21928,16 @@
 <targetPart>
   <id>perv32</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x20</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -12915,6 +21952,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -12944,16 +21993,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -12977,12 +22050,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -12996,8 +22085,16 @@
 <targetPart>
   <id>perv33</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x21</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13012,6 +22109,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13041,16 +22150,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13074,12 +22207,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13093,8 +22242,16 @@
 <targetPart>
   <id>perv34</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x22</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13109,6 +22266,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13138,16 +22307,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13171,12 +22364,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13190,8 +22399,16 @@
 <targetPart>
   <id>perv35</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x23</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13206,6 +22423,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13235,16 +22464,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13268,12 +22521,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13287,8 +22556,16 @@
 <targetPart>
   <id>perv36</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x24</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13303,6 +22580,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13332,16 +22621,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13365,12 +22678,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13384,8 +22713,16 @@
 <targetPart>
   <id>perv37</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x25</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13400,6 +22737,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13429,16 +22778,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13462,12 +22835,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13481,8 +22870,16 @@
 <targetPart>
   <id>perv38</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x26</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13497,6 +22894,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13526,16 +22935,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13559,12 +22992,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13578,8 +23027,16 @@
 <targetPart>
   <id>perv39</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x27</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13594,6 +23051,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13623,16 +23092,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13656,12 +23149,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13675,8 +23184,16 @@
 <targetPart>
   <id>perv40</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x28</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13691,6 +23208,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13720,16 +23249,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13753,12 +23306,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13772,8 +23341,16 @@
 <targetPart>
   <id>perv41</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x29</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13788,6 +23365,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13817,16 +23406,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13850,12 +23463,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13869,8 +23498,16 @@
 <targetPart>
   <id>perv42</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2A</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13885,6 +23522,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -13914,16 +23563,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -13947,12 +23620,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -13966,8 +23655,16 @@
 <targetPart>
   <id>perv43</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2B</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -13982,6 +23679,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14011,16 +23720,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14044,12 +23777,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14063,8 +23812,16 @@
 <targetPart>
   <id>perv44</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2C</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14079,6 +23836,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14108,16 +23877,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14141,12 +23934,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14160,8 +23969,16 @@
 <targetPart>
   <id>perv45</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2D</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14176,6 +23993,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14205,16 +24034,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14238,12 +24091,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14257,8 +24126,16 @@
 <targetPart>
   <id>perv46</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2E</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14273,6 +24150,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14302,16 +24191,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14335,12 +24248,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14354,8 +24283,16 @@
 <targetPart>
   <id>perv47</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x2F</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14370,6 +24307,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14399,16 +24348,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14432,12 +24405,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14451,8 +24440,16 @@
 <targetPart>
   <id>perv48</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x30</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14467,6 +24464,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14496,16 +24505,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14529,12 +24562,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14548,8 +24597,16 @@
 <targetPart>
   <id>perv49</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x31</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14564,6 +24621,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14593,16 +24662,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14626,12 +24719,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14645,8 +24754,16 @@
 <targetPart>
   <id>perv50</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x32</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14661,6 +24778,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14690,16 +24819,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14723,12 +24876,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14742,8 +24911,16 @@
 <targetPart>
   <id>perv51</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x33</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14758,6 +24935,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14787,16 +24976,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14820,12 +25033,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14839,8 +25068,16 @@
 <targetPart>
   <id>perv52</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x34</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14855,6 +25092,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14884,16 +25133,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -14917,12 +25190,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -14936,8 +25225,16 @@
 <targetPart>
   <id>perv53</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x35</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -14952,6 +25249,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -14981,16 +25290,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15014,12 +25347,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -15033,8 +25382,16 @@
 <targetPart>
   <id>perv54</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x36</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15049,6 +25406,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -15078,16 +25447,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15111,12 +25504,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -15130,8 +25539,16 @@
 <targetPart>
   <id>perv55</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x37</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15146,6 +25563,18 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -15175,16 +25604,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>PG</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15208,12 +25661,28 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SCRATCH_UINT8_1</id>
     <default>5</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_CLOCK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_HAS_POWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>TARGET_IS_SCOMMABLE</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -15227,12 +25696,20 @@
 <targetPart>
   <id>xbus1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>XBUS</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>FABRIC</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x6</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15251,6 +25728,26 @@
     <default>INOUT</default>
   </attribute>
   <attribute>
+    <id>EI_BUS_TX_MSBSWAP</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -15280,20 +25777,64 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_DCCAL_FLAGS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_MASTER_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_TX_FFE_PRECURSOR</id>
+    <default>6</default>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_TX_MARGIN_RATIO</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IO_X_DEBUG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PEER_TARGET</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15315,6 +25856,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -15336,12 +25881,20 @@
 <targetPart>
   <id>xbus2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>XBUS</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>FABRIC</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x6</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15358,6 +25911,26 @@
   <attribute>
     <id>DIRECTION</id>
     <default>INOUT</default>
+  </attribute>
+  <attribute>
+    <id>EI_BUS_TX_MSBSWAP</id>
+    <default>0x80</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -15389,20 +25962,64 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000001</default>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_DCCAL_FLAGS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_MASTER_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_TX_FFE_PRECURSOR</id>
+    <default>6</default>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_TX_MARGIN_RATIO</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IO_X_DEBUG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>PEER_TARGET</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15424,6 +26041,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -15445,12 +26066,24 @@
 <targetPart>
   <id>mcbist0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>AVDD_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15463,6 +26096,18 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -15494,16 +26139,100 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>MSS_FREQ</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_FREQ_BIAS_PERCENTAGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_FREQ_OVERRIDE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_NEST_CAPABLE_FREQUENCIES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_AVDD_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_AVDD_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_OVERRIDE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VCS_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VCS_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VDDR_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VDDR_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VDD_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VDD_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VPP_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VPP_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15525,6 +26254,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -15538,6 +26271,22 @@
     <id>TYPE</id>
     <default>MCBIST</default>
   </attribute>
+  <attribute>
+    <id>VCS_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VDDR_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VDD_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPP_ID</id>
+    <default>0</default>
+  </attribute>
   <child_id>mcs0</child_id>
   <child_id>mcs1</child_id>
   <instance_name>mcbist0</instance_name>
@@ -15548,8 +26297,24 @@
 <targetPart>
   <id>mcs0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BAD_DQ_BITMAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15562,6 +26327,818 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>DMI_REFCLOCK_SWIZZLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_BUFFER_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY_ERROR_STATUS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CRC_ERROR_CLEAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CRC_WR_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CS_CMD_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DATA_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0A</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0B</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0C</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0D</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0E</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0F</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BCAx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BCBx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F70BC7x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BC8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BC9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCAx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCBx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC06_07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_7x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_Ax</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_Bx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_RANKS_CONFIGED</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_RCD_MIRROR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SPARE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_AL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_ASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_BANK_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_BANK_GROUP_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_CL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_COLUMN_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_CWL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DENSITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_PPD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_RESET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_GEN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_LPASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MAC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MFG_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MODULE_BUS_WIDTH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_OUTPUT_BUFFER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_PASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_PPR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RANK_MIX</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RBT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RON</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_ROW_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_PARK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_SOFT_PPR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_SRT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TCCD_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TDQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TFAW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TFAW_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TMAW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRAS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRCD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TREFI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRFC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRFC_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_S</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRTP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWTR_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWTR_S</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TXS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WIDTH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WRDDR4_VREF_SCHMOO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_LVL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_VREF</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_VREF_SCHMOO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_GEARDOWN_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_HYBRID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_HYBRID_MEMORY_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_IBM_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_INTERNAL_VREF_MONITOR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_LRDIMM_WORD_X</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MAX_POWERDOWN_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MEMCAL_INTERVAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_LOC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_PAGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_RD_FORMAT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_DROPS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_MASTER_RANKS_PER_DIMM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_PACKAGES_PER_RANK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_RANKS_PER_DIMM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_ODT_INPUT_BUFF</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PER_DRAM_ACCESS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PRIM_DIE_COUNT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PRIM_STACK_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_RD_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_RD_PREAMBLE_TRAIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_READ_DBI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_ADDR_CMD_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_ADDR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_DQS_CLK_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_PARAM_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_RD_EYE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_RD_GATE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_TEST_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_WR_EYE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SELF_REF_ABORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_TEMP_READOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_TEMP_REFRESH_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_RANGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WRITE_CRC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WRITE_DBI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WR_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_ZQCAL_INTERVAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EI_BUS_TX_MSBSWAP</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -15593,16 +27170,592 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IBSCOM_MCS_BASE_ADDR</id>
+    <default>0x0003E00000000000</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_ADDITIONAL_CNTL_WORDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_MR12_REG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_RANK_MULT_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MEMVPD_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CAL_STEP_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXBANDWIDTH_GBS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXBANDWIDTH_MRS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DATABUS_UTIL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXBANDWIDTH_GBS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXBANDWIDTH_MRS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MFG_ID_CODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_THERMAL_LIMIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_EFF_DIMM_FUNCTIONAL_VECTOR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_EFF_VPD_VERSION</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_IGNORE_PLUG_RULES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MASTER_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MASTER_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_M_DRAM_CLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_WATT_TARGET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_UNSUPPORTED_RANK_CONFIG</id>
+    <default>0,0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MVPD_FWMS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MSS_OCC_THROTTLED_N_CMDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_PORT_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_M_DRAM_CLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SLEW_RATE_ADR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SLEW_RATE_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SUPPLIER_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SUPPLIER_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLED_N_COMMANDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLE_CONTROL_CAS_WEIGHT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLE_CONTROL_RAS_WEIGHT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_TOTAL_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_TOTAL_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_CKE_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_DQ_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_0_VERSION_LAYOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_1_VERSION_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_2_SIGNATURE_HASH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DRAM_2N_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_2N_MODE_AUTOSET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A17</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BA0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BA1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BG0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BG1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CLK_D0_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ACTN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_CASN_A15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_RASN_A16</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_WEN_A14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_PAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D0_CLKN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D0_CLKP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D1_CLKN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D1_CLKP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_TSYS_ADR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_TSYS_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_0_VERSION_LAYOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_1_VERSION_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_2_SIGNATURE_HASH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_CKE_PRI_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_CKE_PWR_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_ODT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_OUTPUT_TIMING</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_PARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_RD_UP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_WR_DOWN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_WR_UP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_CTLE_CAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_CTLE_RES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CMD_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CSCID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_RCV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_ODT_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_ODT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_VREF_DRAM_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_VREF_MC_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_WINDAGE_RD_CTR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VREF_CAL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VREF_DAC_NIBBLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15626,7 +27779,15 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHMOO_MULTIPLE_SETUP_CALL</id>
     <default>0</default>
   </attribute>
   <attribute>
@@ -15636,6 +27797,355 @@
   <attribute>
     <id>TYPE</id>
     <default>MCS</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_DRAM_2N_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A17</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BA0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BA1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BG0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D0_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D0_P1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D1_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D1_P1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_CASN_A15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_RASN_A16</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_WEN_A14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_PAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D0_CLK0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D0_CLK1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D1_CLK0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D1_CLK1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_CKE_PRI_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_CKE_PWR_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DIMM_RCD_IBT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DIMM_RCD_OUTPUT_TIMING</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_PARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_RCV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_ODT_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_ODT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_VREF_DRAM_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_VREF_MC_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_WINDAGE_RD_CTR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_CK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_CK_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_DQ</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_DQ_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MT_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_REC_NUM</id>
+    <default>0xFFFF</default>
+  </attribute>
+  <attribute>
+    <id>VPD_SWITCHES</id>
+    <default>
+      <field>
+        <id>pnorCacheValid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>pnorCacheValidRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>disableWriteToPnorRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value></value>
+      </field>
+    </default>
   </attribute>
   <child_id>mca0</child_id>
   <child_id>mca1</child_id>
@@ -15647,8 +28157,20 @@
 <targetPart>
   <id>mca0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x07</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15661,6 +28183,22 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -15692,16 +28230,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15723,6 +28285,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -15736,6 +28302,14 @@
     <id>TYPE</id>
     <default>MCA</default>
   </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW_ENABLE</id>
+    <default>0</default>
+  </attribute>
   <child_id>ddr_ch0:cs0</child_id>
   <child_id>ddr_ch0:cs1</child_id>
   <instance_name>mca0</instance_name>
@@ -15746,8 +28320,16 @@
 <targetPart>
   <id>ddr_ch0:cs0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15766,6 +28348,18 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -15795,6 +28389,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -15803,8 +28409,24 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15828,8 +28450,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -15843,8 +28473,16 @@
 <targetPart>
   <id>ddr_ch0:cs1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15861,6 +28499,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -15892,6 +28542,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -15900,8 +28562,24 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -15925,8 +28603,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -15940,8 +28626,20 @@
 <targetPart>
   <id>mca1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x7</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -15954,6 +28652,22 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -15985,16 +28699,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16016,6 +28754,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>1</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -16029,6 +28771,14 @@
     <id>TYPE</id>
     <default>MCA</default>
   </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW_ENABLE</id>
+    <default>0</default>
+  </attribute>
   <child_id>ddr_ch1:cs0</child_id>
   <child_id>ddr_ch1:cs1</child_id>
   <instance_name>mca1</instance_name>
@@ -16039,8 +28789,16 @@
 <targetPart>
   <id>ddr_ch1:cs0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16057,6 +28815,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -16088,6 +28858,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -16096,8 +28878,24 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16121,8 +28919,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -16136,8 +28942,16 @@
 <targetPart>
   <id>ddr_ch1:cs1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16156,6 +28970,18 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -16185,6 +29011,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -16193,8 +29031,24 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16218,8 +29072,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -16233,8 +29095,24 @@
 <targetPart>
   <id>mcs1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BAD_DQ_BITMAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16249,6 +29127,818 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>DMI_REFCLOCK_SWIZZLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_BUFFER_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY_ERROR_STATUS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CRC_ERROR_CLEAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CRC_WR_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CS_CMD_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DATA_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0A</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0B</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0C</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0D</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0E</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0F</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BCAx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BCBx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F70BC7x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BC8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BC9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCAx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCBx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC06_07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_7x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_Ax</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_Bx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_RANKS_CONFIGED</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_RCD_MIRROR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SPARE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_AL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_ASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_BANK_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_BANK_GROUP_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_CL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_COLUMN_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_CWL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DENSITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_PPD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_RESET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_GEN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_LPASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MAC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MFG_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MODULE_BUS_WIDTH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_OUTPUT_BUFFER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_PASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_PPR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RANK_MIX</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RBT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RON</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_ROW_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_PARK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_SOFT_PPR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_SRT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TCCD_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TDQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TFAW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TFAW_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TMAW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRAS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRCD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TREFI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRFC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRFC_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_S</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRTP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWTR_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWTR_S</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TXS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WIDTH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WRDDR4_VREF_SCHMOO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_LVL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_VREF</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_VREF_SCHMOO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_GEARDOWN_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_HYBRID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_HYBRID_MEMORY_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_IBM_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_INTERNAL_VREF_MONITOR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_LRDIMM_WORD_X</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MAX_POWERDOWN_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MEMCAL_INTERVAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_LOC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_PAGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_RD_FORMAT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_DROPS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_MASTER_RANKS_PER_DIMM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_PACKAGES_PER_RANK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_RANKS_PER_DIMM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_ODT_INPUT_BUFF</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PER_DRAM_ACCESS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PRIM_DIE_COUNT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PRIM_STACK_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_RD_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_RD_PREAMBLE_TRAIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_READ_DBI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_ADDR_CMD_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_ADDR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_DQS_CLK_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_PARAM_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_RD_EYE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_RD_GATE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_TEST_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_WR_EYE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SELF_REF_ABORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_TEMP_READOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_TEMP_REFRESH_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_RANGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WRITE_CRC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WRITE_DBI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WR_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_ZQCAL_INTERVAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EI_BUS_TX_MSBSWAP</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -16278,16 +29968,592 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IBSCOM_MCS_BASE_ADDR</id>
+    <default>0x0003E00000000000</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_ADDITIONAL_CNTL_WORDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_MR12_REG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_RANK_MULT_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MEMVPD_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CAL_STEP_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXBANDWIDTH_GBS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXBANDWIDTH_MRS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DATABUS_UTIL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXBANDWIDTH_GBS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXBANDWIDTH_MRS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MFG_ID_CODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_THERMAL_LIMIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_EFF_DIMM_FUNCTIONAL_VECTOR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_EFF_VPD_VERSION</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_IGNORE_PLUG_RULES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MASTER_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MASTER_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_M_DRAM_CLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_WATT_TARGET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_UNSUPPORTED_RANK_CONFIG</id>
+    <default>0,0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MVPD_FWMS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MSS_OCC_THROTTLED_N_CMDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_PORT_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_M_DRAM_CLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SLEW_RATE_ADR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SLEW_RATE_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SUPPLIER_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SUPPLIER_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLED_N_COMMANDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLE_CONTROL_CAS_WEIGHT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLE_CONTROL_RAS_WEIGHT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_TOTAL_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_TOTAL_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_CKE_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_DQ_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_0_VERSION_LAYOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_1_VERSION_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_2_SIGNATURE_HASH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DRAM_2N_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_2N_MODE_AUTOSET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A17</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BA0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BA1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BG0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BG1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CLK_D0_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ACTN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_CASN_A15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_RASN_A16</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_WEN_A14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_PAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D0_CLKN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D0_CLKP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D1_CLKN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D1_CLKP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_TSYS_ADR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_TSYS_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_0_VERSION_LAYOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_1_VERSION_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_2_SIGNATURE_HASH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_CKE_PRI_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_CKE_PWR_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_ODT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_OUTPUT_TIMING</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_PARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_RD_UP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_WR_DOWN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_WR_UP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_CTLE_CAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_CTLE_RES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CMD_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CSCID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_RCV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_ODT_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_ODT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_VREF_DRAM_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_VREF_MC_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_WINDAGE_RD_CTR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VREF_CAL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VREF_DAC_NIBBLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16311,7 +30577,15 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHMOO_MULTIPLE_SETUP_CALL</id>
     <default>0</default>
   </attribute>
   <attribute>
@@ -16321,6 +30595,355 @@
   <attribute>
     <id>TYPE</id>
     <default>MCS</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_DRAM_2N_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A17</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BA0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BA1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BG0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D0_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D0_P1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D1_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D1_P1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_CASN_A15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_RASN_A16</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_WEN_A14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_PAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D0_CLK0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D0_CLK1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D1_CLK0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D1_CLK1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_CKE_PRI_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_CKE_PWR_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DIMM_RCD_IBT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DIMM_RCD_OUTPUT_TIMING</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_PARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_RCV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_ODT_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_ODT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_VREF_DRAM_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_VREF_MC_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_WINDAGE_RD_CTR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_CK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_CK_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_DQ</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_DQ_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MT_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_REC_NUM</id>
+    <default>0xFFFF</default>
+  </attribute>
+  <attribute>
+    <id>VPD_SWITCHES</id>
+    <default>
+      <field>
+        <id>pnorCacheValid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>pnorCacheValidRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>disableWriteToPnorRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value></value>
+      </field>
+    </default>
   </attribute>
   <child_id>mca2</child_id>
   <child_id>mca3</child_id>
@@ -16332,8 +30955,20 @@
 <targetPart>
   <id>mca2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x7</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16348,6 +30983,22 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -16377,16 +31028,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16408,6 +31083,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -16421,6 +31100,14 @@
     <id>TYPE</id>
     <default>MCA</default>
   </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW_ENABLE</id>
+    <default>0</default>
+  </attribute>
   <child_id>ddr_ch2:cs0</child_id>
   <child_id>ddr_ch2:cs1</child_id>
   <instance_name>mca2</instance_name>
@@ -16431,8 +31118,16 @@
 <targetPart>
   <id>ddr_ch2:cs0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16449,6 +31144,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -16480,6 +31187,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -16488,8 +31207,24 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16513,8 +31248,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -16528,8 +31271,16 @@
 <targetPart>
   <id>ddr_ch2:cs1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16546,6 +31297,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -16577,6 +31340,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -16585,8 +31360,24 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16610,8 +31401,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -16625,8 +31424,20 @@
 <targetPart>
   <id>mca3</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x7</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16641,6 +31452,22 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -16670,16 +31497,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16701,6 +31552,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>1</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -16714,6 +31569,14 @@
     <id>TYPE</id>
     <default>MCA</default>
   </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW_ENABLE</id>
+    <default>0</default>
+  </attribute>
   <child_id>ddr_ch3:cs0</child_id>
   <child_id>ddr_ch3:cs1</child_id>
   <instance_name>mca3</instance_name>
@@ -16724,8 +31587,16 @@
 <targetPart>
   <id>ddr_ch3:cs0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16742,6 +31613,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -16773,6 +31656,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -16781,8 +31676,24 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16806,8 +31717,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -16821,8 +31740,16 @@
 <targetPart>
   <id>ddr_ch3:cs1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16841,6 +31768,18 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -16870,6 +31809,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -16878,8 +31829,24 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -16903,8 +31870,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -16918,12 +31893,24 @@
 <targetPart>
   <id>mcbist1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>AVDD_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -16938,6 +31925,18 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -16967,16 +31966,100 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>MSS_FREQ</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_FREQ_BIAS_PERCENTAGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_FREQ_OVERRIDE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_NEST_CAPABLE_FREQUENCIES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_AVDD_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_AVDD_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_OVERRIDE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VCS_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VCS_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VDDR_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VDDR_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VDD_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VDD_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VPP_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VPP_OFFSET_MILLIVOLTS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17000,6 +32083,10 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
@@ -17011,6 +32098,22 @@
     <id>TYPE</id>
     <default>MCBIST</default>
   </attribute>
+  <attribute>
+    <id>VCS_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VDDR_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VDD_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPP_ID</id>
+    <default>0</default>
+  </attribute>
   <child_id>mcs2</child_id>
   <child_id>mcs3</child_id>
   <instance_name>mcbist1</instance_name>
@@ -17021,8 +32124,24 @@
 <targetPart>
   <id>mcs2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BAD_DQ_BITMAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17037,6 +32156,818 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>DMI_REFCLOCK_SWIZZLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_BUFFER_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY_ERROR_STATUS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CRC_ERROR_CLEAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CRC_WR_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CS_CMD_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DATA_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0A</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0B</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0C</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0D</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0E</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0F</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BCAx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BCBx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F70BC7x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BC8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BC9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCAx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCBx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC06_07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_7x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_Ax</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_Bx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_RANKS_CONFIGED</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_RCD_MIRROR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SPARE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_AL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_ASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_BANK_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_BANK_GROUP_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_CL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_COLUMN_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_CWL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DENSITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_PPD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_RESET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_GEN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_LPASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MAC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MFG_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MODULE_BUS_WIDTH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_OUTPUT_BUFFER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_PASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_PPR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RANK_MIX</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RBT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RON</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_ROW_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_PARK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_SOFT_PPR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_SRT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TCCD_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TDQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TFAW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TFAW_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TMAW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRAS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRCD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TREFI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRFC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRFC_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_S</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRTP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWTR_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWTR_S</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TXS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WIDTH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WRDDR4_VREF_SCHMOO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_LVL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_VREF</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_VREF_SCHMOO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_GEARDOWN_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_HYBRID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_HYBRID_MEMORY_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_IBM_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_INTERNAL_VREF_MONITOR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_LRDIMM_WORD_X</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MAX_POWERDOWN_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MEMCAL_INTERVAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_LOC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_PAGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_RD_FORMAT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_DROPS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_MASTER_RANKS_PER_DIMM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_PACKAGES_PER_RANK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_RANKS_PER_DIMM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_ODT_INPUT_BUFF</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PER_DRAM_ACCESS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PRIM_DIE_COUNT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PRIM_STACK_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_RD_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_RD_PREAMBLE_TRAIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_READ_DBI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_ADDR_CMD_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_ADDR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_DQS_CLK_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_PARAM_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_RD_EYE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_RD_GATE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_TEST_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_WR_EYE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SELF_REF_ABORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_TEMP_READOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_TEMP_REFRESH_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_RANGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WRITE_CRC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WRITE_DBI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WR_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_ZQCAL_INTERVAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EI_BUS_TX_MSBSWAP</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -17066,16 +32997,592 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IBSCOM_MCS_BASE_ADDR</id>
+    <default>0x0003E00000000000</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_ADDITIONAL_CNTL_WORDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_MR12_REG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_RANK_MULT_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MEMVPD_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CAL_STEP_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXBANDWIDTH_GBS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXBANDWIDTH_MRS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DATABUS_UTIL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXBANDWIDTH_GBS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXBANDWIDTH_MRS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MFG_ID_CODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_THERMAL_LIMIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_EFF_DIMM_FUNCTIONAL_VECTOR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_EFF_VPD_VERSION</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_IGNORE_PLUG_RULES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MASTER_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MASTER_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_M_DRAM_CLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_WATT_TARGET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_UNSUPPORTED_RANK_CONFIG</id>
+    <default>0,0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MVPD_FWMS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MSS_OCC_THROTTLED_N_CMDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_PORT_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_M_DRAM_CLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SLEW_RATE_ADR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SLEW_RATE_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SUPPLIER_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SUPPLIER_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLED_N_COMMANDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLE_CONTROL_CAS_WEIGHT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLE_CONTROL_RAS_WEIGHT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_TOTAL_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_TOTAL_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_CKE_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_DQ_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_0_VERSION_LAYOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_1_VERSION_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_2_SIGNATURE_HASH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DRAM_2N_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_2N_MODE_AUTOSET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A17</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BA0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BA1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BG0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BG1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CLK_D0_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ACTN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_CASN_A15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_RASN_A16</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_WEN_A14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_PAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D0_CLKN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D0_CLKP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D1_CLKN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D1_CLKP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_TSYS_ADR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_TSYS_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_0_VERSION_LAYOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_1_VERSION_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_2_SIGNATURE_HASH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_CKE_PRI_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_CKE_PWR_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_ODT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_OUTPUT_TIMING</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_PARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_RD_UP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_WR_DOWN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_WR_UP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_CTLE_CAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_CTLE_RES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CMD_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CSCID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_RCV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_ODT_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_ODT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_VREF_DRAM_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_VREF_MC_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_WINDAGE_RD_CTR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VREF_CAL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VREF_DAC_NIBBLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17099,7 +33606,15 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHMOO_MULTIPLE_SETUP_CALL</id>
     <default>0</default>
   </attribute>
   <attribute>
@@ -17109,6 +33624,355 @@
   <attribute>
     <id>TYPE</id>
     <default>MCS</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_DRAM_2N_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A17</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BA0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BA1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BG0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D0_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D0_P1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D1_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D1_P1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_CASN_A15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_RASN_A16</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_WEN_A14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_PAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D0_CLK0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D0_CLK1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D1_CLK0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D1_CLK1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_CKE_PRI_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_CKE_PWR_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DIMM_RCD_IBT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DIMM_RCD_OUTPUT_TIMING</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_PARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_RCV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_ODT_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_ODT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_VREF_DRAM_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_VREF_MC_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_WINDAGE_RD_CTR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_CK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_CK_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_DQ</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_DQ_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MT_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_REC_NUM</id>
+    <default>0xFFFF</default>
+  </attribute>
+  <attribute>
+    <id>VPD_SWITCHES</id>
+    <default>
+      <field>
+        <id>pnorCacheValid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>pnorCacheValidRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>disableWriteToPnorRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value></value>
+      </field>
+    </default>
   </attribute>
   <child_id>mca4</child_id>
   <child_id>mca5</child_id>
@@ -17120,8 +33984,20 @@
 <targetPart>
   <id>mca4</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x8</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17136,6 +34012,22 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -17165,16 +34057,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17198,6 +34114,10 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
@@ -17209,6 +34129,14 @@
     <id>TYPE</id>
     <default>MCA</default>
   </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW_ENABLE</id>
+    <default>0</default>
+  </attribute>
   <child_id>ddr_ch4:cs0</child_id>
   <child_id>ddr_ch4:cs1</child_id>
   <instance_name>mca4</instance_name>
@@ -17219,8 +34147,16 @@
 <targetPart>
   <id>ddr_ch4:cs0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17239,6 +34175,18 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -17268,6 +34216,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -17276,8 +34236,24 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17301,8 +34277,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -17316,8 +34300,16 @@
 <targetPart>
   <id>ddr_ch4:cs1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17334,6 +34326,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -17365,6 +34369,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -17373,8 +34389,24 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17398,8 +34430,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -17413,8 +34453,20 @@
 <targetPart>
   <id>mca5</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x8</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17427,6 +34479,22 @@
   <attribute>
     <id>DECONFIG_GARDABLE</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -17458,16 +34526,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17489,6 +34581,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>1</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -17502,6 +34598,14 @@
     <id>TYPE</id>
     <default>MCA</default>
   </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW_ENABLE</id>
+    <default>0</default>
+  </attribute>
   <child_id>ddr_ch5:cs0</child_id>
   <child_id>ddr_ch5:cs1</child_id>
   <instance_name>mca5</instance_name>
@@ -17512,8 +34616,16 @@
 <targetPart>
   <id>ddr_ch5:cs0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17530,6 +34642,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -17561,6 +34685,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -17569,8 +34705,24 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17594,8 +34746,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -17609,8 +34769,16 @@
 <targetPart>
   <id>ddr_ch5:cs1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17627,6 +34795,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -17658,6 +34838,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -17666,8 +34858,24 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17691,8 +34899,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -17706,8 +34922,24 @@
 <targetPart>
   <id>mcs3</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BAD_DQ_BITMAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17722,6 +34954,818 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>DMI_REFCLOCK_SWIZZLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_BUFFER_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY_ERROR_STATUS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CA_PARITY_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CRC_ERROR_CLEAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CRC_WR_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_CS_CMD_LATENCY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DATA_MASK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0A</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0B</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0C</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0D</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0E</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_BC0F</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F0BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F1BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BC9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BCAx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F30BCBx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F4BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F5BC6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC0x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F6BC5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F70BC7x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BC8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BC9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCAx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCBx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCCx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCDx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCEx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_F74BCFx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC06_07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_1x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_2x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_3x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_4x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_5x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_6x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_7x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_8x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_9x</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_Ax</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_DDR4_RC_Bx</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_RANKS_CONFIGED</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_RCD_MIRROR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_SPARE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DIMM_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_AL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_ASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_BANK_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_BANK_GROUP_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_CL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_COLUMN_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_CWL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DENSITY</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_PPD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_DLL_RESET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_GEN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_LPASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MAC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MFG_ID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_MODULE_BUS_WIDTH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_OUTPUT_BUFFER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_PASR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_PPR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RANK_MIX</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RBT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RON</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_ROW_BITS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_PARK</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_SOFT_PPR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_SRT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TCCD_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TDQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TFAW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TFAW_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TMAW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRAS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRCD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TREFI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRFC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRFC_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_DLR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRRD_S</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TRTP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWTR_L</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TWTR_S</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_TXS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WIDTH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WRDDR4_VREF_SCHMOO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_LVL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_VREF</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_DRAM_WR_VREF_SCHMOO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_GEARDOWN_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_HYBRID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_HYBRID_MEMORY_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_IBM_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_INTERNAL_VREF_MONITOR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_LRDIMM_WORD_X</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MAX_POWERDOWN_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MEMCAL_INTERVAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_LOC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_PAGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_MPR_RD_FORMAT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_DROPS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_MASTER_RANKS_PER_DIMM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_PACKAGES_PER_RANK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_NUM_RANKS_PER_DIMM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_ODT_INPUT_BUFF</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PER_DRAM_ACCESS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PRIM_DIE_COUNT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_PRIM_STACK_TYPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_RD_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_RD_PREAMBLE_TRAIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_READ_DBI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_ADDR_CMD_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_ADDR_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_DQS_CLK_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_PARAM_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_RD_EYE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_RD_GATE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_TEST_VALID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SCHMOO_WR_EYE_MIN_MARGIN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_SELF_REF_ABORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_TEMP_READOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_TEMP_REFRESH_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_RANGE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_VREF_DQ_TRAIN_VALUE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WRITE_CRC</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WRITE_DBI</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_WR_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EFF_ZQCAL_INTERVAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>EI_BUS_TX_MSBSWAP</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HB_TARGET_SCOMABLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -17751,16 +35795,592 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IBSCOM_MCS_BASE_ADDR</id>
+    <default>0x0003E00000000000</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_ADDITIONAL_CNTL_WORDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_MR12_REG</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>LRDIMM_RANK_MULT_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MEMVPD_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CAL_STEP_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXBANDWIDTH_GBS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXBANDWIDTH_MRS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_CHANNEL_PAIR_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DATABUS_UTIL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXBANDWIDTH_GBS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXBANDWIDTH_MRS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_MFG_ID_CODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_DIMM_THERMAL_LIMIT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_EFF_DIMM_FUNCTIONAL_VECTOR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_EFF_VPD_VERSION</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_IGNORE_PLUG_RULES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MASTER_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MASTER_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_M_DRAM_CLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MEM_WATT_TARGET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_UNSUPPORTED_RANK_CONFIG</id>
+    <default>0,0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_MVPD_FWMS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MSS_OCC_THROTTLED_N_CMDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_PORT_MAXPOWER</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_M_DRAM_CLOCKS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_RUNTIME_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SLEW_RATE_ADR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SLEW_RATE_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SUPPLIER_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_SUPPLIER_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLED_N_COMMANDS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLE_CONTROL_CAS_WEIGHT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_THROTTLE_CONTROL_RAS_WEIGHT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_TOTAL_PWR_INTERCEPT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_TOTAL_PWR_SLOPE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_CKE_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_DQ_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_0_VERSION_LAYOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_1_VERSION_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_2_SIGNATURE_HASH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DPHY_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_DRAM_2N_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_2N_MODE_AUTOSET</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_A17</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BA0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BA1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BG0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_BG1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_ADDR_C2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CLK_D0_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ACTN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_CASN_A15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_RASN_A16</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_ADDR_WEN_A14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CMD_PAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D0_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_CNTL_D1_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D0_CLKN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D0_CLKP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D1_CLKN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_MC_PHASE_ROT_D1_CLKP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_TSYS_ADR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MR_TSYS_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_0_VERSION_LAYOUT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_1_VERSION_DATA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_2_SIGNATURE_HASH</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_CKE_PRI_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_CKE_PWR_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CA</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_CS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_IBT_ODT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DIMM_RCD_OUTPUT_TIMING</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_PARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_RD_UP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_WR_DOWN</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_ACBOOST_WR_UP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_CTLE_CAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DQ_CTLE_RES</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CMD_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_CSCID</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_RCV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_MC_SLEW_RATE_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_ODT_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_ODT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_OFFSET_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_PREAMBLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_VREF_DRAM_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_VREF_MC_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VPD_MT_WINDAGE_RD_CTR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VREF_CAL_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>MSS_VREF_DAC_NIBBLE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17784,7 +36404,15 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>1</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHMOO_MULTIPLE_SETUP_CALL</id>
     <default>0</default>
   </attribute>
   <attribute>
@@ -17794,6 +36422,355 @@
   <attribute>
     <id>TYPE</id>
     <default>MCS</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_DRAM_2N_MODE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A00</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A01</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A02</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A03</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A04</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A05</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A06</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A07</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A08</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A09</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A10</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A11</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A12</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A13</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_A17</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BA0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BA1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_BG0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_ADDR_C2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D0_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D0_P1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D1_P0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CLK_D1_P1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_CASN_A15</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_RASN_A16</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_ADDR_WEN_A14</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CMD_PAR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CKE3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN2</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_CSN3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_CNTL_ODT3</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D0_CLK0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D0_CLK1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D1_CLK0</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_MC_PHASE_ROT_D1_CLK1</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MR_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_CKE_PRI_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_CKE_PWR_MAP</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DIMM_RCD_IBT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DIMM_RCD_OUTPUT_TIMING</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_NOM</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_PARK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_DRAM_RTT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_DRV_IMP_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_RCV_IMP_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_ADDR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_CLK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_CNTL</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_DQ_DQS</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_MC_SLEW_RATE_SPCKE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_ODT_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_ODT_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_GPO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_RLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_OFFSET_WLO</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_VREF_DRAM_WR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_VREF_MC_RD</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_MT_WINDAGE_RD_CTR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_CK</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_CK_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_DQ</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_DQ_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MR</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MR_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MT</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MT_ENABLE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_REC_NUM</id>
+    <default>0xFFFF</default>
+  </attribute>
+  <attribute>
+    <id>VPD_SWITCHES</id>
+    <default>
+      <field>
+        <id>pnorCacheValid</id>
+        <value></value>
+      </field>
+      <field>
+        <id>pnorCacheValidRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>disableWriteToPnorRT</id>
+        <value></value>
+      </field>
+      <field>
+        <id>reserved</id>
+        <value></value>
+      </field>
+    </default>
   </attribute>
   <child_id>mca6</child_id>
   <child_id>mca7</child_id>
@@ -17805,8 +36782,20 @@
 <targetPart>
   <id>mca6</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x8</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17821,6 +36810,22 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -17850,16 +36855,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17881,6 +36910,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -17894,6 +36927,14 @@
     <id>TYPE</id>
     <default>MCA</default>
   </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW_ENABLE</id>
+    <default>0</default>
+  </attribute>
   <child_id>ddr_ch6:cs0</child_id>
   <child_id>ddr_ch6:cs1</child_id>
   <instance_name>mca6</instance_name>
@@ -17904,8 +36945,16 @@
 <targetPart>
   <id>ddr_ch6:cs0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -17922,6 +36971,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -17953,6 +37014,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -17961,8 +37034,24 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -17986,8 +37075,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -18001,8 +37098,16 @@
 <targetPart>
   <id>ddr_ch6:cs1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18019,6 +37124,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -18050,6 +37167,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -18058,8 +37187,24 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18083,8 +37228,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -18098,8 +37251,20 @@
 <targetPart>
   <id>mca7</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>BUS_TYPE</id>
+    <default>NA</default>
+  </attribute>
+  <attribute>
     <id>CDM_DOMAIN</id>
     <default>MEM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0x8</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18114,6 +37279,22 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>EFF_DIMM_SIZE</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -18143,16 +37324,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
     <default>0x00000003</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>MODEL</id>
     <default>NIMBUS</default>
   </attribute>
   <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18174,6 +37379,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>1</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -18187,6 +37396,14 @@
     <id>TYPE</id>
     <default>MCA</default>
   </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW</id>
+    <default>0</default>
+  </attribute>
+  <attribute>
+    <id>VPD_OVERRIDE_MW_ENABLE</id>
+    <default>0</default>
+  </attribute>
   <child_id>ddr_ch7:cs0</child_id>
   <child_id>ddr_ch7:cs1</child_id>
   <instance_name>mca7</instance_name>
@@ -18197,8 +37414,16 @@
 <targetPart>
   <id>ddr_ch7:cs0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18215,6 +37440,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -18246,6 +37483,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -18254,8 +37503,24 @@
     <default>0</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18279,8 +37544,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -18294,8 +37567,16 @@
 <targetPart>
   <id>ddr_ch7:cs1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>DDR4</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18312,6 +37593,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -18343,6 +37636,18 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>MBA_DIMM</id>
     <default>1</default>
   </attribute>
@@ -18351,8 +37656,24 @@
     <default>1</default>
   </attribute>
   <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18376,8 +37697,16 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>SCHEMATIC_INTERFACE</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>TYPE</id>
@@ -18391,8 +37720,16 @@
 <targetPart>
   <id>fsi-slave-0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>FSIM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18415,12 +37752,20 @@
     <default>IN</default>
   </attribute>
   <attribute>
-    <id>FSI_LINK</id>
-    <default>0x00</default>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
   </attribute>
   <attribute>
     <id>FSI_PORT</id>
     <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -18452,8 +37797,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18475,6 +37848,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -18492,8 +37869,16 @@
 <targetPart>
   <id>fsi-slave-1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>FSIM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18516,12 +37901,20 @@
     <default>IN</default>
   </attribute>
   <attribute>
-    <id>FSI_LINK</id>
-    <default>0x00</default>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
   </attribute>
   <attribute>
     <id>FSI_PORT</id>
     <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -18553,8 +37946,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18576,6 +37997,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -18593,8 +38018,16 @@
 <targetPart>
   <id>fsi-cm-0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>FSICM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18617,6 +38050,14 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>FSI_ENGINE</id>
     <default>0x0C</default>
   </attribute>
@@ -18627,6 +38068,10 @@
   <attribute>
     <id>FSI_PORT</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -18658,8 +38103,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>FSICM</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18681,6 +38154,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -18698,8 +38175,16 @@
 <targetPart>
   <id>fsi-cm-1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>FSICM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18722,6 +38207,14 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>FSI_ENGINE</id>
     <default>0x0C</default>
   </attribute>
@@ -18732,6 +38225,10 @@
   <attribute>
     <id>FSI_PORT</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -18763,8 +38260,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>FSICM</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18786,6 +38311,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -18803,8 +38332,16 @@
 <targetPart>
   <id>fsi-cm-2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>FSICM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18827,6 +38364,14 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>FSI_ENGINE</id>
     <default>0x0C</default>
   </attribute>
@@ -18837,6 +38382,10 @@
   <attribute>
     <id>FSI_PORT</id>
     <default>2</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -18868,8 +38417,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>FSICM</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18891,6 +38468,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -18908,8 +38489,16 @@
 <targetPart>
   <id>fsi-cm-3</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>FSICM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -18932,6 +38521,14 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>FSI_ENGINE</id>
     <default>0x0C</default>
   </attribute>
@@ -18942,6 +38539,10 @@
   <attribute>
     <id>FSI_PORT</id>
     <default>3</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -18973,8 +38574,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>FSICM</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -18996,6 +38625,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -19013,8 +38646,16 @@
 <targetPart>
   <id>fsim-0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>FSIM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19037,6 +38678,14 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>FSI_ENGINE</id>
     <default>0x0D</default>
   </attribute>
@@ -19047,6 +38696,10 @@
   <attribute>
     <id>FSI_PORT</id>
     <default>0</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -19078,8 +38731,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>FSIM</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -19101,6 +38782,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -19118,8 +38803,16 @@
 <targetPart>
   <id>fsim-1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>FSIM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19142,6 +38835,14 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>FSI_ENGINE</id>
     <default>0x0D</default>
   </attribute>
@@ -19152,6 +38853,10 @@
   <attribute>
     <id>FSI_PORT</id>
     <default>1</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -19183,8 +38888,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>FSIM</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -19206,6 +38939,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -19223,8 +38960,16 @@
 <targetPart>
   <id>fsim-2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>FSIM</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19247,6 +38992,14 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
     <id>FSI_ENGINE</id>
     <default>0x0D</default>
   </attribute>
@@ -19257,6 +39010,10 @@
   <attribute>
     <id>FSI_PORT</id>
     <default>2</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -19288,8 +39045,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>FSIM</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -19313,6 +39098,10 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
@@ -19328,8 +39117,16 @@
 <targetPart>
   <id>i2c-slave</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19348,6 +39145,18 @@
     <default>IN</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -19377,8 +39186,40 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>I2C_ADDRESS</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -19400,6 +39241,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -19421,8 +39266,16 @@
 <targetPart>
   <id>i2c-master-prom0-mvpd-primary</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19439,6 +39292,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -19470,6 +39335,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -19482,8 +39355,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -19505,6 +39398,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -19522,8 +39419,16 @@
 <targetPart>
   <id>i2c-master-prom1-sbe-primary</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19540,6 +39445,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -19571,6 +39488,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -19583,8 +39508,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -19606,6 +39551,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -19623,8 +39572,16 @@
 <targetPart>
   <id>i2c-master-prom2-mvpd-backup</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19641,6 +39598,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -19672,6 +39641,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -19684,8 +39661,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -19707,6 +39704,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -19724,8 +39725,16 @@
 <targetPart>
   <id>i2c-master-prom3-sbe-backup</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19742,6 +39751,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -19773,6 +39794,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -19785,8 +39814,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -19808,6 +39857,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -19825,8 +39878,16 @@
 <targetPart>
   <id>i2c-master-proc-promb0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19843,6 +39904,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -19874,6 +39947,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -19886,8 +39967,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -19909,6 +40010,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -19926,8 +40031,16 @@
 <targetPart>
   <id>i2c-master-proc-promb1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -19944,6 +40057,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -19975,6 +40100,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -19987,8 +40120,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20010,6 +40163,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20027,8 +40184,16 @@
 <targetPart>
   <id>i2c-master-proc-promc0</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20045,6 +40210,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20076,6 +40253,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20088,8 +40273,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20111,6 +40316,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20128,8 +40337,16 @@
 <targetPart>
   <id>i2c-master-proc-promc1</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20146,6 +40363,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20177,6 +40406,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20189,8 +40426,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20212,6 +40469,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20229,8 +40490,16 @@
 <targetPart>
   <id>i2c-master-proc-promc2</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20247,6 +40516,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20278,6 +40559,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20290,8 +40579,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20313,6 +40622,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20330,8 +40643,16 @@
 <targetPart>
   <id>i2c-master-proc-promc3</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20348,6 +40669,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20379,6 +40712,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20391,8 +40732,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20414,6 +40775,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20431,8 +40796,16 @@
 <targetPart>
   <id>i2c-master-lightpath</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20449,6 +40822,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20480,6 +40865,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20492,8 +40885,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20515,6 +40928,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20532,8 +40949,16 @@
 <targetPart>
   <id>i2c-master-hotplug</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20550,6 +40975,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20581,6 +41018,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20593,8 +41038,28 @@
     <default>0x01</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20616,6 +41081,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20633,8 +41102,16 @@
 <targetPart>
   <id>i2c-master-tpm</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20651,6 +41128,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20682,6 +41171,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20694,8 +41191,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20717,6 +41234,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20734,8 +41255,16 @@
 <targetPart>
   <id>i2c-master-dpss</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20752,6 +41281,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20783,6 +41324,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20795,8 +41344,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20818,6 +41387,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20835,8 +41408,16 @@
 <targetPart>
   <id>i2c-master-op0a</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20853,6 +41434,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20884,6 +41477,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20896,8 +41497,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -20919,6 +41540,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -20936,8 +41561,16 @@
 <targetPart>
   <id>i2c-master-op0b</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -20954,6 +41587,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -20985,6 +41630,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
@@ -20997,8 +41650,28 @@
     <default>0x02</default>
   </attribute>
   <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -21020,6 +41693,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -21037,8 +41714,16 @@
 <targetPart>
   <id>i2c-master-dimm0123</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -21055,6 +41740,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -21086,20 +41783,48 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>I2C_ENGINE</id>
-    <default>0x01</default>
+    <default>0x03</default>
   </attribute>
   <attribute>
     <id>I2C_PORT</id>
-    <default>0x02</default>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -21121,6 +41846,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -21138,8 +41867,16 @@
 <targetPart>
   <id>i2c-master-dimm4567</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>I2C</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -21156,6 +41893,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -21187,20 +41936,48 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
     <id>I2C_CONNECTION_TYPE</id>
     <default>NA</default>
   </attribute>
   <attribute>
     <id>I2C_ENGINE</id>
-    <default>0x01</default>
+    <default>0x03</default>
   </attribute>
   <attribute>
     <id>I2C_PORT</id>
-    <default>0x02</default>
+    <default>0x01</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
   </attribute>
   <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -21222,6 +41999,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -21239,8 +42020,16 @@
 <targetPart>
   <id>lpc-master</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>LPC</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -21257,6 +42046,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>OUT</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -21288,8 +42089,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -21311,6 +42140,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -21328,8 +42161,16 @@
 <targetPart>
   <id>psi-slave</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>PSI</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -21346,6 +42187,18 @@
   <attribute>
     <id>DIRECTION</id>
     <default>IN</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>HWAS_STATE</id>
@@ -21377,8 +42230,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -21402,6 +42283,14 @@
     </default>
   </attribute>
   <attribute>
+    <id>PSI_ENGINE</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
@@ -21417,8 +42306,16 @@
 <targetPart>
   <id>spi-master</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>BUS_TYPE</id>
     <default>SPI</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -21437,6 +42334,18 @@
     <default>OUT</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -21466,8 +42375,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -21491,12 +42428,20 @@
     </default>
   </attribute>
   <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
     <default>0</default>
   </attribute>
   <attribute>
     <id>SPI_ENGINE</id>
     <default>0x00</default>
+  </attribute>
+  <attribute>
+    <id>SPI_FUNCTION</id>
+    <default>NOT_DEFINED</default>
   </attribute>
   <attribute>
     <id>SPI_PORT</id>
@@ -21514,12 +42459,20 @@
 <targetPart>
   <id>proc_fru_assoc</id>
   <attribute>
+    <id>AFFINITY_PATH</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>ASSOCIATION_TYPE</id>
     <default>FRU</default>
   </attribute>
   <attribute>
     <id>BUS_TYPE</id>
     <default>LOGICAL_ASSOCIATION</default>
+  </attribute>
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
@@ -21538,6 +42491,18 @@
     <default>IN</default>
   </attribute>
   <attribute>
+    <id>FAPI_NAME</id>
+    <default>unknown</default>
+  </attribute>
+  <attribute>
+    <id>FAPI_POS</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <default></default>
+  </attribute>
+  <attribute>
     <id>HWAS_STATE</id>
     <default>
       <field>
@@ -21567,8 +42532,36 @@
     </default>
   </attribute>
   <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <default>0x0</default>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <default>0xFF</default>
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <default></default>
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <default>0x00</default>
+  </attribute>
+  <attribute>
     <id>MRW_TYPE</id>
     <default>NA</default>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <default>0xFFFFFFFF</default>
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <default></default>
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
@@ -21590,6 +42583,10 @@
         <value>0</value>
       </field>
     </default>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <default>0xFF</default>
   </attribute>
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
@@ -21603,107 +42600,6 @@
   <is_root>false</is_root>
   <position>-1</position>
   <type>unit-logic_assoc-generic</type>
-</targetPart>
-<targetPart>
-  <id>module-0.mca</id>
-  <attribute>
-    <id>BUS_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>CDM_DOMAIN</id>
-    <default>MEM</default>
-  </attribute>
-  <attribute>
-    <id>CHIP_UNIT</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>CLASS</id>
-    <default>UNIT</default>
-  </attribute>
-  <attribute>
-    <id>DECONFIG_GARDABLE</id>
-    <default>1</default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE</id>
-    <default>
-      <field>
-        <id>deconfiguredByEid</id>
-        <value></value>
-      </field>
-      <field>
-        <id>poweredOn</id>
-        <value></value>
-      </field>
-      <field>
-        <id>present</id>
-        <value></value>
-      </field>
-      <field>
-        <id>functional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>dumpfunctional</id>
-        <value></value>
-      </field>
-      <field>
-        <id>specdeconfig</id>
-        <value></value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <default>0x00000003</default>
-  </attribute>
-  <attribute>
-    <id>MODEL</id>
-    <default>NIMBUS</default>
-  </attribute>
-  <attribute>
-    <id>MRW_TYPE</id>
-    <default>NA</default>
-  </attribute>
-  <attribute>
-    <id>PRIMARY_CAPABILITIES</id>
-    <default>
-      <field>
-        <id>supportsFsiScom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsXscom</id>
-        <value>1</value>
-      </field>
-      <field>
-        <id>supportsInbandScom</id>
-        <value>0</value>
-      </field>
-      <field>
-        <id>reserved</id>
-        <value>0</value>
-      </field>
-    </default>
-  </attribute>
-  <attribute>
-    <id>RESOURCE_IS_CRITICAL</id>
-    <default>0</default>
-  </attribute>
-  <attribute>
-    <id>SCRATCH_UINT8_1</id>
-    <default>5</default>
-  </attribute>
-  <attribute>
-    <id>TYPE</id>
-    <default>MCA</default>
-  </attribute>
-  <instance_name>module-0.mca</instance_name>
-  <is_root>false</is_root>
-  <position>-1</position>
-  <type>unit-mca-nimbus</type>
 </targetPart>
 </targetInstances>
 </partInstance>

--- a/parts/smartchip-generic.xml
+++ b/parts/smartchip-generic.xml
@@ -38,7 +38,7 @@
     </attribute>
     <instance_name>io-0</instance_name>
     <is_root>false</is_root>
-    <parent>unit</parent>
+    <parent>mrw-unit</parent>
     <position>-1</position>
     <type>unit-gpio-generic</type>
   </targetPart>
@@ -55,7 +55,7 @@
     <child_id>io-0</child_id>
     <instance_name>anchor</instance_name>
     <is_root>true</is_root>
-    <parent>chip</parent>
+    <parent>mrw-chip</parent>
     <parent_type>card-motherboard</parent_type>
     <parent_type>card-daughtercard</parent_type>
     <position>0</position>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -9,6 +9,19 @@
 		</attribute>
 	</targetType>
 	<targetType>
+		<id>mrw-base</id>
+		<attribute>
+			<id>MRW_TYPE</id>
+			<default>NA</default>
+		</attribute>
+		<attribute>
+			<id>CLASS</id>
+		</attribute>
+		<attribute>
+			<id>TYPE</id>
+		</attribute>
+	</targetType>
+	<targetType>
     	<id>enc-node-power9</id>
     	<parent>base</parent>
     	<attribute>
@@ -27,6 +40,18 @@
 			<id>RU_TYPE</id>
 		</attribute>
 	</targetType>
+	<targetType>
+		<id>mrw-chip</id>
+		<parent>mrw-base</parent>
+		<parent_type>card-motherboard</parent_type>
+		<parent_type>card-daughtercard</parent_type>
+		<attribute>
+			<id>TYPE</id>
+		</attribute>
+		<attribute>
+			<id>RU_TYPE</id>
+		</attribute>
+	</targetType>	
 	<targetType>
 		<id>card</id>
 		<parent>base</parent>
@@ -54,8 +79,34 @@
 		</attribute>
 	</targetType>
 	<targetType>
+		<id>mrw-card</id>
+		<parent>mrw-base</parent>
+		<attribute>
+			<id>LOCATION_CODE</id>
+		</attribute>
+		<attribute>
+			<id>LOCATION_CODE_TYPE</id>
+		</attribute>	
+		<attribute>
+			<id>POSITION</id>
+		</attribute>
+		<attribute>
+			<id>TYPE</id>
+			<default>NA</default>
+		</attribute>
+		<attribute>
+			<id>CARD_TYPE</id>
+		</attribute>
+		<attribute>
+			<id>STANDBY_PLUGGABLE</id>
+		</attribute>
+		<attribute>
+			<id>RU_TYPE</id>
+		</attribute>
+	</targetType>	
+	<targetType>
 		<id>connector</id>
-	    <parent>base</parent>	
+	    <parent>mrw-base</parent>	
 		<attribute>
 			<id>CLASS</id>
 			<default>CONNECTOR</default>
@@ -85,6 +136,18 @@
 			<default>NA</default>
 		</attribute>
 	</targetType>
+	<targetType>
+		<id>mrw-unit</id>
+		<parent>mrw-base</parent>
+		<attribute>
+			<id>BUS_TYPE</id>
+			<default>NA</default>
+		</attribute>
+		<attribute>
+			<id>CLASS</id>
+			<default>UNIT</default>
+		</attribute>
+	</targetType>	
 	<targetType>
 		<id>unit-ex-power8</id>
 		<parent>unit</parent>
@@ -1018,7 +1081,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-i2c-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1046,7 +1109,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-i2cmd-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1074,7 +1137,7 @@
 	</targetType>	
 	<targetType>
 		<id>unit-i2c-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1097,7 +1160,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-usb-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1116,7 +1179,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-clk-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1135,7 +1198,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-clk-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1154,7 +1217,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-ethernet-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1181,7 +1244,7 @@
 	</targetType>
     <targetType>
 		<id>unit-ethernet-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1204,7 +1267,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-spi-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1232,7 +1295,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-spi-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1256,7 +1319,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-avs-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1272,7 +1335,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-avs-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1288,7 +1351,7 @@
 	</targetType>			
 	<targetType>
 		<id>unit-uart-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1304,7 +1367,7 @@
 	</targetType>
     <targetType>
 		<id>unit-uart-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1320,7 +1383,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-gpio-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1360,7 +1423,7 @@
 	</targetType>
 	<targetType>
 		<id>i2c-device</id>
-		<parent>base</parent>
+		<parent>mrw-base</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>CHIP</default>
@@ -1368,7 +1431,7 @@
 	</targetType>
 	<targetType>
 		<id>smartchip-generic</id>
-		<parent>chip</parent>
+		<parent>mrw-chip</parent>
 		<parent_type>card-motherboard</parent_type>
 		<parent_type>card-daughtercard</parent_type>
 		<attribute>
@@ -1382,7 +1445,7 @@
 	</targetType>
 	<targetType>
 		<id>chip-gpioexp-generic</id>
-		<parent>chip</parent>
+		<parent>mrw-chip</parent>
 		<parent_type>card-motherboard</parent_type>
 		<parent_type>card-daughtercard</parent_type>
 		<attribute>
@@ -1396,7 +1459,7 @@
 	</targetType>
 	<targetType>
 		<id>dummy-presence-generic</id>
-		<parent>chip</parent>
+		<parent>mrw-chip</parent>
 		<parent_type>card-motherboard</parent_type>
 		<parent_type>card-daughtercard</parent_type>
 		<attribute>
@@ -1414,7 +1477,7 @@
 	</targetType>
 	<targetType>
 		<id>chip-vreg-generic</id>
-		<parent>chip</parent>
+		<parent>mrw-chip</parent>
 		<parent_type>card-motherboard</parent_type>
 		<parent_type>card-daughtercard</parent_type>
 		<attribute>
@@ -1428,7 +1491,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-vreg_enable-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1448,7 +1511,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-vreg_pgood-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1468,7 +1531,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-vreg_vout-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1548,7 +1611,7 @@
 	</targetType>	
 	<targetType>
 		<id>unit-vin-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1568,7 +1631,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-vout-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1588,7 +1651,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-vreg_avs-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1608,7 +1671,7 @@
 	</targetType>	
 	<targetType>
 		<id>unit-power-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1628,7 +1691,7 @@
 	</targetType>
 	<targetType>
         <id>chip-tmp-device</id>
-        <parent>chip</parent>
+        <parent>mrw-chip</parent>
         <parent_type>card-motherboard</parent_type>
 		<parent_type>card-daughtercard</parent_type>
         <attribute>
@@ -1652,7 +1715,7 @@
     </targetType>
     <targetType>
         <id>cooling-zone</id>
-        <parent>base</parent>
+        <parent>mrw-base</parent>
         <parent_type>enc-node-power9</parent_type>
 			<attribute><id>MRW_ID</id></attribute>
 			<attribute><id>MTM_NAME</id></attribute>
@@ -1674,7 +1737,7 @@
     </targetType>
     <targetType>
         <id>fan-info</id>
-        <parent>base</parent>
+        <parent>mrw-base</parent>
         <parent_type>enc-node-power9</parent_type>
 			<attribute><id>MRW_ID</id></attribute>
 			<attribute><id>MTM_NAME</id></attribute>
@@ -1696,7 +1759,7 @@
     </targetType>
 	<targetType>
 		<id>chip-vpd-device</id>
-		<parent>chip</parent>
+		<parent>mrw-chip</parent>
 		<attribute>
 			<id>VPD_TYPE</id>
 			<default></default>
@@ -1738,7 +1801,6 @@
 			<id>BYTE_ADDRESS_OFFSET</id>
 			<default>2</default>
 		</attribute>
-
 		<attribute>
 			<id>MEMORY_SIZE_IN_KB</id>
 			<default>0x40</default>
@@ -1808,7 +1870,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-pcie-endpoint</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>BUS_TYPE</id>
 			<default>PCIE</default>
@@ -1820,7 +1882,7 @@
 	</targetType>
 	<targetType>
 		<id>chip-pcie-endpoint</id>
-		<parent>chip</parent>
+		<parent>mrw-chip</parent>
 		<parent_type>card-motherboard</parent_type>
 		<parent_type>card-daughtercard</parent_type>
 	</targetType>
@@ -1861,7 +1923,7 @@
 	<!-- PCIe -->
 	<targetType>
 		<id>slot-pcieslot</id>
-		<parent>base</parent>
+		<parent>mrw-base</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>CONNECTOR</default>
@@ -1882,7 +1944,7 @@
 	</targetType>
 	<targetType>
 		<id>card-pciecard</id>
-		<parent>base</parent>
+		<parent>mrw-base</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>CARD</default>
@@ -2389,7 +2451,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-logic_assoc-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -2434,7 +2496,7 @@
 	</targetType>		
 	<targetType>
 		<id>unit-iomux_group-fsp2</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX_GROUP</default>
@@ -2445,7 +2507,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_group-cfams</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX_GROUP</default>
@@ -2456,7 +2518,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_config-fsp2</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX_GROUP</default>
@@ -2547,7 +2609,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_config-cfams</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX_GROUP</default>
@@ -2638,7 +2700,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-noniomux_config-fsp2</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>NONIOMUX_GROUP</default>
@@ -2674,7 +2736,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_i2c-fsp2</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2682,7 +2744,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_gpio-fsp2</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2690,7 +2752,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_spcn-fsp2</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2698,7 +2760,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_sc-fsp2</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2706,7 +2768,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_uart-fsp2</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2746,7 +2808,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_i2c-cfams</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2754,7 +2816,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_gpio-cfams</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2762,7 +2824,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_spcn-cfams</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2770,7 +2832,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_sc-cfams</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2778,7 +2840,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-iomux_uart-cfams</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>MRW_TYPE</id>
 			<default>IOMUX</default>
@@ -2796,7 +2858,7 @@
 	</targetType>
 	<targetType>
 		<id>chip-sp-cfams</id>
-		<parent>chip</parent>
+		<parent>mrw-chip</parent>
 		<parent_type>card-motherboard</parent_type>
 		<parent_type>card-daughtercard</parent_type>
 		<attribute>
@@ -2806,7 +2868,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-psi-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -2826,7 +2888,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-psi-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -2846,7 +2908,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-lpc-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -2862,7 +2924,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-lpc-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -2878,7 +2940,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-spcn-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>UNIT</default>
@@ -2902,7 +2964,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-jtag-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>UNIT</default>
@@ -2926,7 +2988,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-sc-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>UNIT</default>
@@ -2950,7 +3012,7 @@
 	</targetType>
 		<targetType>
 		<id>unit-sc-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>UNIT</default>
@@ -2974,7 +3036,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-u750-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>UNIT</default>
@@ -2998,7 +3060,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-u5-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>UNIT</default>
@@ -3022,7 +3084,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-pwm-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>UNIT</default>
@@ -3066,7 +3128,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-tach-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>UNIT</default>
@@ -3150,7 +3212,7 @@
 	</targetType>
 	<targetType>
 		<id>unit-ipmi-sensor</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CLASS</id>
 			<default>UNIT</default>
@@ -3222,7 +3284,7 @@
 		<id>chip-apss-psoc</id>
 		<parent_type>sys-sys-power8</parent_type>
 		<parent_type>sys-sys-power9</parent_type>
-		<parent>chip</parent>
+		<parent>mrw-chip</parent>
 		<attribute>
 			<id>TYPE</id>
 			<default>APSS</default>
@@ -3321,7 +3383,7 @@
 
 	<targetType>
 		<id>dpss.unit-config-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CONFIG_ID</id>
 			<default>
@@ -3343,7 +3405,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-dio-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>DIRECTION</id>
 		</attribute>
@@ -3353,7 +3415,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-enable-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -3380,7 +3442,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-error-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -3410,7 +3472,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-fan_global_setting-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>FAN_DOMAIN_0</id>
 			<default>
@@ -3672,14 +3734,14 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-fsi-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>PIN_NAME</id>
 		</attribute>
 	</targetType>
 	<targetType>
 		<id>dpss.unit-gpio-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -3709,7 +3771,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-gpio_global_params-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>PSC0</id>
 			<default>
@@ -3737,7 +3799,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-i2c-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>FIXED_ADDRESS</id>
 		</attribute>
@@ -3763,7 +3825,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-lpc-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>PIN_NAME</id>
 		</attribute>
@@ -3774,7 +3836,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-pgood-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -3849,7 +3911,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-power-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CURRENT_MAX</id>
 		</attribute>
@@ -3865,7 +3927,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-power_control_global-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>DEGATE_CPU_0</id>
 			<default>
@@ -4157,7 +4219,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-presence-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -4177,7 +4239,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-pseq_lookup-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>PSEQ_SLOT0</id>
 			<default>
@@ -4373,7 +4435,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-pwm-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -4398,7 +4460,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-sec_pgood-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>BITS</id>
 		</attribute>
@@ -4417,7 +4479,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-sec_pgood_gpio-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -4447,7 +4509,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-spi-master</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>ENGINE</id>
 		</attribute>
@@ -4463,7 +4525,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-tach-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -4523,7 +4585,7 @@
 	</targetType>
 	<targetType>
 		<id>dpss.unit-wdt-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>END_COUNT</id>
 			<default>
@@ -4548,7 +4610,7 @@
 <!-- APSS units -->
 	<targetType>
 		<id>apss.unit-adc-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -4577,7 +4639,7 @@
 	</targetType>
 	<targetType>
 		<id>apss.unit-adc_global-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>ADC_MAX</id>
 		</attribute>
@@ -4591,7 +4653,7 @@
 	</targetType>
 	<targetType>
 		<id>apss.unit-gpio-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>FUNCTION_ID</id>
 		</attribute>
@@ -4617,7 +4679,7 @@
 	</targetType>
 	<targetType>
 		<id>apss.unit-i2c-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>PIN-NAME</id>
 		</attribute>
@@ -4632,7 +4694,7 @@
 	</targetType>
 	<targetType>
 		<id>apss.unit-power-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CURRENT_MAX</id>
 		</attribute>
@@ -4652,7 +4714,7 @@
 	</targetType>
 	<targetType>
 		<id>apss.unit-pwm-generic</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>CHANNEL</id>
 		</attribute>
@@ -4666,7 +4728,7 @@
 	</targetType>
 	<targetType>
 		<id>apss.unit-spi-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>PIN-NAME</id>
 		</attribute>
@@ -4677,7 +4739,7 @@
 	</targetType>
 	<targetType>
 		<id>apss.unit-uart-slave</id>
-		<parent>unit</parent>
+		<parent>mrw-unit</parent>
 		<attribute>
 			<id>PIN-NAME</id>
 		</attribute>

--- a/target_types_override.xml
+++ b/target_types_override.xml
@@ -1,7 +1,7 @@
 <targetTypes>
 	<targetType>
 		<id>targetoverride-group</id>
-		<parent>base</parent>
+		<parent>mrw-base</parent>
 		<parent_type>sys-sys-power8</parent_type>
 		<parent_type>sys-sys-power9</parent_type>
 		<attribute>
@@ -15,7 +15,7 @@
 	</targetType>
 	<targetType>
 		<id>targetoverride</id>
-		<parent>base</parent>
+		<parent>mrw-base</parent>
 		<parent_type>sys-sys-power8</parent_type>
 		<parent_type>sys-sys-power9</parent_type>
 		<attribute>


### PR DESCRIPTION
This is done for cleanup purposes and to reduce the overall size of the MRW files. 