### PR TITLE
Fixes for things lost in churn

### DIFF
--- a/attribute_types.xml
+++ b/attribute_types.xml
@@ -13676,6 +13676,7 @@ Measured in GB</description>
     <simpleType><uint32_t><default>0</default></uint32_t></simpleType>
     <persistency>non-volatile</persistency>
     <readable/>
+    <global/>
 </attribute>
 
 <attribute>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -1235,6 +1235,10 @@
 			<default>ETHERNET</default>
 		</attribute>
 		<attribute>
+			<id>CHIP_UNIT</id>
+			<default>0</default>
+		</attribute>
+		<attribute>
 			<id>DIRECTION</id>
 			<default>OUT</default>
 		</attribute>
@@ -1276,6 +1280,10 @@
 	<targetType>
 		<id>unit-spi-master</id>
 		<parent>mrw-unit</parent>
+		<attribute>
+			<id>CHIP_UNIT</id>
+			<default>0</default>
+		</attribute>
 		<attribute>
 			<id>TYPE</id>
 			<default>NA</default>
@@ -1399,6 +1407,10 @@
 		<attribute>
 			<id>BUS_TYPE</id>
 			<default>U750</default>
+		</attribute>
+		<attribute>
+			<id>CHIP_UNIT</id>
+			<default>0</default>
 		</attribute>
 		<attribute>
 			<id>DIRECTION</id>


### PR DESCRIPTION
1) Make FRU_ID be a global attribute so it can have different values even when the underlying XML is common.

2) Add CHIP_UNIT into some units since they are now a child of mrw-unit and not unit (which had it).