### PR TITLE
Add cooling zone profile to fan

### DIFF
--- a/attribute_types_obmc.xml
+++ b/attribute_types_obmc.xml
@@ -1,4 +1,22 @@
 <attributes>
+	<enumerationType>
+		<id>COOLING_PROFILE</id>
+		<description>Enumerates the different cooling profiles</description>
+		<enumerator>
+			<name>ALL</name>
+			<value>0</value>
+		</enumerator>
+		<enumerator>
+			<name>AIR</name>
+			<value>1</value>
+		</enumerator>
+		<enumerator>
+			<name>WATER</name>
+			<value>2</value>
+		</enumerator>
+		<default>ALL</default>
+	</enumerationType>
+
 	<attribute>
 		<id>MANUFACTURER</id>
         <description>The manufacturer</description>
@@ -159,4 +177,16 @@
 		<readable/>
 	</attribute>
 
+	<attribute>
+		<id>COOLING_ZONE_PROFILE</id>
+		<description>Which cooling zone profile the part participates in.
+                     For example, maybe in a zone only when air cooled. </description>
+		<simpleType>
+			<enumeration>
+				<id>COOLING_PROFILE</id>
+			</enumeration>
+		</simpleType>
+		<readable/>
+        <global/>
+	</attribute>
 </attributes>

--- a/parts/FAN_COUNTER_ROTATING.xml
+++ b/parts/FAN_COUNTER_ROTATING.xml
@@ -18,6 +18,14 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>COOLING_ZONE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>COOLING_ZONE_PROFILE</id>
+		<default>ALL</default>
+	</attribute>
+	<attribute>
 		<id>CHIP_ID</id>
 		<default></default>
 	</attribute>


### PR DESCRIPTION
Add the COOLING_ZONE_PROFILE attribute to a fan part as a way to specify
it is only required for certain cooling scenarios (like air cooled
vs water cooled).

Also add a COOLING_ZONE attribute to a fan part so it can be in a
cooling zone.