### PR TITLE
common-mrw-xml update 5-25-2017

### DIFF
--- a/attribute_types_hb.xml
+++ b/attribute_types_hb.xml
@@ -1,4285 +1,4295 @@
 <attributes>
-<!-- =====================================================================
+  <!-- =====================================================================
      HOST BOOT ATTRIBUTE TYPES
      Contains the definition of all hostboot attributes which can be synced
      to/from FSP
      ================================================================= -->
-<enumerationType>
-  <id>CLASS</id>
-  <description>Enumeration indicating the target's
-  class</description>
-  <enumerator>
-    <name>NA</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>CARD</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>ENC</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>CHIP</name>
-    <value>3</value>
-  </enumerator>
-  <enumerator>
-    <name>UNIT</name>
-    <value>4</value>
-  </enumerator>
-  <enumerator>
-    <name>DEV</name>
-    <value>5</value>
-  </enumerator>
-  <enumerator>
-    <name>SYS</name>
-    <value>6</value>
-  </enumerator>
-  <enumerator>
-    <name>LOGICAL_CARD</name>
-    <value>7</value>
-  </enumerator>
-  <enumerator>
-    <name>BATTERY</name>
-    <value>8</value>
-  </enumerator>
-  <enumerator>
-    <name>LED</name>
-    <value>9</value>
-  </enumerator>
-  <enumerator>
-    <name>MAX</name>
-    <value>10</value>
-  </enumerator>
-  <default>NA</default>
-</enumerationType>
-<!-- The script genHwsvMrwXml.pl hardcodes the HUID type field to match
+  <enumerationType>
+    <id>CLASS</id>
+    <description>Enumeration indicating the target's
+    class</description>
+    <enumerator>
+      <name>NA</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>CARD</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>ENC</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>CHIP</name>
+      <value>3</value>
+    </enumerator>
+    <enumerator>
+      <name>UNIT</name>
+      <value>4</value>
+    </enumerator>
+    <enumerator>
+      <name>DEV</name>
+      <value>5</value>
+    </enumerator>
+    <enumerator>
+      <name>SYS</name>
+      <value>6</value>
+    </enumerator>
+    <enumerator>
+      <name>LOGICAL_CARD</name>
+      <value>7</value>
+    </enumerator>
+    <enumerator>
+      <name>BATTERY</name>
+      <value>8</value>
+    </enumerator>
+    <enumerator>
+      <name>LED</name>
+      <value>9</value>
+    </enumerator>
+    <enumerator>
+      <name>MAX</name>
+      <value>10</value>
+    </enumerator>
+    <default>NA</default>
+  </enumerationType>
+  <!-- The script genHwsvMrwXml.pl hardcodes the HUID type field to match
      these values and should be kept in sync. Leave holes in in the range
      if a type is deleted. Not changing the values keeps the values
      consistent over builds making them easier to recognize.  -->
-<enumerationType>
-  <id>TYPE</id>
-  <description>Enumeration indicating the target's
-  type</description>
-  <enumerator>
-    <name>NA</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>SYS</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>NODE</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>DIMM</name>
-    <value>3</value>
-  </enumerator>
-  <enumerator>
-    <name>MEMBUF</name>
-    <value>4</value>
-  </enumerator>
-  <enumerator>
-    <name>PROC</name>
-    <value>5</value>
-  </enumerator>
-  <enumerator>
-    <name>EX</name>
-    <value>6</value>
-  </enumerator>
-  <enumerator>
-    <name>CORE</name>
-    <value>7</value>
-  </enumerator>
-  <enumerator>
-    <name>L2</name>
-    <value>8</value>
-  </enumerator>
-  <enumerator>
-    <name>L3</name>
-    <value>9</value>
-  </enumerator>
-  <enumerator>
-    <name>L4</name>
-    <value>10</value>
-  </enumerator>
-  <enumerator>
-    <name>MCS</name>
-    <value>11</value>
-  </enumerator>
-  <enumerator>
-    <name>MBA</name>
-    <value>13</value>
-  </enumerator>
-  <enumerator>
-    <name>XBUS</name>
-    <value>14</value>
-  </enumerator>
-  <enumerator>
-    <name>ABUS</name>
-    <value>15</value>
-  </enumerator>
-  <enumerator>
-    <name>PCI</name>
-    <value>16</value>
-  </enumerator>
-  <enumerator>
-    <name>DPSS</name>
-    <value>17</value>
-  </enumerator>
-  <enumerator>
-    <name>APSS</name>
-    <value>18</value>
-  </enumerator>
-  <enumerator>
-    <name>OCC</name>
-    <value>19</value>
-  </enumerator>
-  <enumerator>
-    <name>PSI</name>
-    <value>20</value>
-  </enumerator>
-  <enumerator>
-    <name>FSP</name>
-    <value>21</value>
-  </enumerator>
-  <enumerator>
-    <name>PNOR</name>
-    <value>22</value>
-  </enumerator>
-  <enumerator>
-    <name>OSC</name>
-    <value>23</value>
-  </enumerator>
-  <enumerator>
-    <name>TODCLK</name>
-    <value>24</value>
-  </enumerator>
-  <enumerator>
-    <name>CONTROL_NODE</name>
-    <value>25</value>
-  </enumerator>
-  <enumerator>
-    <name>OSCREFCLK</name>
-    <value>26</value>
-  </enumerator>
-  <enumerator>
-    <name>OSCPCICLK</name>
-    <value>27</value>
-  </enumerator>
-  <enumerator>
-    <name>REFCLKENDPT</name>
-    <value>28</value>
-  </enumerator>
-  <enumerator>
-    <name>PCICLKENDPT</name>
-    <value>29</value>
-  </enumerator>
-  <enumerator>
-    <name>NX</name>
-    <value>30</value>
-  </enumerator>
-  <enumerator>
-    <name>PORE</name>
-    <value>31</value>
-  </enumerator>
-  <enumerator>
-    <name>PCIESWITCH</name>
-    <value>32</value>
-  </enumerator>
-  <enumerator>
-    <name>CAPP</name>
-    <value>33</value>
-  </enumerator>
-  <enumerator>
-    <name>FSI</name>
-    <value>34</value>
-  </enumerator>
-  <!-- Add P9 targets -->
-  <enumerator>
-    <name>EQ</name>
-    <value>35</value>
-  </enumerator>
-  <enumerator>
-    <name>MCA</name>
-    <value>36</value>
-  </enumerator>
-  <enumerator>
-    <name>MCBIST</name>
-    <value>37</value>
-  </enumerator>
-  <enumerator>
-    <name>MI</name>
-    <value>38</value>
-  </enumerator>
-  <enumerator>
-    <name>DMI</name>
-    <value>39</value>
-  </enumerator>
-  <enumerator>
-    <name>OBUS</name>
-    <value>40</value>
-  </enumerator>
-  <enumerator>
-    <name>NV</name>
-    <value>41</value>
-  </enumerator>
-  <enumerator>
-    <name>SBE</name>
-    <value>42</value>
-  </enumerator>
-  <enumerator>
-    <name>PPE</name>
-    <value>43</value>
-  </enumerator>
-  <enumerator>
-    <name>PERV</name>
-    <value>44</value>
-  </enumerator>
-  <enumerator>
-    <name>PEC</name>
-    <value>45</value>
-  </enumerator>
-  <enumerator>
-    <name>PHB</name>
-    <value>46</value>
-  </enumerator>
-  <enumerator>
-    <name>SYSREFCLKENDPT</name>
-    <value>47</value>
-  </enumerator>
-  <enumerator>
-    <name>MFREFCLKENDPT</name>
-    <value>48</value>
-  </enumerator>
-  <enumerator>
-    <name>TPM</name>
-    <value>49</value>
-  </enumerator>
-  <enumerator>
-    <name>SP</name>
-    <value>50</value>
-  </enumerator>
-  <enumerator>
-    <name>UART</name>
-    <value>51</value>
-  </enumerator>
-  <enumerator>
-    <name>PS</name>
-    <value>52</value>
-  </enumerator>
-  <enumerator>
-    <name>FAN</name>
-    <value>53</value>
-  </enumerator>
-  <enumerator>
-    <name>VRM</name>
-    <value>54</value>
-  </enumerator>
-  <enumerator>
-    <name>USB</name>
-    <value>55</value>
-  </enumerator>
-  <enumerator>
-    <name>ETH</name>
-    <value>56</value>
-  </enumerator>
-  <enumerator>
-    <name>PANEL</name>
-    <value>57</value>
-  </enumerator>
-  <enumerator>
-    <name>BMC</name>
-    <value>58</value>
-  </enumerator>
-  <enumerator>
-    <name>FLASH</name>
-    <value>59</value>
-  </enumerator>
-  <enumerator>
-    <name>SEEPROM</name>
-    <value>60</value>
-  </enumerator>
-  <enumerator>
-    <name>TMP</name>
-    <value>61</value>
-  </enumerator>
-  <enumerator>
-    <name>GPIO_EXPANDER</name>
-    <value>62</value>
-  </enumerator>
-  <enumerator>
-    <name>POWER_SEQUENCER</name>
-    <value>63</value>
-  </enumerator>
-  <enumerator>
-    <name>RTC</name>
-    <value>64</value>
-  </enumerator>
-  <enumerator>
-    <name>FANCTLR</name>
-    <value>65</value>
-  </enumerator>
-  <!-- add any new types here, and increment TEST_FAIL and LAST_IN_RANGE -->
-  <enumerator>
-    <name>TEST_FAIL</name>
-    <value>66</value>
-  </enumerator>
-  <enumerator>
-    <name>LAST_IN_RANGE</name>
-    <value>67</value>
-  </enumerator>
-  <default>NA</default>
-</enumerationType>
-<enumerationType>
-  <id>MODEL</id>
-  <description>Enumeration indicating the target's
-  model</description>
-  <enumerator>
-    <name>NA</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>RESERVED</name>
-    <!-- Left here to keep later values the same -->
-    <value>16</value>
-  </enumerator>
-  <enumerator>
-    <name>VENICE</name>
-  </enumerator>
-  <enumerator>
-    <name>MURANO</name>
-  </enumerator>
-  <enumerator>
-    <name>NAPLES</name>
-  </enumerator>
-  <enumerator>
-    <name>NIMBUS</name>
-  </enumerator>
-  <enumerator>
-    <name>CUMULUS</name>
-  </enumerator>
-  <enumerator>
-    <name>CENTAUR</name>
-    <value>48</value>
-  </enumerator>
-  <enumerator>
-    <name>JEDEC</name>
-    <value>80</value>
-  </enumerator>
-  <enumerator>
-    <name>CDIMM</name>
-  </enumerator>
-  <!-- POWER8 is system/node model, not processor chip level -->
-  <enumerator>
-    <name>POWER8</name>
-    <value>112</value>
-  </enumerator>
-  <!-- POWER9 is system/node model, not processor chip level -->
-  <enumerator>
-    <name>POWER9</name>
-    <value>144</value>
-  </enumerator>
-  <enumerator>
-    <name>CECTPM</name>
-  </enumerator>
-  <enumerator>
-    <name>BMC</name>
-  </enumerator>
-  <default>NA</default>
-</enumerationType>
-<enumerationType>
-  <id>ENGINE_TYPE</id>
-  <description>Enumeration indicating the target's engine
-  type</description>
-  <enumerator>
-    <name>NA</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>ENGINE_IIC</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>ENGINE_SCOM</name>
-    <value>2</value>
-  </enumerator>
-  <default>NA</default>
-</enumerationType>
-<enumerationType>
-  <id>FSI_MASTER_TYPE</id>
-  <description>Enumeration indicating the master's FSI
-  type</description>
-  <enumerator>
-    <name>MFSI</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>CMFSI</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>NO_MASTER</name>
-    <value>2</value>
-  </enumerator>
-  <default>NO_MASTER</default>
-</enumerationType>
-<attribute>
-  <id>CLASS</id>
-  <description>Attribute indicating the target's
-  class</description>
-  <simpleType>
-    <enumeration>
-      <id>CLASS</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<attribute>
-  <id>TYPE</id>
-  <description>Attribute indicating the target's type</description>
-  <simpleType>
-    <enumeration>
-      <id>TYPE</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<attribute>
-  <id>MODEL</id>
-  <description>Attribute indicating the target's
-  model</description>
-  <simpleType>
-    <enumeration>
-      <id>MODEL</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<attribute>
-  <id>ENGINE_TYPE</id>
-  <description>Attribute indicating the target's engine
-  type</description>
-  <simpleType>
-    <enumeration>
-      <id>ENGINE_TYPE</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<attribute>
-  <id>DUMMY_RW</id>
-  <description>Dummy attribute with read/write
-  permissions</description>
-  <simpleType>
-    <uint8_t>
-      <default>5</default>
-    </uint8_t>
-    <array>1,3,5</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_DUMMY_SCRATCH_PLAT_INIT_UINT8</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>DUMMY_WO</id>
-  <description>Dummy attribute with write-only
-  permissions</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <writeable />
-</attribute>
-<attribute>
-  <id>DUMMY_RO</id>
-  <description>Dummy attribute with read-only
-  permissions</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PHYS_PATH</id>
-  <description>Physical hierarchical path to the
-  target</description>
-  <nativeType>
-    <name>EntityPath</name>
-  </nativeType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>AFFINITY_PATH</id>
-  <description>Hierarchical path to the target with respect to
-  logical affinity</description>
-  <nativeType>
-    <name>EntityPath</name>
-  </nativeType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>POWER_PATH</id>
-  <description>Hierarchical path to the target with respect to
-  power</description>
-  <nativeType>
-    <name>EntityPath</name>
-  </nativeType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PRIMARY_CAPABILITIES</id>
-  <description>Attribute which describes capabilities of a
-  target</description>
-  <complexType>
-    <description>Structure which defines a target's primary
-    capabilities. A target can only support at most FSI SCOM and
-    one of the other two SCOM types. Applicable for all targets.
-    Structure is read-only.</description>
-    <field>
-      <name>supportsFsiScom</name>
-      <description>0b0: Target does not support FSI SCOM; 0b1:
-      Target supports FSI SCOM</description>
-      <type>uint8_t</type>
-      <bits>1</bits>
-      <default>0</default>
-    </field>
-    <field>
-      <name>supportsXscom</name>
-      <description>0b0: Target does not support XSCOM; 0b1: Target
-      supports FSI XSCOM</description>
-      <type>uint8_t</type>
-      <bits>1</bits>
-      <default>0</default>
-    </field>
-    <field>
-      <name>supportsInbandScom</name>
-      <description>0b0: Target does not support inband
-      SCOM</description>
-      <type>uint8_t</type>
-      <bits>1</bits>
-      <default>0</default>
-    </field>
-    <field>
-      <name>reserved</name>
-      <description>Reserved for future use</description>
-      <type>uint8_t</type>
-      <bits>5</bits>
-      <default>0</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>CPU_ATTR</id>
-  <description>CPU Attribute</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>FSI_MASTER_CHIP</id>
-  <description>Chip which contains the FSI master logic that drives
-  this slave when booting from the default master
-  processor</description>
-  <nativeType>
-    <name>EntityPath</name>
-    <default>physical:sys-0</default>
-  </nativeType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>ALTFSI_MASTER_CHIP</id>
-  <description>Chip which contains the FSI master logic that drives
-  this slave when booting from the alternate master
-  processor</description>
-  <nativeType>
-    <name>EntityPath</name>
-    <default>physical:sys-0</default>
-  </nativeType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>FSI_MASTER_TYPE</id>
-  <description>Type of Master FSI connection to this slave (MFSI or
-  cMFSI)</description>
-  <simpleType>
-    <enumeration>
-      <id>FSI_MASTER_TYPE</id>
-      <default>NO_MASTER</default>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-</attribute>
-<attribute>
-  <id>FSI_MASTER_PORT</id>
-  <description>Which port is this chip hanging off of when booting
-  from the default master processor</description>
-  <simpleType>
-    <uint8_t>
-      <default>0xFF</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>ALTFSI_MASTER_PORT</id>
-  <description>Which port is this chip hanging off of when booting
-  from the alternate master processor</description>
-  <simpleType>
-    <uint8_t>
-      <default>0xFF</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>I2C_SLAVE_ADDRESS</id>
-  <description>I2C Slave Address</description>
-  <simpleType>
-    <uint8_t>
-      <default>0x00</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_I2C_SLAVE_ADDRESS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FSI_SLAVE_CASCADE</id>
-  <description>Slave cascade position</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>FSI_OPTION_FLAGS</id>
-  <description>Reserved for any special flags we might need to
-  access FSI</description>
-  <complexType>
-    <description>FSI flags</description>
-    <field>
-      <name>flipPort</name>
-      <description>Set on FSI master chips (procs) if that chip
-      uses slaveB to attach to the acting master
-      chip.</description>
-      <type>uint16_t</type>
-      <bits>1</bits>
-      <default>0</default>
-    </field>
-    <field>
-      <name>reserved</name>
-      <description>Reserved for future expansion</description>
-      <type>uint16_t</type>
-      <bits>15</bits>
-      <default>0</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>EXECUTION_PLATFORM</id>
-  <description>Which execution platform the HW Procedure is running
-  on Some HWPs (e.g. special wakeup) use different registers for
-  different platforms to avoid arbitration problems when multiple
-  platforms do the same thing concurrently HOST = 0x01, FSP = 0x02,
-  OCC = 0x03</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_EXECUTION_PLATFORM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IS_SIMULATION</id>
-  <description>env: 1 = Awan/HWSimulator. 0 =
-  Simics/RealHW.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_IS_SIMULATION</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>HWAS_STATE_CHANGED_FLAG</id>
-  <description>HardWare Availability Service State Changed
-  Attribute. Keeps track of changedSinceChecked state, indicates if
-  the target has changed since last checked by the appropriate
-  service. This is a bit field of flags (see HWAS_CHANGED_BIT
-  enumeration that follows).</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-  <description>HardWare Availability Service State Changed Mask.
-  Used when a target changes (ie, via HCDB change) to set the
-  HWAS_STATE_CHANGED_FLAG, so that the appropriate services will
-  all handle the change. This is a bit field of flags (see
-  HWAS_CHANGED_BIT enumeration that follows).</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>HWAS_CHANGED_BIT</id>
-  <description>Enumeration indicating the services that are
-  concerned with target changes (ie, via HCDB change). The values
-  can be combined using a bitwise 'OR'.</description>
-  <enumerator>
-    <name>GARD</name>
-    <value>0x00000001</value>
-  </enumerator>
-  <enumerator>
-    <name>MEMDIAG</name>
-    <value>0x00000002</value>
-  </enumerator>
-  <enumerator>
-    <name>PSIDIAG</name>
-    <value>0x00000004</value>
-  </enumerator>
-  <!-- combination of all DIAG values -->
-  <!-- if you add a DIAG flag above, add the bit in the mask below -->
-  <enumerator>
-    <name>DIAG_MASK</name>
-    <value>0x00000006</value>
-  </enumerator>
-  <enumerator>
-    <name>HOSTSVC_HBEL</name>
-    <value>0x00000008</value>
-  </enumerator>
-</enumerationType>
-<!-- For POD Testing -->
-<attribute>
-  <id>NUMERIC_POD_TYPE_TEST</id>
-  <description>Attribute which tests numeric POD
-  types</description>
-  <complexType>
-    <description>Numeric POD type test structure</description>
-    <field>
-      <name>fsiPath</name>
-      <description>Entity path for testing purposes</description>
-      <type>EntityPath</type>
+  <enumerationType>
+    <id>TYPE</id>
+    <description>Enumeration indicating the target's
+    type</description>
+    <enumerator>
+      <name>NA</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>SYS</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>NODE</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>DIMM</name>
+      <value>3</value>
+    </enumerator>
+    <enumerator>
+      <name>MEMBUF</name>
+      <value>4</value>
+    </enumerator>
+    <enumerator>
+      <name>PROC</name>
+      <value>5</value>
+    </enumerator>
+    <enumerator>
+      <name>EX</name>
+      <value>6</value>
+    </enumerator>
+    <enumerator>
+      <name>CORE</name>
+      <value>7</value>
+    </enumerator>
+    <enumerator>
+      <name>L2</name>
+      <value>8</value>
+    </enumerator>
+    <enumerator>
+      <name>L3</name>
+      <value>9</value>
+    </enumerator>
+    <enumerator>
+      <name>L4</name>
+      <value>10</value>
+    </enumerator>
+    <enumerator>
+      <name>MCS</name>
+      <value>11</value>
+    </enumerator>
+    <enumerator>
+      <name>MBA</name>
+      <value>13</value>
+    </enumerator>
+    <enumerator>
+      <name>XBUS</name>
+      <value>14</value>
+    </enumerator>
+    <enumerator>
+      <name>ABUS</name>
+      <value>15</value>
+    </enumerator>
+    <enumerator>
+      <name>PCI</name>
+      <value>16</value>
+    </enumerator>
+    <enumerator>
+      <name>DPSS</name>
+      <value>17</value>
+    </enumerator>
+    <enumerator>
+      <name>APSS</name>
+      <value>18</value>
+    </enumerator>
+    <enumerator>
+      <name>OCC</name>
+      <value>19</value>
+    </enumerator>
+    <enumerator>
+      <name>PSI</name>
+      <value>20</value>
+    </enumerator>
+    <enumerator>
+      <name>FSP</name>
+      <value>21</value>
+    </enumerator>
+    <enumerator>
+      <name>PNOR</name>
+      <value>22</value>
+    </enumerator>
+    <enumerator>
+      <name>OSC</name>
+      <value>23</value>
+    </enumerator>
+    <enumerator>
+      <name>TODCLK</name>
+      <value>24</value>
+    </enumerator>
+    <enumerator>
+      <name>CONTROL_NODE</name>
+      <value>25</value>
+    </enumerator>
+    <enumerator>
+      <name>OSCREFCLK</name>
+      <value>26</value>
+    </enumerator>
+    <enumerator>
+      <name>OSCPCICLK</name>
+      <value>27</value>
+    </enumerator>
+    <enumerator>
+      <name>REFCLKENDPT</name>
+      <value>28</value>
+    </enumerator>
+    <enumerator>
+      <name>PCICLKENDPT</name>
+      <value>29</value>
+    </enumerator>
+    <enumerator>
+      <name>NX</name>
+      <value>30</value>
+    </enumerator>
+    <enumerator>
+      <name>PORE</name>
+      <value>31</value>
+    </enumerator>
+    <enumerator>
+      <name>PCIESWITCH</name>
+      <value>32</value>
+    </enumerator>
+    <enumerator>
+      <name>CAPP</name>
+      <value>33</value>
+    </enumerator>
+    <enumerator>
+      <name>FSI</name>
+      <value>34</value>
+    </enumerator>
+    <!-- Add P9 targets -->
+    <enumerator>
+      <name>EQ</name>
+      <value>35</value>
+    </enumerator>
+    <enumerator>
+      <name>MCA</name>
+      <value>36</value>
+    </enumerator>
+    <enumerator>
+      <name>MCBIST</name>
+      <value>37</value>
+    </enumerator>
+    <enumerator>
+      <name>MI</name>
+      <value>38</value>
+    </enumerator>
+    <enumerator>
+      <name>DMI</name>
+      <value>39</value>
+    </enumerator>
+    <enumerator>
+      <name>OBUS</name>
+      <value>40</value>
+    </enumerator>
+    <!-- @TODO RTC:173529-Remove once NV is not used anywhere and leave a gap-->
+    <enumerator>
+      <name>NV</name>
+      <value>41</value>
+    </enumerator>
+    <enumerator>
+      <name>SBE</name>
+      <value>42</value>
+    </enumerator>
+    <enumerator>
+      <name>PPE</name>
+      <value>43</value>
+    </enumerator>
+    <enumerator>
+      <name>PERV</name>
+      <value>44</value>
+    </enumerator>
+    <enumerator>
+      <name>PEC</name>
+      <value>45</value>
+    </enumerator>
+    <enumerator>
+      <name>PHB</name>
+      <value>46</value>
+    </enumerator>
+    <enumerator>
+      <name>SYSREFCLKENDPT</name>
+      <value>47</value>
+    </enumerator>
+    <enumerator>
+      <name>MFREFCLKENDPT</name>
+      <value>48</value>
+    </enumerator>
+    <enumerator>
+      <name>TPM</name>
+      <value>49</value>
+    </enumerator>
+    <enumerator>
+      <name>SP</name>
+      <value>50</value>
+    </enumerator>
+    <enumerator>
+      <name>UART</name>
+      <value>51</value>
+    </enumerator>
+    <enumerator>
+      <name>PS</name>
+      <value>52</value>
+    </enumerator>
+    <enumerator>
+      <name>FAN</name>
+      <value>53</value>
+    </enumerator>
+    <enumerator>
+      <name>VRM</name>
+      <value>54</value>
+    </enumerator>
+    <enumerator>
+      <name>USB</name>
+      <value>55</value>
+    </enumerator>
+    <enumerator>
+      <name>ETH</name>
+      <value>56</value>
+    </enumerator>
+    <enumerator>
+      <name>PANEL</name>
+      <value>57</value>
+    </enumerator>
+    <enumerator>
+      <name>BMC</name>
+      <value>58</value>
+    </enumerator>
+    <enumerator>
+      <name>FLASH</name>
+      <value>59</value>
+    </enumerator>
+    <enumerator>
+      <name>SEEPROM</name>
+      <value>60</value>
+    </enumerator>
+    <enumerator>
+      <name>TMP</name>
+      <value>61</value>
+    </enumerator>
+    <enumerator>
+      <name>GPIO_EXPANDER</name>
+      <value>62</value>
+    </enumerator>
+    <enumerator>
+      <name>POWER_SEQUENCER</name>
+      <value>63</value>
+    </enumerator>
+    <enumerator>
+      <name>RTC</name>
+      <value>64</value>
+    </enumerator>
+    <enumerator>
+      <name>FANCTLR</name>
+      <value>65</value>
+    </enumerator>
+    <enumerator>
+      <name>OBUS_BRICK</name>
+      <value>66</value>
+    </enumerator>
+    <enumerator>
+      <name>NPU</name>
+      <value>67</value>
+    </enumerator>
+    <!-- add any new types here, and increment TEST_FAIL and LAST_IN_RANGE -->
+    <enumerator>
+      <name>TEST_FAIL</name>
+      <value>68</value>
+    </enumerator>
+    <enumerator>
+      <name>LAST_IN_RANGE</name>
+      <value>69</value>
+    </enumerator>
+    <default>NA</default>
+  </enumerationType>
+  <enumerationType>
+    <id>MODEL</id>
+    <description>Enumeration indicating the target's
+    model</description>
+    <enumerator>
+      <name>NA</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>RESERVED</name>
+      <!-- Left here to keep later values the same -->
+      <value>16</value>
+    </enumerator>
+    <enumerator>
+      <name>VENICE</name>
+    </enumerator>
+    <enumerator>
+      <name>MURANO</name>
+    </enumerator>
+    <enumerator>
+      <name>NAPLES</name>
+    </enumerator>
+    <enumerator>
+      <name>NIMBUS</name>
+    </enumerator>
+    <enumerator>
+      <name>CUMULUS</name>
+    </enumerator>
+    <enumerator>
+      <name>CENTAUR</name>
+      <value>48</value>
+    </enumerator>
+    <enumerator>
+      <name>JEDEC</name>
+      <value>80</value>
+    </enumerator>
+    <enumerator>
+      <name>CDIMM</name>
+    </enumerator>
+    <!-- POWER8 is system/node model, not processor chip level -->
+    <enumerator>
+      <name>POWER8</name>
+      <value>112</value>
+    </enumerator>
+    <!-- POWER9 is system/node model, not processor chip level -->
+    <enumerator>
+      <name>POWER9</name>
+      <value>144</value>
+    </enumerator>
+    <enumerator>
+      <name>CECTPM</name>
+    </enumerator>
+    <enumerator>
+      <name>BMC</name>
+    </enumerator>
+    <default>NA</default>
+  </enumerationType>
+  <enumerationType>
+    <id>ENGINE_TYPE</id>
+    <description>Enumeration indicating the target's engine
+    type</description>
+    <enumerator>
+      <name>NA</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>ENGINE_IIC</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>ENGINE_SCOM</name>
+      <value>2</value>
+    </enumerator>
+    <default>NA</default>
+  </enumerationType>
+  <enumerationType>
+    <id>FSI_MASTER_TYPE</id>
+    <description>Enumeration indicating the master's FSI
+    type</description>
+    <enumerator>
+      <name>MFSI</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>CMFSI</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>NO_MASTER</name>
+      <value>2</value>
+    </enumerator>
+    <default>NO_MASTER</default>
+  </enumerationType>
+  <attribute>
+    <id>CLASS</id>
+    <description>Attribute indicating the target's
+    class</description>
+    <simpleType>
+      <enumeration>
+        <id>CLASS</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <attribute>
+    <id>TYPE</id>
+    <description>Attribute indicating the target's
+    type</description>
+    <simpleType>
+      <enumeration>
+        <id>TYPE</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <attribute>
+    <id>MODEL</id>
+    <description>Attribute indicating the target's
+    model</description>
+    <simpleType>
+      <enumeration>
+        <id>MODEL</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <attribute>
+    <id>ENGINE_TYPE</id>
+    <description>Attribute indicating the target's engine
+    type</description>
+    <simpleType>
+      <enumeration>
+        <id>ENGINE_TYPE</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <attribute>
+    <id>DUMMY_RW</id>
+    <description>Dummy attribute with read/write
+    permissions</description>
+    <simpleType>
+      <uint8_t>
+        <default>5</default>
+      </uint8_t>
+      <array>1,3,5</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_DUMMY_SCRATCH_PLAT_INIT_UINT8</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>DUMMY_WO</id>
+    <description>Dummy attribute with write-only
+    permissions</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>DUMMY_RO</id>
+    <description>Dummy attribute with read-only
+    permissions</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PHYS_PATH</id>
+    <description>Physical hierarchical path to the
+    target</description>
+    <nativeType>
+      <name>EntityPath</name>
+    </nativeType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>AFFINITY_PATH</id>
+    <description>Hierarchical path to the target with respect to
+    logical affinity</description>
+    <nativeType>
+      <name>EntityPath</name>
+    </nativeType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>POWER_PATH</id>
+    <description>Hierarchical path to the target with respect to
+    power</description>
+    <nativeType>
+      <name>EntityPath</name>
+    </nativeType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PRIMARY_CAPABILITIES</id>
+    <description>Attribute which describes capabilities of a
+    target</description>
+    <complexType>
+      <description>Structure which defines a target's primary
+      capabilities. A target can only support at most FSI SCOM and
+      one of the other two SCOM types. Applicable for all targets.
+      Structure is read-only.</description>
+      <field>
+        <name>supportsFsiScom</name>
+        <description>0b0: Target does not support FSI SCOM; 0b1:
+        Target supports FSI SCOM</description>
+        <type>uint8_t</type>
+        <bits>1</bits>
+        <default>0</default>
+      </field>
+      <field>
+        <name>supportsXscom</name>
+        <description>0b0: Target does not support XSCOM; 0b1:
+        Target supports FSI XSCOM</description>
+        <type>uint8_t</type>
+        <bits>1</bits>
+        <default>0</default>
+      </field>
+      <field>
+        <name>supportsInbandScom</name>
+        <description>0b0: Target does not support inband
+        SCOM</description>
+        <type>uint8_t</type>
+        <bits>1</bits>
+        <default>0</default>
+      </field>
+      <field>
+        <name>reserved</name>
+        <description>Reserved for future use</description>
+        <type>uint8_t</type>
+        <bits>5</bits>
+        <default>0</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>CPU_ATTR</id>
+    <description>CPU Attribute</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>FSI_MASTER_CHIP</id>
+    <description>Chip which contains the FSI master logic that
+    drives this slave when booting from the default master
+    processor</description>
+    <nativeType>
+      <name>EntityPath</name>
       <default>physical:sys-0</default>
-    </field>
-    <field>
-      <name>className</name>
-      <description>Class for testing purposes</description>
-      <type>CLASS</type>
-      <default>CHIP</default>
-    </field>
-    <field>
-      <name>uint8</name>
-      <description>Test uint8</description>
-      <type>uint8_t</type>
-      <default>0xAB</default>
-    </field>
-    <field>
-      <name>uint16</name>
-      <description>Test uint16</description>
-      <type>uint16_t</type>
-      <default>0xABCD</default>
-    </field>
-    <field>
-      <name>uint32</name>
-      <description>Test uint32</description>
-      <type>uint32_t</type>
-      <default>0xABCDEF01</default>
-    </field>
-    <field>
-      <name>uint64</name>
-      <description>Test uint64</description>
-      <type>uint64_t</type>
-      <default>0xABCDEF0123456789</default>
-    </field>
-    <field>
-      <name>int8</name>
-      <description>Test int8</description>
-      <type>int8_t</type>
-      <default>-124</default>
-    </field>
-    <field>
-      <name>int16</name>
-      <description>Test int16</description>
-      <type>int16_t</type>
-      <default>-32764</default>
-    </field>
-    <field>
-      <name>int32</name>
-      <description>Test int32</description>
-      <type>int32_t</type>
-      <default>-2147483644</default>
-    </field>
-    <field>
-      <name>int64</name>
-      <description>Test int64</description>
-      <type>int64_t</type>
-      <default>-9223372036854775804</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>DECONFIG_GARDABLE</id>
-  <description>If the Target is directly deconfigurable and
-  GARDable; target may still be deconfigured in 'by association'
-  processing.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>ISTEP_MODE</id>
-  <description>If True, puts HostBoot into SPLess SingleStep
-  mode.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_ISTEP_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>EEPROM_VPD_PRIMARY_INFO</id>
-  <description>Information needed to address the EEPROM
-  slaves</description>
-  <complexType>
-    <description>Structure to define the addressing for an I2C
-    slave device.</description>
-    <field>
-      <name>i2cMasterPath</name>
-      <description>Entity path to the chip that contains the I2C
-      master</description>
-      <type>EntityPath</type>
+    </nativeType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>ALTFSI_MASTER_CHIP</id>
+    <description>Chip which contains the FSI master logic that
+    drives this slave when booting from the alternate master
+    processor</description>
+    <nativeType>
+      <name>EntityPath</name>
       <default>physical:sys-0</default>
-    </field>
-    <field>
-      <name>port</name>
-      <description>Port from the I2C Master device. This is a 6-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>devAddr</name>
-      <description>Device address on the I2C bus. This is a 7-bit
-      value, but then shifted 1 bit left.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>engine</name>
-      <description>I2C master engine. This is a 2-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>byteAddrOffset</name>
-      <description>The number of bytes a device requires to set its
-      internal address/offset. DDR4 DIMMs require a special EEPROM
-      page switching mechanic denoted here by a value of 1 0 = Zero
-      Byte Addressing 1 = One Byte Addressing with page select 2 =
-      Two Byte Addressing 3 = OneByte Addressing with no page
-      select</description>
-      <type>uint8_t</type>
-      <default>0x02</default>
-    </field>
-    <field>
-      <name>maxMemorySizeKB</name>
-      <description>The number of kilobytes a device can hold.
-      'Zero' value possible for some devices.</description>
-      <type>uint64_t</type>
-      <default>0x0</default>
-    </field>
-    <field>
-      <name>chipCount</name>
-      <description>The number of chips making up an eeprom
-      device.</description>
-      <type>uint8_t</type>
-      <default>0x01</default>
-    </field>
-    <field>
-      <name>writePageSize</name>
-      <description>The maximum number of bytes that can be written
-      to a device at one time. 'Zero' value means no maximum value
-      is expected or checked.</description>
-      <type>uint64_t</type>
-      <default>0x0</default>
-    </field>
-    <field>
-      <name>writeCycleTime</name>
-      <description>The amount of time in milliseconds a device
-      requires on the completion of a write command to update its
-      internal memory.</description>
-      <type>uint64_t</type>
-      <default>0xA</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>EEPROM_VPD_BACKUP_INFO</id>
-  <description>Information needed to address the EERPROM
-  slaves</description>
-  <complexType>
-    <description>Structure to define the addressing for an I2C
-    slave device.</description>
-    <field>
-      <name>i2cMasterPath</name>
-      <description>Entity path to the chip that contains the I2C
-      master</description>
-      <type>EntityPath</type>
-      <default>physical:sys-0</default>
-    </field>
-    <field>
-      <name>port</name>
-      <description>Port from the I2C Master device. This is a 6-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>devAddr</name>
-      <description>Device address on the I2C bus. This is a 7-bit
-      value, but then shifted 1 bit left.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>engine</name>
-      <description>I2C master engine. This is a 2-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>byteAddrOffset</name>
-      <description>The number of bytes a device requires to set its
-      internal address/offset.</description>
-      <type>uint8_t</type>
-      <default>0x02</default>
-    </field>
-    <field>
-      <name>maxMemorySizeKB</name>
-      <description>The number of kilobytes a device can hold.
-      'Zero' value possible for some devices.</description>
-      <type>uint64_t</type>
-      <default>0x0</default>
-    </field>
-    <field>
-      <name>chipCount</name>
-      <description>The number of chips making up an eeprom
-      device.</description>
-      <type>uint8_t</type>
-      <default>0x01</default>
-    </field>
-    <field>
-      <name>writePageSize</name>
-      <description>The maximum number of bytes that can be written
-      to a device at one time. 'Zero' value means no maximum value
-      is expected or checked.</description>
-      <type>uint64_t</type>
-      <default>0x0</default>
-    </field>
-    <field>
-      <name>writeCycleTime</name>
-      <description>The amount of time in milliseconds a device
-      requires on the completion of a write command to update its
-      internal memory.</description>
-      <type>uint64_t</type>
-      <default>0xA</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>EEPROM_SBE_PRIMARY_INFO</id>
-  <description>Information needed to address the EERPROM
-  slaves</description>
-  <complexType>
-    <description>Structure to define the addressing for an I2C
-    slave device.</description>
-    <field>
-      <name>i2cMasterPath</name>
-      <description>Entity path to the chip that contains the I2C
-      master</description>
-      <type>EntityPath</type>
-      <default>physical:sys-0</default>
-    </field>
-    <field>
-      <name>port</name>
-      <description>Port from the I2C Master device. This is a 6-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>devAddr</name>
-      <description>Device address on the I2C bus. This is a 7-bit
-      value, but then shifted 1 bit left.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>engine</name>
-      <description>I2C master engine. This is a 2-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>byteAddrOffset</name>
-      <description>The number of bytes a device requires to set its
-      internal address/offset.</description>
-      <type>uint8_t</type>
-      <default>0x02</default>
-    </field>
-    <field>
-      <name>maxMemorySizeKB</name>
-      <description>The number of kilobytes a device can hold.
-      'Zero' value possible for some devices.</description>
-      <type>uint64_t</type>
-      <default>0x100</default>
-    </field>
-    <field>
-      <name>chipCount</name>
-      <description>The number of chips making up an eeprom
-      device.</description>
-      <type>uint8_t</type>
-      <default>0x04</default>
-    </field>
-    <field>
-      <name>writePageSize</name>
-      <description>The maximum number of bytes that can be written
-      to a device at one time. 'Zero' value means no maximum value
-      is expected or checked.</description>
-      <type>uint64_t</type>
-      <default>0x0</default>
-    </field>
-    <field>
-      <name>writeCycleTime</name>
-      <description>The amount of time in milliseconds a device
-      requires on the completion of a write command to update its
-      internal memory.</description>
-      <type>uint64_t</type>
-      <default>0x0</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>EEPROM_SBE_BACKUP_INFO</id>
-  <description>Information needed to address the EERPROM
-  slaves</description>
-  <complexType>
-    <description>Structure to define the addressing for an I2C
-    slave device.</description>
-    <field>
-      <name>i2cMasterPath</name>
-      <description>Entity path to the chip that contains the I2C
-      master</description>
-      <type>EntityPath</type>
-      <default>physical:sys-0</default>
-    </field>
-    <field>
-      <name>port</name>
-      <description>Port from the I2C Master device. This is a 6-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>devAddr</name>
-      <description>Device address on the I2C bus. This is a 7-bit
-      value, but then shifted 1 bit left.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>engine</name>
-      <description>I2C master engine. This is a 2-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>byteAddrOffset</name>
-      <description>The number of bytes a device requires to set its
-      internal address/offset.</description>
-      <type>uint8_t</type>
-      <default>0x02</default>
-    </field>
-    <field>
-      <name>maxMemorySizeKB</name>
-      <description>The number of kilobytes a device can hold.
-      'Zero' value possible for some devices.</description>
-      <type>uint64_t</type>
-      <default>0x100</default>
-    </field>
-    <field>
-      <name>chipCount</name>
-      <description>The number of chips making up an eeprom
-      device.</description>
-      <type>uint8_t</type>
-      <default>0x04</default>
-    </field>
-    <field>
-      <name>writePageSize</name>
-      <description>The maximum number of bytes that can be written
-      to a device at one time. 'Zero' value means no maximum value
-      is expected or checked.</description>
-      <type>uint64_t</type>
-      <default>0x0</default>
-    </field>
-    <field>
-      <name>writeCycleTime</name>
-      <description>The amount of time in milliseconds a device
-      requires on the completion of a write command to update its
-      internal memory.</description>
-      <type>uint64_t</type>
-      <default>0x0</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>TEMP_SENSOR_I2C_CONFIG</id>
-  <description>Information needed to address an I2C slave
-  device</description>
-  <complexType>
-    <description>Structure to define the addressing for an I2C
-    slave device.</description>
-    <field>
-      <name>i2cMasterPath</name>
-      <description>Entity path to the chip that contains the I2C
-      master</description>
-      <type>EntityPath</type>
-      <default>physical:sys-0</default>
-    </field>
-    <field>
-      <name>engine</name>
-      <description>I2C master engine. This is a 2-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>port</name>
-      <description>Port from the I2C Master device. This is a 6-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-    <field>
-      <name>devAddr</name>
-      <description>Device address on the I2C bus. This is a 7-bit
-      value, but then shifted 1 bit left.</description>
-      <type>uint8_t</type>
-      <default>0x80</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>TPM_INFO</id>
-  <description>Information needed to address the TPM
-  slaves</description>
-  <complexType>
-    <description>Structure to define the addressing for an I2C
-    TPM.</description>
-    <field>
-      <name>tpmEnabled</name>
-      <description>Boolean indicating whether this TPM is available
-      in the system</description>
-      <type>uint8_t</type>
-      <default>0x0</default>
-    </field>
-    <field>
-      <name>i2cMasterPath</name>
-      <description>Entity path to the chip that contains the I2C
-      master</description>
-      <type>EntityPath</type>
-      <default>physical:sys-0</default>
-    </field>
-    <field>
-      <name>port</name>
-      <description>Port from the I2C Master device. This is a 6-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x01</default>
-    </field>
-    <field>
-      <name>devAddrLocality0</name>
-      <description>Device address on the I2C bus for Locality 0.
-      This is a 7-bit value, but then shifted 1 bit
-      left.</description>
-      <type>uint8_t</type>
-      <default>0xAE</default>
-    </field>
-    <field>
-      <name>devAddrLocality1</name>
-      <description>Device address on the I2C bus for Locality 1.
-      This is a 7-bit value, but then shifted 1 bit
-      left.</description>
-      <type>uint8_t</type>
-      <default>0xA8</default>
-    </field>
-    <field>
-      <name>devAddrLocality2</name>
-      <description>Device address on the I2C bus for Locality 2.
-      This is a 7-bit value, but then shifted 1 bit
-      left.</description>
-      <type>uint8_t</type>
-      <default>0xAA</default>
-    </field>
-    <field>
-      <name>devAddrLocality3</name>
-      <description>Device address on the I2C bus for Locality 3.
-      This is a 7-bit value, but then shifted 1 bit
-      left.</description>
-      <type>uint8_t</type>
-      <default>0xA4</default>
-    </field>
-    <field>
-      <name>devAddrLocality4</name>
-      <description>Device address on the I2C bus for Locality 4.
-      This is a 7-bit value, but then shifted 1 bit
-      left.</description>
-      <type>uint8_t</type>
-      <default>0xA6</default>
-    </field>
-    <field>
-      <name>engine</name>
-      <description>I2C master engine. This is a 2-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0x00</default>
-    </field>
-    <field>
-      <name>byteAddrOffset</name>
-      <description>The number of bytes a device requires to set its
-      internal address/offset.</description>
-      <type>uint8_t</type>
-      <default>0x01</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>FSI_GP_REG_SCOM_ACCESS</id>
-  <description>attribute indicating if the chip's FSI GP regs have
-  scom access</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FSI_GP_REG_SCOM_ACCESS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>CHIP_UNIT</id>
-  <description>A unit (chiplet) 's offset number within the
-  chip.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_CHIP_UNIT_POS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>POSITION</id>
-  <description>Position of target relative to node</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MBA_PORT</id>
-  <description>MBA port this DIMM is connected to</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MBA_PORT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MBA_DIMM</id>
-  <description>MBA port DIMM number of this DIMM</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MBA_DIMM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>CEN_DQ_TO_DIMM_CONN_DQ</id>
-  <description>Centaur DQ to DIMM connector DQ mapping for a JEDEC
-  DIMM. Uint8 value for each Centaur DQ (0-79). The value is the
-  corresponding DIMM Connector DQ.</description>
-  <simpleType>
-    <uint8_t>
-      <!-- Default is 1:1 mapping, DQ0-DQ0, DQ1-DQ1 etc -->
-      <!-- Data will eventually come from MRW -->
-      <default>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,
-      20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,
-      40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,
-      60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79</default>
-    </uint8_t>
-    <array>80</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>PROC_EPS_TABLE_TYPE</id>
-  <description>Enumeration indicating the
-  PROC_EPS_TABLE_TYPE</description>
-  <enumerator>
-    <name>EPS_TYPE_LE</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>EPS_TYPE_HE</name>
-    <value>2</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>PROC_EPS_TABLE_TYPE</id>
-  <description>System attribute. Processor epsilon table type. Used
-  to calculate the processor nest epsilon register
-  values.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_EPS_TABLE_TYPE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>PROC_FABRIC_PUMP_MODE</id>
-  <description>Enumeration indicating the
-  PROC_FABRIC_PUMP_MODE</description>
-  <enumerator>
-    <name>MODE1</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>MODE2</name>
-    <value>2</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>PROC_FABRIC_PUMP_MODE</id>
-  <description>System attribute. Processor SMP Fabric broadcast
-  scope configuration. MODE1 = default = chip/group/system/remote
-  group/foreign. MODE2 = group/system/remote group/foreign.
-  Provided by the Machine Readable Workbook.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FABRIC_PUMP_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>ALL_MCS_IN_INTERLEAVING_GROUP</id>
-  <description>System attribute. If all MCS chiplets are in an
-  interleaving group (1=true, 0=false). - If true the SMP fabric is
-  setup in normal mode and multiple MCSs are grouped (disallowing
-  systems with memory only under 1 MCS (i.e. systems with a single
-  C-DIMM)) - If false the SMP fabric is setup in checkerboard mode.
-  Provided by the Machine Readable Workbook. This attribute is
-  based on Machine-Type-Model (MTM) and is setup by the service
-  processor.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0x00</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_ALL_MCS_IN_INTERLEAVING_GROUP</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FABRIC_NODE_ID</id>
-  <description>DEPRECATED!!!! Chip attribute. Logical fabric node
-  the chip belongs to. Provided by the Machine Readable Workbook.
-  Can vary across drawers.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FABRIC_NODE_ID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FABRIC_GROUP_ID</id>
-  <description>Chip attribute. Logical fabric group the chip
-  belongs to. Provided by the Machine Readable Workbook. Can vary
-  across drawers.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FABRIC_GROUP_ID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_EFF_FABRIC_GROUP_ID</id>
-  <description>Effective fabric group ID associated with this chip.
-  Directly drives programming of chip memory map layout. Compared
-  with ATTR_PROC_FABRIC_GROUP_ID to configure FBC XOR
-  masking.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_EFF_FABRIC_GROUP_ID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FABRIC_CHIP_ID</id>
-  <description>Chip attribute. Logical fabric chip id for this chip
-  (position within the fabric). Provided by the Machine Readable
-  Workbook. Can vary across drawers.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FABRIC_CHIP_ID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_EFF_FABRIC_CHIP_ID</id>
-  <description>Effective fabric chip ID associated with this chip.
-  Directly drives programming of chip memory map layout. Compared
-  with ATTR_PROC_FABRIC_CHIP_ID to configure FBC XOR
-  masking.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_EFF_FABRIC_CHIP_ID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>CHIP_HAS_SBE</id>
-  <description>Chip attribute. If true, the chip has an SBE and the
-  associated registers. Provided by the Machine Readable
-  Workbook.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_CHIP_HAS_SBE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FREQ_PROC_REFCLOCK</id>
-  <description>System attribute. The frequency of the processor
-  refclock in MHz. Provided by the MRW.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FREQ_PROC_REFCLOCK</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FREQ_PROC_REFCLOCK_KHZ</id>
-  <description>System attribute. The frequency of the processor
-  refclock in KHz. Provided by the MRW.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FREQ_PROC_REFCLOCK_KHZ</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FREQ_MEM_REFCLOCK</id>
-  <description>System attribute. The frequency of the memory
-  refclock in MHz. Provided by the MRW.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FREQ_MEM_REFCLOCK</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>DPO_MIN_FREQ_PERCENT</id>
-  <description>Defines a negative percentage value that is applied
-  to the ATTR_NOMINAL_FREQ_MHZ determined from MVPD #V. It is used
-  to explicitly raise the value of MIN_FREQ_MHZ above what is
-  specified by MVPD #V data. On FSP systems this is sourced from
-  the power_management def file. Value must be between 0 and 100. A
-  value of zero indicates no override.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>FREQ_PB_MHZ</id>
-  <description>System attribute. The frequency of a processor's PB
-  chiplet in MHz. This is the same for all PB chiplets in the
-  system. Provided by the MRW.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FREQ_PB_MHZ</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FREQ_A_MHZ</id>
-  <description>System attribute. The frequency of a processor's
-  A-bus chiplet in MHz. This is the same for all A-bus chiplets in
-  the system. Provided by the MRW.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x1900</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FREQ_A_MHZ</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FREQ_X_MHZ</id>
-  <description>System attribute. The frequency of a processor's
-  X-bus chiplet in MHz. This is the same for all X-bus chiplets in
-  the system. Provided by the MRW.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FREQ_X_MHZ</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>HUID</id>
-  <description>Hardware Unit ID SSSSNNNNTTTTTTTTiiiiiiiiiiiiiiii
-  S=System N=Node Number T=Target Type (matches TYPE attribute)
-  i=Instance/Sequence number of target, relative to
-  node</description>
-  <simpleType>
-    <uint32_t />
-    <default>0xFFFFFFFF</default>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>SP_FUNCTIONS</id>
-  <description>Attribute which describes what the SP is or is not
-  doing in this system</description>
-  <complexType>
-    <description>Structure which defines a system's SP functions.
-    Applicable for System target only. Structure is
-    read-only.</description>
-    <field>
-      <name>baseServices</name>
-      <description>If this flag is set then mailboxEnabled MUST
-      also be set 0b0: SP does not support for VPD, payload, ATTR
-      sync, VDDR, TOD; 0b1: SP supports VPD, payload, ATTR sync,
-      VDDR, TOD</description>
-      <type>uint32_t</type>
-      <bits>1</bits>
-      <default>1</default>
-    </field>
-    <field>
-      <name>fsiSlaveInit</name>
-      <description>0b0: SP does not initialize FSI slave logic,
-      Hostboot must; 0b1: SP does initialize FSI slave logic so
-      Hostboot should not</description>
-      <type>uint32_t</type>
-      <bits>1</bits>
-      <default>1</default>
-    </field>
-    <field>
-      <name>mailboxEnabled</name>
-      <description>0b0: There is no SP mailbox support; 0b1: There
-      is SP mailbox support</description>
-      <type>uint32_t</type>
-      <bits>1</bits>
-      <default>0</default>
-    </field>
-    <field>
-      <name>fsiMasterInit</name>
-      <description>0b0: SP does not initialize FSI master logic,
-      Hostboot must; 0b1: SP does initialize FSI master logic so
-      Hostboot should not</description>
-      <type>uint32_t</type>
-      <bits>1</bits>
-      <default>1</default>
-    </field>
-    <field>
-      <name>hardwareChangeDetection</name>
-      <description>0b0: SP does not perform hardware change
-      detection, Hostboot must; 0b1: SP does perform hardware
-      change detection (HCDB) so Hostboot should not</description>
-      <type>uint32_t</type>
-      <bits>1</bits>
-      <default>1</default>
-    </field>
-    <field>
-      <name>powerLineDisturbance</name>
-      <description>0b0: SP does not perform Power Line Disturbance
-      (PLD) detection, Hostboot must; 0b1: SP does perform Power
-      Line Disturbance (PLD) detection so Hostboot should
-      not</description>
-      <type>uint32_t</type>
-      <bits>1</bits>
-      <default>1</default>
-    </field>
-    <field>
-      <name>reserved</name>
-      <description>Reserved for future use</description>
-      <type>uint32_t</type>
-      <bits>26</bits>
-      <default>0</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>HB_SETTINGS</id>
-  <description>Attribute which describes how the SP has configured
-  features in Hostboot.</description>
-  <complexType>
-    <description>Structure which defines a system's HB settings.
-    Applicable for System target only.</description>
-    <field>
-      <name>traceContinuous</name>
-      <description>Enable / Disable continuous trace. 0b0:
-      Continuous trace is disabled. 0b1: Continuous trace is
-      enabled.</description>
-      <type>uint8_t</type>
-      <bits>1</bits>
-      <default>0</default>
-    </field>
-    <field>
-      <name>traceScanDebug</name>
-      <description>Override trace debug selection for SCAN
-      component. 0b0: TRACS entries for SCAN have default behavior.
-      0b1: TRACS entries for SCAN are enabled.</description>
-      <type>uint8_t</type>
-      <bits>1</bits>
-      <default>0</default>
-    </field>
-    <field>
-      <name>traceFapiDebug</name>
-      <description>Override trace debug selection for DBG
-      component. 0b0: TRACS entries for DBG have default behavior.
-      0b1: TRACS entries for DBG are enabled.</description>
-      <type>uint8_t</type>
-      <bits>1</bits>
-      <default>0</default>
-    </field>
-    <field>
-      <name>reserved</name>
-      <description>Reserved for future use</description>
-      <type>uint8_t</type>
-      <bits>5</bits>
-      <default>0</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<!-- Begin attributes (4) to test string support -->
-<!-- End attributes (4) to test string support -->
-<attribute>
-  <id>FAPI_NAME</id>
-  <description>Common name across FAPI environments chip target
-  -&gt; pu:k0:n0:s0:p00 DIMM target -&gt; dimm:k0:n0:s0:p00 chip
-  unit target -&gt; pu.core:k0:n0:s0:p00:c0 cage/system target
-  -&gt; k0 (chip type).(unit type):k(cage,always zero for
-  us):n(node/drawer) :s(slot,always zero for us):p(chip
-  position):c(core/unit position) pu = generic
-  processor</description>
-  <simpleType>
-    <string>
-      <default>unknown</default>
-      <sizeInclNull>64</sizeInclNull>
-    </string>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VPD_REC_NUM</id>
-  <description>Record offset for this target's VPD</description>
-  <simpleType>
-    <uint16_t>
-      <default>0xFFFF</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PEER_TARGET</id>
-  <description>Peer target's address of a A/X-bus connection. NULL
-  means address 0 for no peer target. If a target instance
-  overrides the default with the peer target's PHYS_PATH. The
-  target compiler will convert the valid PHYS_PATH string into the
-  runtime virtual address of the peer target
-  instance.</description>
-  <simpleType>
-    <Target_t>
-      <default>NULL</default>
-    </Target_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>PAYLOAD_KIND</id>
-  <description>Enumeration indicating what kind of payload is to be
-  started</description>
-  <enumerator>
-    <name>UNKNOWN</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>PHYP</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>SAPPHIRE</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>NONE</name>
-    <value>3</value>
-  </enumerator>
-  <default>UNKNOWN</default>
-</enumerationType>
-<attribute>
-  <id>PAYLOAD_KIND</id>
-  <description>Attribute indicating what kind of payload is to be
-  started.</description>
-  <simpleType>
-    <enumeration>
-      <id>PAYLOAD_KIND</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hasStringConversion />
-</attribute>
-<!--    TARGETING attributes to support mss_setup_bars and proc_setup_bars  -->
-<!-- ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
+    </nativeType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>FSI_MASTER_TYPE</id>
+    <description>Type of Master FSI connection to this slave (MFSI
+    or cMFSI)</description>
+    <simpleType>
+      <enumeration>
+        <id>FSI_MASTER_TYPE</id>
+        <default>NO_MASTER</default>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+  </attribute>
+  <attribute>
+    <id>FSI_MASTER_PORT</id>
+    <description>Which port is this chip hanging off of when
+    booting from the default master processor</description>
+    <simpleType>
+      <uint8_t>
+        <default>0xFF</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>ALTFSI_MASTER_PORT</id>
+    <description>Which port is this chip hanging off of when
+    booting from the alternate master processor</description>
+    <simpleType>
+      <uint8_t>
+        <default>0xFF</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>I2C_SLAVE_ADDRESS</id>
+    <description>I2C Slave Address</description>
+    <simpleType>
+      <uint8_t>
+        <default>0x00</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_I2C_SLAVE_ADDRESS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FSI_SLAVE_CASCADE</id>
+    <description>Slave cascade position</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>FSI_OPTION_FLAGS</id>
+    <description>Reserved for any special flags we might need to
+    access FSI</description>
+    <complexType>
+      <description>FSI flags</description>
+      <field>
+        <name>flipPort</name>
+        <description>Set on FSI master chips (procs) if that chip
+        uses slaveB to attach to the acting master
+        chip.</description>
+        <type>uint16_t</type>
+        <bits>1</bits>
+        <default>0</default>
+      </field>
+      <field>
+        <name>reserved</name>
+        <description>Reserved for future expansion</description>
+        <type>uint16_t</type>
+        <bits>15</bits>
+        <default>0</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>EXECUTION_PLATFORM</id>
+    <description>Which execution platform the HW Procedure is
+    running on Some HWPs (e.g. special wakeup) use different
+    registers for different platforms to avoid arbitration problems
+    when multiple platforms do the same thing concurrently HOST =
+    0x01, FSP = 0x02, OCC = 0x03</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_EXECUTION_PLATFORM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IS_SIMULATION</id>
+    <description>env: 1 = Awan/HWSimulator. 0 =
+    Simics/RealHW.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IS_SIMULATION</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_FLAG</id>
+    <description>HardWare Availability Service State Changed
+    Attribute. Keeps track of changedSinceChecked state, indicates
+    if the target has changed since last checked by the appropriate
+    service. This is a bit field of flags (see HWAS_CHANGED_BIT
+    enumeration that follows).</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+    <description>HardWare Availability Service State Changed Mask.
+    Used when a target changes (ie, via HCDB change) to set the
+    HWAS_STATE_CHANGED_FLAG, so that the appropriate services will
+    all handle the change. This is a bit field of flags (see
+    HWAS_CHANGED_BIT enumeration that follows).</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>HWAS_CHANGED_BIT</id>
+    <description>Enumeration indicating the services that are
+    concerned with target changes (ie, via HCDB change). The values
+    can be combined using a bitwise 'OR'.</description>
+    <enumerator>
+      <name>GARD</name>
+      <value>0x00000001</value>
+    </enumerator>
+    <enumerator>
+      <name>MEMDIAG</name>
+      <value>0x00000002</value>
+    </enumerator>
+    <enumerator>
+      <name>PSIDIAG</name>
+      <value>0x00000004</value>
+    </enumerator>
+    <!-- combination of all DIAG values -->
+    <!-- if you add a DIAG flag above, add the bit in the mask below -->
+    <enumerator>
+      <name>DIAG_MASK</name>
+      <value>0x00000006</value>
+    </enumerator>
+    <enumerator>
+      <name>HOSTSVC_HBEL</name>
+      <value>0x00000008</value>
+    </enumerator>
+  </enumerationType>
+  <!-- For POD Testing -->
+  <attribute>
+    <id>NUMERIC_POD_TYPE_TEST</id>
+    <description>Attribute which tests numeric POD
+    types</description>
+    <complexType>
+      <description>Numeric POD type test structure</description>
+      <field>
+        <name>fsiPath</name>
+        <description>Entity path for testing purposes</description>
+        <type>EntityPath</type>
+        <default>physical:sys-0</default>
+      </field>
+      <field>
+        <name>className</name>
+        <description>Class for testing purposes</description>
+        <type>CLASS</type>
+        <default>CHIP</default>
+      </field>
+      <field>
+        <name>uint8</name>
+        <description>Test uint8</description>
+        <type>uint8_t</type>
+        <default>0xAB</default>
+      </field>
+      <field>
+        <name>uint16</name>
+        <description>Test uint16</description>
+        <type>uint16_t</type>
+        <default>0xABCD</default>
+      </field>
+      <field>
+        <name>uint32</name>
+        <description>Test uint32</description>
+        <type>uint32_t</type>
+        <default>0xABCDEF01</default>
+      </field>
+      <field>
+        <name>uint64</name>
+        <description>Test uint64</description>
+        <type>uint64_t</type>
+        <default>0xABCDEF0123456789</default>
+      </field>
+      <field>
+        <name>int8</name>
+        <description>Test int8</description>
+        <type>int8_t</type>
+        <default>-124</default>
+      </field>
+      <field>
+        <name>int16</name>
+        <description>Test int16</description>
+        <type>int16_t</type>
+        <default>-32764</default>
+      </field>
+      <field>
+        <name>int32</name>
+        <description>Test int32</description>
+        <type>int32_t</type>
+        <default>-2147483644</default>
+      </field>
+      <field>
+        <name>int64</name>
+        <description>Test int64</description>
+        <type>int64_t</type>
+        <default>-9223372036854775804</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>DECONFIG_GARDABLE</id>
+    <description>If the Target is directly deconfigurable and
+    GARDable; target may still be deconfigured in 'by association'
+    processing.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>ISTEP_MODE</id>
+    <description>If True, puts HostBoot into SPLess SingleStep
+    mode.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_ISTEP_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>EEPROM_VPD_PRIMARY_INFO</id>
+    <description>Information needed to address the EEPROM
+    slaves</description>
+    <complexType>
+      <description>Structure to define the addressing for an I2C
+      slave device.</description>
+      <field>
+        <name>i2cMasterPath</name>
+        <description>Entity path to the chip that contains the I2C
+        master</description>
+        <type>EntityPath</type>
+        <default>physical:sys-0</default>
+      </field>
+      <field>
+        <name>port</name>
+        <description>Port from the I2C Master device. This is a
+        6-bit value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>devAddr</name>
+        <description>Device address on the I2C bus. This is a 7-bit
+        value, but then shifted 1 bit left.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>engine</name>
+        <description>I2C master engine. This is a 2-bit
+        value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>byteAddrOffset</name>
+        <description>The number of bytes a device requires to set
+        its internal address/offset. DDR4 DIMMs require a special
+        EEPROM page switching mechanic denoted here by a value of 1
+        0 = Zero Byte Addressing 1 = One Byte Addressing with page
+        select 2 = Two Byte Addressing 3 = OneByte Addressing with
+        no page select</description>
+        <type>uint8_t</type>
+        <default>0x02</default>
+      </field>
+      <field>
+        <name>maxMemorySizeKB</name>
+        <description>The number of kilobytes a device can hold.
+        'Zero' value possible for some devices.</description>
+        <type>uint64_t</type>
+        <default>0x0</default>
+      </field>
+      <field>
+        <name>chipCount</name>
+        <description>The number of chips making up an eeprom
+        device.</description>
+        <type>uint8_t</type>
+        <default>0x01</default>
+      </field>
+      <field>
+        <name>writePageSize</name>
+        <description>The maximum number of bytes that can be
+        written to a device at one time. 'Zero' value means no
+        maximum value is expected or checked.</description>
+        <type>uint64_t</type>
+        <default>0x0</default>
+      </field>
+      <field>
+        <name>writeCycleTime</name>
+        <description>The amount of time in milliseconds a device
+        requires on the completion of a write command to update its
+        internal memory.</description>
+        <type>uint64_t</type>
+        <default>0xA</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>EEPROM_VPD_BACKUP_INFO</id>
+    <description>Information needed to address the EERPROM
+    slaves</description>
+    <complexType>
+      <description>Structure to define the addressing for an I2C
+      slave device.</description>
+      <field>
+        <name>i2cMasterPath</name>
+        <description>Entity path to the chip that contains the I2C
+        master</description>
+        <type>EntityPath</type>
+        <default>physical:sys-0</default>
+      </field>
+      <field>
+        <name>port</name>
+        <description>Port from the I2C Master device. This is a
+        6-bit value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>devAddr</name>
+        <description>Device address on the I2C bus. This is a 7-bit
+        value, but then shifted 1 bit left.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>engine</name>
+        <description>I2C master engine. This is a 2-bit
+        value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>byteAddrOffset</name>
+        <description>The number of bytes a device requires to set
+        its internal address/offset.</description>
+        <type>uint8_t</type>
+        <default>0x02</default>
+      </field>
+      <field>
+        <name>maxMemorySizeKB</name>
+        <description>The number of kilobytes a device can hold.
+        'Zero' value possible for some devices.</description>
+        <type>uint64_t</type>
+        <default>0x0</default>
+      </field>
+      <field>
+        <name>chipCount</name>
+        <description>The number of chips making up an eeprom
+        device.</description>
+        <type>uint8_t</type>
+        <default>0x01</default>
+      </field>
+      <field>
+        <name>writePageSize</name>
+        <description>The maximum number of bytes that can be
+        written to a device at one time. 'Zero' value means no
+        maximum value is expected or checked.</description>
+        <type>uint64_t</type>
+        <default>0x0</default>
+      </field>
+      <field>
+        <name>writeCycleTime</name>
+        <description>The amount of time in milliseconds a device
+        requires on the completion of a write command to update its
+        internal memory.</description>
+        <type>uint64_t</type>
+        <default>0xA</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>EEPROM_SBE_PRIMARY_INFO</id>
+    <description>Information needed to address the EERPROM
+    slaves</description>
+    <complexType>
+      <description>Structure to define the addressing for an I2C
+      slave device.</description>
+      <field>
+        <name>i2cMasterPath</name>
+        <description>Entity path to the chip that contains the I2C
+        master</description>
+        <type>EntityPath</type>
+        <default>physical:sys-0</default>
+      </field>
+      <field>
+        <name>port</name>
+        <description>Port from the I2C Master device. This is a
+        6-bit value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>devAddr</name>
+        <description>Device address on the I2C bus. This is a 7-bit
+        value, but then shifted 1 bit left.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>engine</name>
+        <description>I2C master engine. This is a 2-bit
+        value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>byteAddrOffset</name>
+        <description>The number of bytes a device requires to set
+        its internal address/offset.</description>
+        <type>uint8_t</type>
+        <default>0x02</default>
+      </field>
+      <field>
+        <name>maxMemorySizeKB</name>
+        <description>The number of kilobytes a device can hold.
+        'Zero' value possible for some devices.</description>
+        <type>uint64_t</type>
+        <default>0x100</default>
+      </field>
+      <field>
+        <name>chipCount</name>
+        <description>The number of chips making up an eeprom
+        device.</description>
+        <type>uint8_t</type>
+        <default>0x04</default>
+      </field>
+      <field>
+        <name>writePageSize</name>
+        <description>The maximum number of bytes that can be
+        written to a device at one time. 'Zero' value means no
+        maximum value is expected or checked.</description>
+        <type>uint64_t</type>
+        <default>0x0</default>
+      </field>
+      <field>
+        <name>writeCycleTime</name>
+        <description>The amount of time in milliseconds a device
+        requires on the completion of a write command to update its
+        internal memory.</description>
+        <type>uint64_t</type>
+        <default>0x0</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>EEPROM_SBE_BACKUP_INFO</id>
+    <description>Information needed to address the EERPROM
+    slaves</description>
+    <complexType>
+      <description>Structure to define the addressing for an I2C
+      slave device.</description>
+      <field>
+        <name>i2cMasterPath</name>
+        <description>Entity path to the chip that contains the I2C
+        master</description>
+        <type>EntityPath</type>
+        <default>physical:sys-0</default>
+      </field>
+      <field>
+        <name>port</name>
+        <description>Port from the I2C Master device. This is a
+        6-bit value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>devAddr</name>
+        <description>Device address on the I2C bus. This is a 7-bit
+        value, but then shifted 1 bit left.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>engine</name>
+        <description>I2C master engine. This is a 2-bit
+        value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>byteAddrOffset</name>
+        <description>The number of bytes a device requires to set
+        its internal address/offset.</description>
+        <type>uint8_t</type>
+        <default>0x02</default>
+      </field>
+      <field>
+        <name>maxMemorySizeKB</name>
+        <description>The number of kilobytes a device can hold.
+        'Zero' value possible for some devices.</description>
+        <type>uint64_t</type>
+        <default>0x100</default>
+      </field>
+      <field>
+        <name>chipCount</name>
+        <description>The number of chips making up an eeprom
+        device.</description>
+        <type>uint8_t</type>
+        <default>0x04</default>
+      </field>
+      <field>
+        <name>writePageSize</name>
+        <description>The maximum number of bytes that can be
+        written to a device at one time. 'Zero' value means no
+        maximum value is expected or checked.</description>
+        <type>uint64_t</type>
+        <default>0x0</default>
+      </field>
+      <field>
+        <name>writeCycleTime</name>
+        <description>The amount of time in milliseconds a device
+        requires on the completion of a write command to update its
+        internal memory.</description>
+        <type>uint64_t</type>
+        <default>0x0</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>TEMP_SENSOR_I2C_CONFIG</id>
+    <description>Information needed to address an I2C slave
+    device</description>
+    <complexType>
+      <description>Structure to define the addressing for an I2C
+      slave device.</description>
+      <field>
+        <name>i2cMasterPath</name>
+        <description>Entity path to the chip that contains the I2C
+        master</description>
+        <type>EntityPath</type>
+        <default>physical:sys-0</default>
+      </field>
+      <field>
+        <name>engine</name>
+        <description>I2C master engine. This is a 2-bit
+        value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>port</name>
+        <description>Port from the I2C Master device. This is a
+        6-bit value.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+      <field>
+        <name>devAddr</name>
+        <description>Device address on the I2C bus. This is a 7-bit
+        value, but then shifted 1 bit left.</description>
+        <type>uint8_t</type>
+        <default>0x80</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>TPM_INFO</id>
+    <description>Information needed to address the TPM
+    slaves</description>
+    <complexType>
+      <description>Structure to define the addressing for an I2C
+      TPM.</description>
+      <field>
+        <name>tpmEnabled</name>
+        <description>Boolean indicating whether this TPM is
+        available in the system</description>
+        <type>uint8_t</type>
+        <default>0x0</default>
+      </field>
+      <field>
+        <name>i2cMasterPath</name>
+        <description>Entity path to the chip that contains the I2C
+        master</description>
+        <type>EntityPath</type>
+        <default>physical:sys-0</default>
+      </field>
+      <field>
+        <name>port</name>
+        <description>Port from the I2C Master device. This is a
+        6-bit value.</description>
+        <type>uint8_t</type>
+        <default>0x01</default>
+      </field>
+      <field>
+        <name>devAddrLocality0</name>
+        <description>Device address on the I2C bus for Locality 0.
+        This is a 7-bit value, but then shifted 1 bit
+        left.</description>
+        <type>uint8_t</type>
+        <default>0xAE</default>
+      </field>
+      <field>
+        <name>devAddrLocality1</name>
+        <description>Device address on the I2C bus for Locality 1.
+        This is a 7-bit value, but then shifted 1 bit
+        left.</description>
+        <type>uint8_t</type>
+        <default>0xA8</default>
+      </field>
+      <field>
+        <name>devAddrLocality2</name>
+        <description>Device address on the I2C bus for Locality 2.
+        This is a 7-bit value, but then shifted 1 bit
+        left.</description>
+        <type>uint8_t</type>
+        <default>0xAA</default>
+      </field>
+      <field>
+        <name>devAddrLocality3</name>
+        <description>Device address on the I2C bus for Locality 3.
+        This is a 7-bit value, but then shifted 1 bit
+        left.</description>
+        <type>uint8_t</type>
+        <default>0xA4</default>
+      </field>
+      <field>
+        <name>devAddrLocality4</name>
+        <description>Device address on the I2C bus for Locality 4.
+        This is a 7-bit value, but then shifted 1 bit
+        left.</description>
+        <type>uint8_t</type>
+        <default>0xA6</default>
+      </field>
+      <field>
+        <name>engine</name>
+        <description>I2C master engine. This is a 2-bit
+        value.</description>
+        <type>uint8_t</type>
+        <default>0x00</default>
+      </field>
+      <field>
+        <name>byteAddrOffset</name>
+        <description>The number of bytes a device requires to set
+        its internal address/offset.</description>
+        <type>uint8_t</type>
+        <default>0x01</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>FSI_GP_REG_SCOM_ACCESS</id>
+    <description>attribute indicating if the chip's FSI GP regs
+    have scom access</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_FSI_GP_REG_SCOM_ACCESS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>CHIP_UNIT</id>
+    <description>A unit (chiplet) 's offset number within the
+    chip.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_CHIP_UNIT_POS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>POSITION</id>
+    <description>Position of target relative to node</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MBA_PORT</id>
+    <description>MBA port this DIMM is connected to</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MBA_PORT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MBA_DIMM</id>
+    <description>MBA port DIMM number of this DIMM</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MBA_DIMM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>CEN_DQ_TO_DIMM_CONN_DQ</id>
+    <description>Centaur DQ to DIMM connector DQ mapping for a
+    JEDEC DIMM. Uint8 value for each Centaur DQ (0-79). The value
+    is the corresponding DIMM Connector DQ.</description>
+    <simpleType>
+      <uint8_t>
+        <!-- Default is 1:1 mapping, DQ0-DQ0, DQ1-DQ1 etc -->
+        <!-- Data will eventually come from MRW -->
+        <default>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,
+        20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,
+        40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,
+        60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79</default>
+      </uint8_t>
+      <array>80</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>PROC_EPS_TABLE_TYPE</id>
+    <description>Enumeration indicating the
+    PROC_EPS_TABLE_TYPE</description>
+    <enumerator>
+      <name>EPS_TYPE_LE</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>EPS_TYPE_HE</name>
+      <value>2</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>PROC_EPS_TABLE_TYPE</id>
+    <description>System attribute. Processor epsilon table type.
+    Used to calculate the processor nest epsilon register
+    values.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_EPS_TABLE_TYPE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>PROC_FABRIC_PUMP_MODE</id>
+    <description>Enumeration indicating the
+    PROC_FABRIC_PUMP_MODE</description>
+    <enumerator>
+      <name>MODE1</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>MODE2</name>
+      <value>2</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>PROC_FABRIC_PUMP_MODE</id>
+    <description>System attribute. Processor SMP Fabric broadcast
+    scope configuration. MODE1 = default = chip/group/system/remote
+    group/foreign. MODE2 = group/system/remote group/foreign.
+    Provided by the Machine Readable Workbook.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FABRIC_PUMP_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>ALL_MCS_IN_INTERLEAVING_GROUP</id>
+    <description>System attribute. If all MCS chiplets are in an
+    interleaving group (1=true, 0=false). - If true the SMP fabric
+    is setup in normal mode and multiple MCSs are grouped
+    (disallowing systems with memory only under 1 MCS (i.e. systems
+    with a single C-DIMM)) - If false the SMP fabric is setup in
+    checkerboard mode. Provided by the Machine Readable Workbook.
+    This attribute is based on Machine-Type-Model (MTM) and is
+    setup by the service processor.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0x00</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_ALL_MCS_IN_INTERLEAVING_GROUP</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FABRIC_NODE_ID</id>
+    <description>DEPRECATED!!!! Chip attribute. Logical fabric node
+    the chip belongs to. Provided by the Machine Readable Workbook.
+    Can vary across drawers.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_FABRIC_NODE_ID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FABRIC_GROUP_ID</id>
+    <description>Chip attribute. Logical fabric group the chip
+    belongs to. Provided by the Machine Readable Workbook. Can vary
+    across drawers.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FABRIC_GROUP_ID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_EFF_FABRIC_GROUP_ID</id>
+    <description>Effective fabric group ID associated with this
+    chip. Directly drives programming of chip memory map layout.
+    Compared with ATTR_PROC_FABRIC_GROUP_ID to configure FBC XOR
+    masking.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_EFF_FABRIC_GROUP_ID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FABRIC_CHIP_ID</id>
+    <description>Chip attribute. Logical fabric chip id for this
+    chip (position within the fabric). Provided by the Machine
+    Readable Workbook. Can vary across drawers.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FABRIC_CHIP_ID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_EFF_FABRIC_CHIP_ID</id>
+    <description>Effective fabric chip ID associated with this
+    chip. Directly drives programming of chip memory map layout.
+    Compared with ATTR_PROC_FABRIC_CHIP_ID to configure FBC XOR
+    masking.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_EFF_FABRIC_CHIP_ID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>CHIP_HAS_SBE</id>
+    <description>Chip attribute. If true, the chip has an SBE and
+    the associated registers. Provided by the Machine Readable
+    Workbook.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_CHIP_HAS_SBE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FREQ_PROC_REFCLOCK</id>
+    <description>System attribute. The frequency of the processor
+    refclock in MHz. Provided by the MRW.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_FREQ_PROC_REFCLOCK</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FREQ_PROC_REFCLOCK_KHZ</id>
+    <description>System attribute. The frequency of the processor
+    refclock in KHz. Provided by the MRW.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_FREQ_PROC_REFCLOCK_KHZ</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FREQ_MEM_REFCLOCK</id>
+    <description>System attribute. The frequency of the memory
+    refclock in MHz. Provided by the MRW.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_FREQ_MEM_REFCLOCK</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>DPO_MIN_FREQ_PERCENT</id>
+    <description>Defines a negative percentage value that is
+    applied to the ATTR_NOMINAL_FREQ_MHZ determined from MVPD #V.
+    It is used to explicitly raise the value of MIN_FREQ_MHZ above
+    what is specified by MVPD #V data. On FSP systems this is
+    sourced from the power_management def file. Value must be
+    between 0 and 100. A value of zero indicates no
+    override.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>FREQ_PB_MHZ</id>
+    <description>System attribute. The frequency of a processor's
+    PB chiplet in MHz. This is the same for all PB chiplets in the
+    system. Provided by the MRW.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_FREQ_PB_MHZ</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FREQ_A_MHZ</id>
+    <description>System attribute. The frequency of a processor's
+    A-bus chiplet in MHz. This is the same for all A-bus chiplets
+    in the system. Provided by the MRW.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x1900</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_FREQ_A_MHZ</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>HUID</id>
+    <description>Hardware Unit ID SSSSNNNNTTTTTTTTiiiiiiiiiiiiiiii
+    S=System N=Node Number T=Target Type (matches TYPE attribute)
+    i=Instance/Sequence number of target, relative to
+    node</description>
+    <simpleType>
+      <uint32_t />
+      <default>0xFFFFFFFF</default>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>SP_FUNCTIONS</id>
+    <description>Attribute which describes what the SP is or is not
+    doing in this system</description>
+    <complexType>
+      <description>Structure which defines a system's SP functions.
+      Applicable for System target only. Structure is
+      read-only.</description>
+      <field>
+        <name>baseServices</name>
+        <description>If this flag is set then mailboxEnabled MUST
+        also be set 0b0: SP does not support for VPD, payload, ATTR
+        sync, VDDR, TOD; 0b1: SP supports VPD, payload, ATTR sync,
+        VDDR, TOD</description>
+        <type>uint32_t</type>
+        <bits>1</bits>
+        <default>1</default>
+      </field>
+      <field>
+        <name>fsiSlaveInit</name>
+        <description>0b0: SP does not initialize FSI slave logic,
+        Hostboot must; 0b1: SP does initialize FSI slave logic so
+        Hostboot should not</description>
+        <type>uint32_t</type>
+        <bits>1</bits>
+        <default>1</default>
+      </field>
+      <field>
+        <name>mailboxEnabled</name>
+        <description>0b0: There is no SP mailbox support; 0b1:
+        There is SP mailbox support</description>
+        <type>uint32_t</type>
+        <bits>1</bits>
+        <default>0</default>
+      </field>
+      <field>
+        <name>fsiMasterInit</name>
+        <description>0b0: SP does not initialize FSI master logic,
+        Hostboot must; 0b1: SP does initialize FSI master logic so
+        Hostboot should not</description>
+        <type>uint32_t</type>
+        <bits>1</bits>
+        <default>1</default>
+      </field>
+      <field>
+        <name>hardwareChangeDetection</name>
+        <description>0b0: SP does not perform hardware change
+        detection, Hostboot must; 0b1: SP does perform hardware
+        change detection (HCDB) so Hostboot should
+        not</description>
+        <type>uint32_t</type>
+        <bits>1</bits>
+        <default>1</default>
+      </field>
+      <field>
+        <name>powerLineDisturbance</name>
+        <description>0b0: SP does not perform Power Line
+        Disturbance (PLD) detection, Hostboot must; 0b1: SP does
+        perform Power Line Disturbance (PLD) detection so Hostboot
+        should not</description>
+        <type>uint32_t</type>
+        <bits>1</bits>
+        <default>1</default>
+      </field>
+      <field>
+        <name>reserved</name>
+        <description>Reserved for future use</description>
+        <type>uint32_t</type>
+        <bits>26</bits>
+        <default>0</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>HB_SETTINGS</id>
+    <description>Attribute which describes how the SP has
+    configured features in Hostboot.</description>
+    <complexType>
+      <description>Structure which defines a system's HB settings.
+      Applicable for System target only.</description>
+      <field>
+        <name>traceContinuous</name>
+        <description>Enable / Disable continuous trace. 0b0:
+        Continuous trace is disabled. 0b1: Continuous trace is
+        enabled.</description>
+        <type>uint8_t</type>
+        <bits>1</bits>
+        <default>0</default>
+      </field>
+      <field>
+        <name>traceScanDebug</name>
+        <description>Override trace debug selection for SCAN
+        component. 0b0: TRACS entries for SCAN have default
+        behavior. 0b1: TRACS entries for SCAN are
+        enabled.</description>
+        <type>uint8_t</type>
+        <bits>1</bits>
+        <default>0</default>
+      </field>
+      <field>
+        <name>traceFapiDebug</name>
+        <description>Override trace debug selection for DBG
+        component. 0b0: TRACS entries for DBG have default
+        behavior. 0b1: TRACS entries for DBG are
+        enabled.</description>
+        <type>uint8_t</type>
+        <bits>1</bits>
+        <default>0</default>
+      </field>
+      <field>
+        <name>reserved</name>
+        <description>Reserved for future use</description>
+        <type>uint8_t</type>
+        <bits>5</bits>
+        <default>0</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <!-- Begin attributes (4) to test string support -->
+  <!-- End attributes (4) to test string support -->
+  <attribute>
+    <id>FAPI_NAME</id>
+    <description>Common name across FAPI environments chip target
+    -&gt; pu:k0:n0:s0:p00 DIMM target -&gt; dimm:k0:n0:s0:p00 chip
+    unit target -&gt; pu.core:k0:n0:s0:p00:c0 cage/system target
+    -&gt; k0 (chip type).(unit type):k(cage,always zero for
+    us):n(node/drawer) :s(slot,always zero for us):p(chip
+    position):c(core/unit position) pu = generic
+    processor</description>
+    <simpleType>
+      <string>
+        <default>unknown</default>
+        <sizeInclNull>64</sizeInclNull>
+      </string>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VPD_REC_NUM</id>
+    <description>Record offset for this target's VPD</description>
+    <simpleType>
+      <uint16_t>
+        <default>0xFFFF</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PEER_TARGET</id>
+    <description>Peer target's address of a A/X-bus connection.
+    NULL means address 0 for no peer target. If a target instance
+    overrides the default with the peer target's PHYS_PATH. The
+    target compiler will convert the valid PHYS_PATH string into
+    the runtime virtual address of the peer target
+    instance.</description>
+    <simpleType>
+      <Target_t>
+        <default>NULL</default>
+      </Target_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>PAYLOAD_KIND</id>
+    <description>Enumeration indicating what kind of payload is to
+    be started</description>
+    <enumerator>
+      <name>UNKNOWN</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>PHYP</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>SAPPHIRE</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>NONE</name>
+      <value>3</value>
+    </enumerator>
+    <default>UNKNOWN</default>
+  </enumerationType>
+  <attribute>
+    <id>PAYLOAD_KIND</id>
+    <description>Attribute indicating what kind of payload is to be
+    started.</description>
+    <simpleType>
+      <enumeration>
+        <id>PAYLOAD_KIND</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hasStringConversion />
+  </attribute>
+  <!--    TARGETING attributes to support mss_setup_bars and proc_setup_bars  -->
+  <!-- ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
      Memory Map
      The attributes below are defined by the PHYP Memory Map
      documentation owned by Shawn Lambeth
 
      @todo: RTC:44128 will be used to automatically create this data
      ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== -->
-<!-- ===== System Attributes ===== -->
-<attribute>
-  <id>XSCOM_BASE_ADDRESS</id>
-  <description>System XSCOM base address</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>IBSCOM_MCS_BASE_ADDR</id>
-  <description>MCS Inband Scom base address</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0003E00000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MCS_INBAND_BASE_ADDRESS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IBSCOM_PROC_BASE_ADDR</id>
-  <description>PROC Inband Scom base address</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0003E00000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MIRROR_BASE_ADDRESS</id>
-  <description>System Mirrorable base address</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000800000000000</default>
-      <!-- 128 TB -->
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MIRROR_BASE_ADDRESS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PAYLOAD_IN_MIRROR_MEM</id>
-  <description>Indicate that payload should be placed in mirrored
-  memory. Set by the FSP based on the value of the registry key
-  indicating the memory mirroring mode.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-      <!-- false -->
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<!-- ===== Processor Chip Attributes ===== -->
-<attribute>
-  <id>NPU_MMIO_BAR_BASE_ADDR</id>
-  <description>NPU MMIO BAR base address values creator: platform
-  consumer: proc_setup_bars firmware notes: 64-bit address
-  representing BAR RA NOTE: BAR register covers RA 14:51 first
-  dimension: unit number (0:3) second dimension: BAR number
-  (0:1)</description>
-  <simpleType>
-    <uint64_t>
-      <default>0</default>
-    </uint64_t>
-    <array>4,2</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NPU_MMIO_BAR_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>NPU_MMIO_BAR_SIZE</id>
-  <description>Enumeration indicating the BAR size used with
-  ATTR_PROC_NPU_MMIO_BAR_SIZE</description>
-  <enumerator>
-    <name>2_MB</name>
-    <value>0x0000000000200000</value>
-  </enumerator>
-  <enumerator>
-    <name>1_MB</name>
-    <value>0x0000000000100000</value>
-  </enumerator>
-  <enumerator>
-    <name>512_KB</name>
-    <value>0x0000000000080000</value>
-  </enumerator>
-  <enumerator>
-    <name>256_KB</name>
-    <value>0x0000000000040000</value>
-  </enumerator>
-  <enumerator>
-    <name>128_KB</name>
-    <value>0x0000000000020000</value>
-  </enumerator>
-  <enumerator>
-    <name>64_KB</name>
-    <value>0x0000000000010000</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>NPU_MMIO_BAR_SIZE</id>
-  <description>NPU MMIO BAR size values creator: platform consumer:
-  proc_setup_bars firmware notes: none first dimension: unit number
-  (0:3) second dimension: BAR number (0:1)</description>
-  <simpleType>
-    <uint64_t>
-      <default>0</default>
-    </uint64_t>
-    <array>4,2</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NPU_MMIO_BAR_SIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FSP_BASE_ADDR</id>
-  <description>Base Address of FSP IO Region</description>
-  <simpleType>
-    <uint64_t>
-      <!-- Starts at 1024TB - 128GB, 4GB per proc -->
-      <default>0x0003FFE000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FSP_BAR_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FSP_BAR_SIZE</id>
-  <description>Size of FSP IO Region</description>
-  <simpleType>
-    <uint64_t>
-      <!-- 4GB per Proc -->
-      <default>0x0000000100000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PSI_BRIDGE_BASE_ADDR</id>
-  <description>Base Address of PSI Bridge Logic</description>
-  <simpleType>
-    <uint64_t>
-      <!-- Starts at 1024TB - 6GB, 1MB per link -->
-      <!-- 0x0003FFFE80000000 + 0x100000*procnum -->
-      <default>0xFFFFFFFFFFFFFFFF</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PSI_BRIDGE_BAR_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>INTP_BASE_ADDR</id>
-  <description>Base Address of Interrupt Presenter</description>
-  <simpleType>
-    <uint64_t>
-      <!-- Starts at 1024TB - 2GB, 1MB per proc -->
-      <!-- 0x0003FFFF80000000 + 0x100000*procnum -->
-      <default>0xFFFFFFFFFFFFFFFF</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_INTP_BAR_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PHB_BASE_ADDRS</id>
-  <description>Base Address of PHB Register Space</description>
-  <simpleType>
-    <uint64_t>
-      <!-- Starts at 1024TB - 7GB -->
-      <!-- 0x0003FFFE40000000 + 0x400000*procnum + 0x100000*phbnum -->
-      <default>0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
-      0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF</default>
-    </uint64_t>
-    <array>4</array>
-    <!-- per PHB -->
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PCI_BASE_ADDRS_64</id>
-  <description>Base Address of PCI 64 bit Memory
-  Space</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-    <array>4</array>
-    <!-- per PHB -->
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PCI_BASE_ADDRS_32</id>
-  <description>Base Address of PCI 32 bit Memory
-  Space</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-    <array>4</array>
-    <!-- per PHB -->
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>RNG_BASE_ADDR</id>
-  <description>Base Address of RNG IO Region</description>
-  <simpleType>
-    <uint64_t>
-      <!-- Starts at 1024TB - 3GB -->
-      <!-- 0x0003FFFF40000000 + 0x1000*procnum -->
-      <default>0xFFFFFFFFFFFFFFFF</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NX_MMIO_BAR_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>RNG_BAR_SIZE</id>
-  <description>Size of RNG IO Region</description>
-  <simpleType>
-    <uint64_t>
-      <!-- 4 KB per processor -->
-      <default>0x000000000001000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>IMT_BASE_ADDR</id>
-  <description>Base Address of In-Memory Trace Region Set by
-  FSP-based tooling</description>
-  <simpleType>
-    <uint64_t>
-      <default>0xFFFFFFFFFFFFFFFF</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>IMT_BAR_SIZE</id>
-  <description>Size of IMT IO Region Set by FSP-based
-  tooling</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000000000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<!-- ===== ===== End Memory Map ===== ===== ===== ===== ===== ===== -->
-<attribute>
-  <id>FREQ_PCIE_MHZ</id>
-  <description>The frequency of a processor's PCI-e bus in MHz.
-  This is the same for all PCI-e busses in the system. Provided by
-  the MRW.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FREQ_PCIE_MHZ</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MNFG_FLAGS</id>
-  <description>Provides the manufacturing flags. This is a
-  bitfield. Multiple flags can be set at once. Use MNFG_FLAG_BIT to
-  decode. Expected use-case is for FSP to write this attribute
-  based on the MNFG component flags and for HWSV/Hostboot to read
-  it.</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000000000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MNFG_FLAGS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>MNFG_FLAG</id>
-  <description>Enumeration indicating the mnfg flags that are set
-  by the user. The values can be combined using a bitwise 'OR'. The
-  values will need to be kept in sync with the FAPI enumerator
-  values. Also the enumeration type is used by the ATTR_MNFG_FLAGS
-  attribute. Should note that the MNFG_FLAG values are of type
-  uint32_t</description>
-  <enumerator>
-    <!-- Use default mfg error thresholds and reporting values -->
-    <name>THRESHOLDS</name>
-    <value>0x00000001</value>
-  </enumerator>
-  <enumerator>
-    <!-- Enable AVP execution -->
-    <name>AVP_ENABLE</name>
-    <value>0x00000002</value>
-  </enumerator>
-  <enumerator>
-    <!-- Enable HDAT AVPs** -->
-    <name>HDAT_AVP_ENABLE</name>
-    <value>0x00000004</value>
-  </enumerator>
-  <enumerator>
-    <!-- All SRCs are terminating (CEC hardware/procedural) -->
-    <name>SRC_TERM</name>
-    <value>0x00000008</value>
-  </enumerator>
-  <enumerator>
-    <!-- Enable IPL memory diagnostics to report memory CE -->
-    <name>IPL_MEMORY_CE_CHECKING</name>
-    <value>0x00000010</value>
-  </enumerator>
-  <enumerator>
-    <!-- Enable Fast Background Scrub -->
-    <name>FAST_BACKGROUND_SCRUB</name>
-    <value>0x00000020</value>
-  </enumerator>
-  <enumerator>
-    <!-- Test DRAM Repairs -->
-    <name>TEST_DRAM_REPAIRS</name>
-    <value>0x00000040</value>
-  </enumerator>
-  <enumerator>
-    <!-- Disable Dram Repairs -->
-    <name>DISABLE_DRAM_REPAIRS</name>
-    <value>0x00000080</value>
-  </enumerator>
-  <enumerator>
-    <!-- Enable exhaustive pattern test -->
-    <name>ENABLE_EXHAUSTIVE_PATTERN_TEST</name>
-    <value>0x00000100</value>
-  </enumerator>
-  <enumerator>
-    <!-- Enable standard pattern test -->
-    <name>ENABLE_STANDARD_PATTERN_TEST</name>
-    <value>0x00000200</value>
-  </enumerator>
-  <enumerator>
-    <!-- Enable minimum pattern test -->
-    <name>ENABLE_MINIMUM_PATTERN_TEST</name>
-    <value>0x00000400</value>
-  </enumerator>
-  <enumerator>
-    <!-- Disable Fabric eRepair -->
-    <name>DISABLE_FABRIC_eREPAIR</name>
-    <value>0x00000800</value>
-  </enumerator>
-  <enumerator>
-    <!-- Disable Memory eRepair -->
-    <name>DISABLE_MEMORY_eREPAIR</name>
-    <value>0x00001000</value>
-  </enumerator>
-  <enumerator>
-    <!-- Fabric deploy lane spares -->
-    <name>FABRIC_DEPLOY_LANE_SPARES</name>
-    <value>0x00002000</value>
-  </enumerator>
-  <enumerator>
-    <!-- DMI deploy lane spares -->
-    <name>DMI_DEPLOY_LANE_SPARES</name>
-    <value>0x00004000</value>
-  </enumerator>
-  <enumerator>
-    <!-- Forcibly run PSI diagnostics -->
-    <name>PSI_DIAGNOSTIC</name>
-    <value>0x00008000</value>
-  </enumerator>
-  <enumerator>
-    <!-- Brazos Wrap Config -->
-    <name>BRAZOS_WRAP_CONFIG</name>
-    <value>0x00010000</value>
-  </enumerator>
-  <enumerator>
-    <!-- FSP is responsible for updating Processor SBE Image -->
-    <name>FSP_UPDATE_SBE_IMAGE</name>
-    <value>0x00020000</value>
-  </enumerator>
-  <enumerator>
-    <!-- Update both sides of SBE Image if update is needed -->
-    <name>UPDATE_BOTH_SIDES_OF_SBE</name>
-    <value>0x00040000</value>
-  </enumerator>
-</enumerationType>
-<!-- Support for pm_hwp_attributes.xml -->
-<attribute>
-  <id>PM_SLEEP_ENTRY</id>
-  <description>PROC_CHIP Attribute Set Assisted if power off
-  serialization is needed and SLEEP_TYPE=Fast; Set to Hardware if
-  the system can handle the unrelated powering off between cores.
-  Hardware setting decreases entry latency Producer: MRWB Consumer:
-  proc_pm_init and proc_pcbs_init</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_SLEEP_ENTRY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_SLEEP_EXIT</id>
-  <description>PROC_CHIP Attribute Set to Assisted if power on
-  serialization is needed and SLEEP_TYPE=Fast; Set to Hardware if
-  the system can handle the unrelated powering off between cores.
-  Hardware setting decreases entry latency Must be set to Assisted
-  if ATTR_PM_SLEEP_TYPE=Deep as this necessary for restore. Setting
-  to Hardware is a test mode for Fast only. Producer: MRWB
-  Consumer: proc_pm_init and proc_pcbs_init.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_SLEEP_EXIT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_SLEEP_TYPE</id>
-  <description>PROC_CHIP Attribute Selects which voltage level to
-  place the Core domain PFETs upon Sleep entry. 0 = Vret (Fast
-  Sleep Mode), 1 = Voff (Deep Sleep Mode) Producer: MRWB Consumer:
-  proc_pm_init and proc_pcbs_init</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_SLEEP_TYPE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_WINKLE_TYPE</id>
-  <description>PROC_CHIP Attribute Selects which voltage level to
-  place the Core and ECO domain PFETs upon Winkle entry. 0 = Vret
-  (Fast Winkle Mode), 1 = Voff (Deep Winkle Mode)</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_WINKLE_TYPE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_PFET_POWERUP_CORE_DELAY0</id>
-  <description>PROC_CHIP Attribute</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_PFET_POWERUP_CORE_DELAY0</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_PFET_POWERUP_CORE_DELAY1</id>
-  <description>PROC_CHIP Attribute</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_PFET_POWERUP_CORE_DELAY1</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_PFET_POWERDOWN_CORE_DELAY0</id>
-  <description>PROC_CHIP Attribute</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_PFET_POWERDOWN_CORE_DELAY0</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_PFET_POWERDOWN_CORE_DELAY1</id>
-  <description>PROC_CHIP Attribute</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_PFET_POWERDOWN_CORE_DELAY1</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_PFET_POWERUP_ECO_DELAY0</id>
-  <description>PROC_CHIP Attribute</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_PFET_POWERUP_ECO_DELAY0</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_PFET_POWERUP_ECO_DELAY1</id>
-  <description>PROC_CHIP Attribute</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_PFET_POWERUP_ECO_DELAY1</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_PFET_POWERDOWN_ECO_DELAY0</id>
-  <description>PROC_CHIP Attribute</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_PFET_POWERDOWN_ECO_DELAY0</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_PFET_POWERDOWN_ECO_DELAY1</id>
-  <description>PROC_CHIP Attribute</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_PFET_POWERDOWN_ECO_DELAY1</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>NEST_LEAKAGE_PERCENT</id>
-  <description>SYSTEM Attribute Nest leakage percentage used to
-  calculate the Core leakage. Will eventually be read into OCC
-  Pstate Parameter Block so the OCC can see it for it's
-  calculations. Valid Values: 0% thru 100% Producer: Machine
-  Readable Workbook Consumer: OCC Firmware</description>
-  <simpleType>
-    <uint8_t>
-      <default>60</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_NEST_LEAKAGE_PERCENT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- End pm_hwp_attributes.xml -->
-<!-- Support for pm_plat_attributes.xml -->
-<attribute>
-  <id>EXTERNAL_VRM_STEPSIZE</id>
-  <description>SYSTEM Attribute Step size (binary in microvolts) to
-  take upon external VRM voltage transitions. The value set here
-  must take into account where internal VRMs are enabled or not as,
-  when they are enabled, the step size must account for the
-  tracking (eg PFET strength recalculation) for the step. Consumer:
-  proc_build_pstate_tables.C, proc_pmc_init.C -config Provided by
-  the Machine Readable Workbook after system
-  characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_EXTERNAL_VRM_STEPSIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>EXTERNAL_VRM_TRANSITION_START_NS</id>
-  <description>Delay (binary in nanoseconds) from the time the VRM
-  receives the write voltage command until the voltage actually
-  moves. This value is used for both increasing and decreasing
-  transitions as part of the overall voltage transition time
-  calculation. Firmware provides a default value of 8000ns (eg
-  8us)) if this attribute is zero. Note: the smallest possible
-  delay is limited to 1ns. Consumer: p9_pstate_parameter_block
-  -&gt; Pstate Parameter Block (PSPB) for PGPE Provided by the
-  Machine Readable Workbook after system
-  characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_EXTERNAL_VRM_TRANSITION_START_NS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>EXTERNAL_VRM_TRANSITION_RATE_INC_UV_PER_US</id>
-  <description>Transition rate (binary in microVolts per
-  microsecond) of the VRM for an increasing voltage transition.
-  This is used as part of the overall voltage transition time
-  calculation Firmware provides a default value of 10000 uV/us (eg
-  10mV/us) if this attribute is zero. Note: the fastest possible
-  rate is limited to 1uV/us. Consumer: p9_pstate_parameter_block
-  -&gt; Pstate Parameter Block (PSPB) for PGPE Provided by the
-  Machine Readable Workbook after system
-  characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_EXTERNAL_VRM_TRANSITION_RATE_INC_UV_PER_US</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>EXTERNAL_VRM_TRANSITION_RATE_DEC_UV_PER_US</id>
-  <description>Transition rate (binary in microVolts per
-  microsecond) of the VRM for an decreasing voltage transition.
-  This is used as part of the overall voltage transition time
-  calculation Firmware provides a default value of 10000 uV/us (eg
-  10mV/us) if this attribute is zero. Note: the fastest possible
-  rate is limited to 1uV/us. Consumer: p9_pstate_parameter_block
-  -&gt; Pstate Parameter Block (PSPB) for PGPE Provided by the
-  Machine Readable Workbook after system
-  characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_EXTERNAL_VRM_TRANSITION_RATE_DEC_UV_PER_US</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>EXTERNAL_VRM_TRANSITION_STABILIZATION_TIME_NS</id>
-  <description>Time (binary in nanoseconds) to allow the voltage
-  rail to stabilize before considering the transition to be fully
-  complete. This value is used for both increasing and decreasing
-  transitions as part of the overall voltage transition time
-  calculation. Firmware provides a default value of 5000ns (5us) if
-  this attribute is zero. Note: the smallest delay is limited to
-  1ns. Consumer: p9_pstate_parameter_block -&gt; Pstate Parameter
-  Block (PSPB) for PGPE Provided by the Machine Readable Workbook
-  after system characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_EXTERNAL_VRM_TRANSITION_STABILIZATION_TIME_NS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>EXTERNAL_VRM_STEPDELAY</id>
-  <description>SYSTEM Attribute Step delay (binary in microseconds)
-  after a voltage change Consumer: proc_pmc_init -config Provided
-  by the Machine Readable Workbook after system
-  characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_EXTERNAL_VRM_STEPDELAY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_SPIVID_FREQUENCY</id>
-  <description>SYSTEM Attribute SPI Clock Frequency (binary in MHz)
-  Consumer: proc_pm_effective Produces ATTR_PM_SPIVID_CLOCK_DIVIDER
-  Provided by the Machine Readable Workbook.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_SPIVID_FREQUENCY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_SPIVID_PORT_ENABLE</id>
-  <description>PROC_CHIP Attribute Defines the configuration of the
-  SPIVID ports from the target. - NONE means that no VRM is
-  attached. - PORTxNONRED means that the indicated port is used in
-  a non-redundant configuration. - REDUNDANT means that all three
-  are connected and considered redundant. Provided by the Machine
-  Readable Workbook.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_SPIVID_PORT_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_SAFE_FREQUENCY</id>
-  <description>Frequency (binary in KHz) indicating the frequency
-  that the cores will be moved to in the event of the loss of the
-  OCC Heartbeat. This value needs to be the maximum of the DpoMin
-  frequency for proper PowerBus operation and the PowerSave value
-  for the present part. Provided by the Machine Readable Workbook
-  after system characterization. The value is translated to the
-  Pstate space. Producer: Machine Readable Workbook Consumers:
-  p8_build_gpstate_table.C DYNAMIC_ATTRIBUTE:
-  ATTR_PM_SAFE_PSTATE</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_SAFE_FREQUENCY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_RESONANT_CLOCK_FULL_CLOCK_SECTOR_BUFFER_FREQUENCY</id>
-  <description>SYSTEM Attribute Frequency (binary in MHz) for the
-  point at which clock sector buffers should be at full strength.
-  This is to support Vmin operation. Setting cannot overlap the Low
-  or High bands. Provided by the Machine Readable Workbook after
-  system characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>
-    ATTR_PM_RESONANT_CLOCK_FULL_CLOCK_SECTOR_BUFFER_FREQUENCY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_RESONANT_CLOCK_LOW_BAND_LOWER_FREQUENCY</id>
-  <description>SYSTEM Attribute Frequency (binary in MHz)) for the
-  lower end of the Low Frequency Resonant band Provided by the
-  Machine Readable Workbook after system
-  characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_RESONANT_CLOCK_LOW_BAND_LOWER_FREQUENCY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_RESONANT_CLOCK_LOW_BAND_UPPER_FREQUENCY</id>
-  <description>SYSTEM Attribute Frequency (binary in MHz) for the
-  upper end of the Low Frequency Resonant band Provided by the
-  Machine Readable Workbook after system
-  characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_RESONANT_CLOCK_LOW_BAND_UPPER_FREQUENCY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_RESONANT_CLOCK_HIGH_BAND_LOWER_FREQUENCY</id>
-  <description>SYSTEM Attribute Frequency (binary in MHz) for the
-  lower end of the High Frequency Resonant band Provided by the
-  Machine Readable Workbook after system
-  characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_RESONANT_CLOCK_HIGH_BAND_LOWER_FREQUENCY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_RESONANT_CLOCK_HIGH_BAND_UPPER_FREQUENCY</id>
-  <description>SYSTEM Attribute Frequency (binary in MHz)) for the
-  upper end of the High Frequency Resonant band Provided by the
-  Machine Readable Workbook after system
-  characterization.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_RESONANT_CLOCK_HIGH_BAND_UPPER_FREQUENCY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_PBAX_NODEID</id>
-  <description>DEPRECATED!!! Use PBAX_GROUPID instead PROC_CHIP
-  Attribute Receive PBAX Nodeid. Value that indicates this PBA's
-  PBAX Node affinity. This is matched to pbax_nodeid of the PMISC
-  Address phase. Provided by the Machine Readable
-  Workbook.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_PBAX_NODEID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PBAX_GROUPID</id>
-  <description>PROC_CHIP Attribute Receive PBAX Nodeid. Value that
-  indicates this PBA's PBAX Node affinity. This is matched to
-  pbax_nodeid of the PMISC Address phase. Provided by the Machine
-  Readable Workbook.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PBAX_GROUPID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PBAX_CHIPID</id>
-  <description>PROC_CHIP Attribute Receive PBAX Chipid. Value that
-  indicates this PBA's PBAX Chipid within the PBAX node. Is matched
-  to pbax_chipid of the Address phase if pbax_type=unicast.
-  Provided by the Machine Readable Workbook.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PBAX_CHIPID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PBAX_BRDCST_ID_VECTOR</id>
-  <description>PROC_CHIP Attribute Receive PBAX Broadcast Group.
-  Vector that is indexed when decoded PMISC pbax_type=broadcast
-  with the decoded PMISC pbax_chipid value. If the bit in this
-  vector at the decoded bit location is a 1, then this receive
-  engine will participate in the broadcast operation. Provided by
-  the Machine Readable Workbook.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PBAX_BRDCST_ID_VECTOR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FREQ_CORE_MAX</id>
-  <description>SYSTEM Attribute Maximum frequency (binary in MHz)
-  that any processor in the system will run. Used to define the top
-  end of the PState range in the frequency space. From this, the
-  ATTR_PROCPM_PSTATE0_FREQUENCY is computed using
-  ATTR_SYSTEM_REFCLK_FREQUENCY to determine the step size.
-  Consumers: proc_build_gpstate_table.C (among others) Data is is
-  provided by MVPD #V and is calculated as the minimum of the turbo
-  frequencies</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_FREQ_CORE_MAX</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- End pm_plat_attributes.xml -->
-<attribute>
-  <id>PROC_PCIE_IOP_CONFIG</id>
-  <description>PCIE IOP lane configuration creator: platform
-  consumer: proc_pcie_scominit firmware notes: Encoded PCIE IOP
-  lane configuration</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_IOP_CONFIG</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PHB_ACTIVE</id>
-  <description>PCIE PHB valid mask creator: platform consumer:
-  proc_pcie_scominit firmware notes: Bit mask defining set of
-  active/valid PHBs bit0=PHB0, bit1=PHB1, bit2=PHB2,
-  bit3=PHB3</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PHB_ACTIVE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>AVDD_ID</id>
-  <description>Memory AVDD voltage domain ID. All memory buffers in
-  the same AVDD voltage domain will share the same ID. IDs are
-  arbitrarily assigned, used for correlation between HB + HWSV, and
-  are generated by genHwsvMrwXml.pl</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VDD_ID</id>
-  <description>Memory VDD voltage domain ID. All memory buffers in
-  the same VDD voltage domain will share the same ID. IDs are
-  arbitrarily assigned, used for correlation between HB + HWSV, and
-  are generated by genHwsvMrwXml.pl</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VCS_ID</id>
-  <description>Memory VCS voltage domain ID. All memory buffers in
-  the same VCS voltage domain will share the same ID. IDs are
-  arbitrarily assigned, used for correlation between HB + HWSV, and
-  are generated by genHwsvMrwXml.pl</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VPP_ID</id>
-  <description>Memory VPP voltage domain ID. All memory buffers in
-  the same VPP voltage domain will share the same ID. IDs are
-  arbitrarily assigned, used for correlation between HB + HWSV, and
-  are generated by genHwsvMrwXml.pl</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VDDR_ID</id>
-  <description>Voltage Memory Rail Manager ID. Currently HB only
-  needs to configured the Vddr voltage rail manager during the IPL.
-  The ID is an arbitary value and needed as correlation token
-  between HB and HWSV. It will be generated by the
-  genHwsvMrwXml.pl.</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NEST_VDDR_ID</id>
-  <description>Nest VDDR Voltage Rail ID. The ID is an arbitrary
-  value and is needed as correlation token between HB and HWSV. It
-  will be generated by the genHwsvMrwXml.pl</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NEST_VIO_ID</id>
-  <description>Nest VIO Voltage Rail ID. The ID is an arbitrary
-  value and is needed as correlation token between HB and HWSV. It
-  will be generated by the genHwsvMrwXml.pl</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NEST_VDD_ID</id>
-  <description>Nest VDD Voltage Rail ID. The ID is an arbitrary
-  value and is needed as correlation token between HB and HWSV. It
-  will be generated by the genHwsvMrwXml.pl</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NEST_VDN_ID</id>
-  <description>Nest VDN Voltage Rail ID. The ID is an arbitrary
-  value and is needed as correlation token between HB and HWSV. It
-  will be generated by the genHwsvMrwXml.pl</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NEST_VCS_ID</id>
-  <description>Nest VCS Voltage Rail ID. The ID is an arbitrary
-  value and is needed as correlation token between HB and HWSV. It
-  will be generated by the genHwsvMrwXml.pl</description>
-  <simpleType>
-    <uint16_t>
-      <default>0</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<!--    Add attributes for sbe_config_update    -->
-<attribute>
-  <id>ASYNC_NEST_FREQ_MHZ</id>
-  <description>The asynchronous nest frequency</description>
-  <simpleType>
-    <uint32_t>
-      <default>2000</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_ASYNC_NEST_FREQ_MHZ</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_ADU_UNTRUSTED_BAR_BASE_ADDR</id>
-  <description>ADU Untrusted BAR base address (secure mode)
-  creator: platform firmware notes: 64-bit address representing BAR
-  RA</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000000000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_ADU_UNTRUSTED_BAR_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_ADU_UNTRUSTED_BAR_SIZE</id>
-  <description>ADU Untrusted BAR size (secure mode) creator:
-  platform firmware notes: mask applied to RA 14:43</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000000000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_ADU_UNTRUSTED_BAR_SIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>SBE_IMAGE_MINIMUM_VALID_EXS</id>
-  <description>The minimum number of valid EXs that is required to
-  be used when customizing a SBE image. The customization will fail
-  if it cannot create an image with at least this many
-  EXs.</description>
-  <simpleType>
-    <uint32_t>
-      <default>3</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_SBE_IMAGE_MINIMUM_VALID_EXS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PSI_UNTRUSTED_BAR0_BASE_ADDR</id>
-  <description>PSI Untrusted BAR0 base address (secure mode)
-  creator: platform firmware notes: 64-bit address representing BAR
-  RA</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000000000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PSI_UNTRUSTED_BAR0_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PSI_UNTRUSTED_BAR0_SIZE</id>
-  <description>PSI Untrusted BAR0 size (secure mode) creator:
-  platform firmware notes: mask applied to RA 14:43</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000000000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PSI_UNTRUSTED_BAR0_SIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PSI_UNTRUSTED_BAR1_BASE_ADDR</id>
-  <description>PSI Untrusted BAR1 base address (secure mode)
-  creator: platform firmware notes: 64-bit address representing BAR
-  RA</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000000000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PSI_UNTRUSTED_BAR1_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PSI_UNTRUSTED_BAR1_SIZE</id>
-  <description>PSI Untrusted BAR1 size (secure mode) creator:
-  platform firmware notes: mask applied to RA 14:43</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000000000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PSI_UNTRUSTED_BAR1_SIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_SECURITY_SETUP_VECTOR</id>
-  <description>Secureboot 64-bit proc_sbe_security_setup_vector
-  used by proc_sbe_security_setup.S. 0s are an unsecure SBE image
-  creator: platform firmware notes: 64-bit
-  proc_sbe_security_setup_vector</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x8000000080000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_SECURITY_SETUP_VECTOR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- ===== Attributes supporting memory_attributes.xml HWPF Attributes ===== -->
-<attribute>
-  <id>MSS_VDDR_PROGRAM</id>
-  <description>VDDR memory programming type 0 = POWERON - domain is
-  programmed as part of regular power on sequence, 1 = STATIC -
-  domain needs to be programmed, no special computation needed, 2 =
-  DYNAMIC - domain needs to be programmed, uses dynamic vid
-  logic</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<attribute>
-  <id>MSS_VPP_PROGRAM</id>
-  <description>VPP memory programming type 0 = POWERON - domain is
-  programmed as part of regular power on sequence, 1 = STATIC -
-  domain needs to be programmed, no special computation needed, 2 =
-  DYNAMIC - domain needs to be programmed, uses dynamic vid
-  logic</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<attribute>
-  <id>MSS_VCS_PROGRAM</id>
-  <description>VCS memory programming type 0 = POWERON - domain is
-  programmed as part of regular power on sequence, 1 = STATIC -
-  domain needs to be programmed, no special computation needed, 2 =
-  DYNAMIC - domain needs to be programmed, uses dynamic vid
-  logic</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<attribute>
-  <id>MSS_AVDD_PROGRAM</id>
-  <description>AVDD memory programming type 0 = POWERON - domain is
-  programmed as part of regular power on sequence, 1 = STATIC -
-  domain needs to be programmed, no special computation needed, 2 =
-  DYNAMIC - domain needs to be programmed, uses dynamic vid
-  logic</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<attribute>
-  <id>MSS_VDD_PROGRAM</id>
-  <description>VDD memory programming type 0 = POWERON - domain is
-  programmed as part of regular power on sequence, 1 = STATIC -
-  domain needs to be programmed, no special computation needed, 2 =
-  DYNAMIC - domain needs to be programmed, uses dynamic vid
-  logic</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<!-- Calculated dynamic voltages -->
-<!-- end of Dynamic voltage -->
-<!-- TODO RTC 87603. These termination data EFF attributes have corresponding
+  <!-- ===== System Attributes ===== -->
+  <attribute>
+    <id>XSCOM_BASE_ADDRESS</id>
+    <description>System XSCOM base address</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>IBSCOM_MCS_BASE_ADDR</id>
+    <description>MCS Inband Scom base address</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0003E00000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MCS_INBAND_BASE_ADDRESS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IBSCOM_PROC_BASE_ADDR</id>
+    <description>PROC Inband Scom base address</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0003E00000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MIRROR_BASE_ADDRESS</id>
+    <description>System Mirrorable base address</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000800000000000</default>
+        <!-- 128 TB -->
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MIRROR_BASE_ADDRESS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PAYLOAD_IN_MIRROR_MEM</id>
+    <description>Indicate that payload should be placed in mirrored
+    memory. Set by the FSP based on the value of the registry key
+    indicating the memory mirroring mode.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+        <!-- false -->
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <!-- ===== Processor Chip Attributes ===== -->
+  <attribute>
+    <id>NPU_MMIO_BAR_BASE_ADDR</id>
+    <description>NPU MMIO BAR base address values creator: platform
+    consumer: proc_setup_bars firmware notes: 64-bit address
+    representing BAR RA NOTE: BAR register covers RA 14:51 first
+    dimension: unit number (0:3) second dimension: BAR number
+    (0:1)</description>
+    <simpleType>
+      <uint64_t>
+        <default>0</default>
+      </uint64_t>
+      <array>4,2</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NPU_MMIO_BAR_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>NPU_MMIO_BAR_SIZE</id>
+    <description>Enumeration indicating the BAR size used with
+    ATTR_PROC_NPU_MMIO_BAR_SIZE</description>
+    <enumerator>
+      <name>2_MB</name>
+      <value>0x0000000000200000</value>
+    </enumerator>
+    <enumerator>
+      <name>1_MB</name>
+      <value>0x0000000000100000</value>
+    </enumerator>
+    <enumerator>
+      <name>512_KB</name>
+      <value>0x0000000000080000</value>
+    </enumerator>
+    <enumerator>
+      <name>256_KB</name>
+      <value>0x0000000000040000</value>
+    </enumerator>
+    <enumerator>
+      <name>128_KB</name>
+      <value>0x0000000000020000</value>
+    </enumerator>
+    <enumerator>
+      <name>64_KB</name>
+      <value>0x0000000000010000</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>NPU_MMIO_BAR_SIZE</id>
+    <description>NPU MMIO BAR size values creator: platform
+    consumer: proc_setup_bars firmware notes: none first dimension:
+    unit number (0:3) second dimension: BAR number
+    (0:1)</description>
+    <simpleType>
+      <uint64_t>
+        <default>0</default>
+      </uint64_t>
+      <array>4,2</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NPU_MMIO_BAR_SIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FSP_BASE_ADDR</id>
+    <description>Base Address of FSP IO Region</description>
+    <simpleType>
+      <uint64_t>
+        <!-- Starts at 1024TB - 128GB, 4GB per proc -->
+        <default>0x0003FFE000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FSP_BAR_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FSP_BAR_SIZE</id>
+    <description>Size of FSP IO Region</description>
+    <simpleType>
+      <uint64_t>
+        <!-- 4GB per Proc -->
+        <default>0x0000000100000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PSI_BRIDGE_BASE_ADDR</id>
+    <description>Base Address of PSI Bridge Logic</description>
+    <simpleType>
+      <uint64_t>
+        <!-- Starts at 1024TB - 6GB, 1MB per link -->
+        <!-- 0x0003FFFE80000000 + 0x100000*procnum -->
+        <default>0xFFFFFFFFFFFFFFFF</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PSI_BRIDGE_BAR_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>INTP_BASE_ADDR</id>
+    <description>Base Address of Interrupt Presenter</description>
+    <simpleType>
+      <uint64_t>
+        <!-- Starts at 1024TB - 2GB, 1MB per proc -->
+        <!-- 0x0003FFFF80000000 + 0x100000*procnum -->
+        <default>0xFFFFFFFFFFFFFFFF</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_INTP_BAR_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PHB_BASE_ADDRS</id>
+    <description>Base Address of PHB Register Space</description>
+    <simpleType>
+      <uint64_t>
+        <!-- Starts at 1024TB - 7GB -->
+        <!-- 0x0003FFFE40000000 + 0x400000*procnum + 0x100000*phbnum -->
+        <default>0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
+        0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF</default>
+      </uint64_t>
+      <array>4</array>
+      <!-- per PHB -->
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PCI_BASE_ADDRS_64</id>
+    <description>Base Address of PCI 64 bit Memory
+    Space</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+      <array>4</array>
+      <!-- per PHB -->
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PCI_BASE_ADDRS_32</id>
+    <description>Base Address of PCI 32 bit Memory
+    Space</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+      <array>4</array>
+      <!-- per PHB -->
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>RNG_BASE_ADDR</id>
+    <description>Base Address of RNG IO Region</description>
+    <simpleType>
+      <uint64_t>
+        <!-- Starts at 1024TB - 3GB -->
+        <!-- 0x0003FFFF40000000 + 0x1000*procnum -->
+        <default>0xFFFFFFFFFFFFFFFF</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NX_MMIO_BAR_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>RNG_BAR_SIZE</id>
+    <description>Size of RNG IO Region</description>
+    <simpleType>
+      <uint64_t>
+        <!-- 4 KB per processor -->
+        <default>0x000000000001000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>IMT_BASE_ADDR</id>
+    <description>Base Address of In-Memory Trace Region Set by
+    FSP-based tooling</description>
+    <simpleType>
+      <uint64_t>
+        <default>0xFFFFFFFFFFFFFFFF</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>IMT_BAR_SIZE</id>
+    <description>Size of IMT IO Region Set by FSP-based
+    tooling</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000000000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <!-- ===== ===== End Memory Map ===== ===== ===== ===== ===== ===== -->
+  <attribute>
+    <id>FREQ_PCIE_MHZ</id>
+    <description>The frequency of a processor's PCI-e bus in MHz.
+    This is the same for all PCI-e busses in the system. Provided
+    by the MRW.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_FREQ_PCIE_MHZ</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MNFG_FLAGS</id>
+    <description>Provides the manufacturing flags. This is a
+    bitfield. Multiple flags can be set at once. Use MNFG_FLAG_BIT
+    to decode. Expected use-case is for FSP to write this attribute
+    based on the MNFG component flags and for HWSV/Hostboot to read
+    it.</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000000000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MNFG_FLAGS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>MNFG_FLAG</id>
+    <description>Enumeration indicating the mnfg flags that are set
+    by the user. The values can be combined using a bitwise 'OR'.
+    The values will need to be kept in sync with the FAPI
+    enumerator values. Also the enumeration type is used by the
+    ATTR_MNFG_FLAGS attribute. Should note that the MNFG_FLAG
+    values are of type uint32_t</description>
+    <enumerator>
+      <!-- Use default mfg error thresholds and reporting values -->
+      <name>THRESHOLDS</name>
+      <value>0x00000001</value>
+    </enumerator>
+    <enumerator>
+      <!-- Enable AVP execution -->
+      <name>AVP_ENABLE</name>
+      <value>0x00000002</value>
+    </enumerator>
+    <enumerator>
+      <!-- Enable HDAT AVPs** -->
+      <name>HDAT_AVP_ENABLE</name>
+      <value>0x00000004</value>
+    </enumerator>
+    <enumerator>
+      <!-- All SRCs are terminating (CEC hardware/procedural) -->
+      <name>SRC_TERM</name>
+      <value>0x00000008</value>
+    </enumerator>
+    <enumerator>
+      <!-- Enable IPL memory diagnostics to report memory CE -->
+      <name>IPL_MEMORY_CE_CHECKING</name>
+      <value>0x00000010</value>
+    </enumerator>
+    <enumerator>
+      <!-- Enable Fast Background Scrub -->
+      <name>FAST_BACKGROUND_SCRUB</name>
+      <value>0x00000020</value>
+    </enumerator>
+    <enumerator>
+      <!-- Test DRAM Repairs -->
+      <name>TEST_DRAM_REPAIRS</name>
+      <value>0x00000040</value>
+    </enumerator>
+    <enumerator>
+      <!-- Disable Dram Repairs -->
+      <name>DISABLE_DRAM_REPAIRS</name>
+      <value>0x00000080</value>
+    </enumerator>
+    <enumerator>
+      <!-- Enable exhaustive pattern test -->
+      <name>ENABLE_EXHAUSTIVE_PATTERN_TEST</name>
+      <value>0x00000100</value>
+    </enumerator>
+    <enumerator>
+      <!-- Enable standard pattern test -->
+      <name>ENABLE_STANDARD_PATTERN_TEST</name>
+      <value>0x00000200</value>
+    </enumerator>
+    <enumerator>
+      <!-- Enable minimum pattern test -->
+      <name>ENABLE_MINIMUM_PATTERN_TEST</name>
+      <value>0x00000400</value>
+    </enumerator>
+    <enumerator>
+      <!-- Disable Fabric eRepair -->
+      <name>DISABLE_FABRIC_eREPAIR</name>
+      <value>0x00000800</value>
+    </enumerator>
+    <enumerator>
+      <!-- Disable Memory eRepair -->
+      <name>DISABLE_MEMORY_eREPAIR</name>
+      <value>0x00001000</value>
+    </enumerator>
+    <enumerator>
+      <!-- Fabric deploy lane spares -->
+      <name>FABRIC_DEPLOY_LANE_SPARES</name>
+      <value>0x00002000</value>
+    </enumerator>
+    <enumerator>
+      <!-- DMI deploy lane spares -->
+      <name>DMI_DEPLOY_LANE_SPARES</name>
+      <value>0x00004000</value>
+    </enumerator>
+    <enumerator>
+      <!-- Forcibly run PSI diagnostics -->
+      <name>PSI_DIAGNOSTIC</name>
+      <value>0x00008000</value>
+    </enumerator>
+    <enumerator>
+      <!-- Brazos Wrap Config -->
+      <name>BRAZOS_WRAP_CONFIG</name>
+      <value>0x00010000</value>
+    </enumerator>
+    <enumerator>
+      <!-- FSP is responsible for updating Processor SBE Image -->
+      <name>FSP_UPDATE_SBE_IMAGE</name>
+      <value>0x00020000</value>
+    </enumerator>
+    <enumerator>
+      <!-- Update both sides of SBE Image if update is needed -->
+      <name>UPDATE_BOTH_SIDES_OF_SBE</name>
+      <value>0x00040000</value>
+    </enumerator>
+  </enumerationType>
+  <!-- Support for pm_hwp_attributes.xml -->
+  <attribute>
+    <id>PM_SLEEP_ENTRY</id>
+    <description>PROC_CHIP Attribute Set Assisted if power off
+    serialization is needed and SLEEP_TYPE=Fast; Set to Hardware if
+    the system can handle the unrelated powering off between cores.
+    Hardware setting decreases entry latency Producer: MRWB
+    Consumer: proc_pm_init and proc_pcbs_init</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_SLEEP_ENTRY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_SLEEP_EXIT</id>
+    <description>PROC_CHIP Attribute Set to Assisted if power on
+    serialization is needed and SLEEP_TYPE=Fast; Set to Hardware if
+    the system can handle the unrelated powering off between cores.
+    Hardware setting decreases entry latency Must be set to
+    Assisted if ATTR_PM_SLEEP_TYPE=Deep as this necessary for
+    restore. Setting to Hardware is a test mode for Fast only.
+    Producer: MRWB Consumer: proc_pm_init and
+    proc_pcbs_init.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_SLEEP_EXIT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_SLEEP_TYPE</id>
+    <description>PROC_CHIP Attribute Selects which voltage level to
+    place the Core domain PFETs upon Sleep entry. 0 = Vret (Fast
+    Sleep Mode), 1 = Voff (Deep Sleep Mode) Producer: MRWB
+    Consumer: proc_pm_init and proc_pcbs_init</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_SLEEP_TYPE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_WINKLE_TYPE</id>
+    <description>PROC_CHIP Attribute Selects which voltage level to
+    place the Core and ECO domain PFETs upon Winkle entry. 0 = Vret
+    (Fast Winkle Mode), 1 = Voff (Deep Winkle Mode)</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_WINKLE_TYPE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_CORE_DELAY0</id>
+    <description>PROC_CHIP Attribute</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_PFET_POWERUP_CORE_DELAY0</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_CORE_DELAY1</id>
+    <description>PROC_CHIP Attribute</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_PFET_POWERUP_CORE_DELAY1</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_CORE_DELAY0</id>
+    <description>PROC_CHIP Attribute</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_PFET_POWERDOWN_CORE_DELAY0</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_CORE_DELAY1</id>
+    <description>PROC_CHIP Attribute</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_PFET_POWERDOWN_CORE_DELAY1</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_ECO_DELAY0</id>
+    <description>PROC_CHIP Attribute</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_PFET_POWERUP_ECO_DELAY0</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERUP_ECO_DELAY1</id>
+    <description>PROC_CHIP Attribute</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_PFET_POWERUP_ECO_DELAY1</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_ECO_DELAY0</id>
+    <description>PROC_CHIP Attribute</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_PFET_POWERDOWN_ECO_DELAY0</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_PFET_POWERDOWN_ECO_DELAY1</id>
+    <description>PROC_CHIP Attribute</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_PFET_POWERDOWN_ECO_DELAY1</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>NEST_LEAKAGE_PERCENT</id>
+    <description>SYSTEM Attribute Nest leakage percentage used to
+    calculate the Core leakage. Will eventually be read into OCC
+    Pstate Parameter Block so the OCC can see it for it's
+    calculations. Valid Values: 0% thru 100% Producer: Machine
+    Readable Workbook Consumer: OCC Firmware</description>
+    <simpleType>
+      <uint8_t>
+        <default>60</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_NEST_LEAKAGE_PERCENT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- End pm_hwp_attributes.xml -->
+  <!-- Support for pm_plat_attributes.xml -->
+  <attribute>
+    <id>EXTERNAL_VRM_STEPSIZE</id>
+    <description>SYSTEM Attribute Step size (binary in microvolts)
+    to take upon external VRM voltage transitions. The value set
+    here must take into account where internal VRMs are enabled or
+    not as, when they are enabled, the step size must account for
+    the tracking (eg PFET strength recalculation) for the step.
+    Consumer: proc_build_pstate_tables.C, proc_pmc_init.C -config
+    Provided by the Machine Readable Workbook after system
+    characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_EXTERNAL_VRM_STEPSIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>EXTERNAL_VRM_TRANSITION_START_NS</id>
+    <description>Delay (binary in nanoseconds) from the time the
+    VRM receives the write voltage command until the voltage
+    actually moves. This value is used for both increasing and
+    decreasing transitions as part of the overall voltage
+    transition time calculation. Firmware provides a default value
+    of 8000ns (eg 8us)) if this attribute is zero. Note: the
+    smallest possible delay is limited to 1ns. Consumer:
+    p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB)
+    for PGPE Provided by the Machine Readable Workbook after system
+    characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_EXTERNAL_VRM_TRANSITION_START_NS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>EXTERNAL_VRM_TRANSITION_RATE_INC_UV_PER_US</id>
+    <description>Transition rate (binary in microVolts per
+    microsecond) of the VRM for an increasing voltage transition.
+    This is used as part of the overall voltage transition time
+    calculation Firmware provides a default value of 10000 uV/us
+    (eg 10mV/us) if this attribute is zero. Note: the fastest
+    possible rate is limited to 1uV/us. Consumer:
+    p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB)
+    for PGPE Provided by the Machine Readable Workbook after system
+    characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_EXTERNAL_VRM_TRANSITION_RATE_INC_UV_PER_US</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>EXTERNAL_VRM_TRANSITION_RATE_DEC_UV_PER_US</id>
+    <description>Transition rate (binary in microVolts per
+    microsecond) of the VRM for an decreasing voltage transition.
+    This is used as part of the overall voltage transition time
+    calculation Firmware provides a default value of 10000 uV/us
+    (eg 10mV/us) if this attribute is zero. Note: the fastest
+    possible rate is limited to 1uV/us. Consumer:
+    p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB)
+    for PGPE Provided by the Machine Readable Workbook after system
+    characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_EXTERNAL_VRM_TRANSITION_RATE_DEC_UV_PER_US</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>EXTERNAL_VRM_TRANSITION_STABILIZATION_TIME_NS</id>
+    <description>Time (binary in nanoseconds) to allow the voltage
+    rail to stabilize before considering the transition to be fully
+    complete. This value is used for both increasing and decreasing
+    transitions as part of the overall voltage transition time
+    calculation. Firmware provides a default value of 5000ns (5us)
+    if this attribute is zero. Note: the smallest delay is limited
+    to 1ns. Consumer: p9_pstate_parameter_block -&gt; Pstate
+    Parameter Block (PSPB) for PGPE Provided by the Machine
+    Readable Workbook after system characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_EXTERNAL_VRM_TRANSITION_STABILIZATION_TIME_NS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>EXTERNAL_VRM_STEPDELAY</id>
+    <description>SYSTEM Attribute Step delay (binary in
+    microseconds) after a voltage change Consumer: proc_pmc_init
+    -config Provided by the Machine Readable Workbook after system
+    characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_EXTERNAL_VRM_STEPDELAY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_FREQUENCY</id>
+    <description>SYSTEM Attribute SPI Clock Frequency (binary in
+    MHz) Consumer: proc_pm_effective Produces
+    ATTR_PM_SPIVID_CLOCK_DIVIDER Provided by the Machine Readable
+    Workbook.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_SPIVID_FREQUENCY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_SPIVID_PORT_ENABLE</id>
+    <description>PROC_CHIP Attribute Defines the configuration of
+    the SPIVID ports from the target. - NONE means that no VRM is
+    attached. - PORTxNONRED means that the indicated port is used
+    in a non-redundant configuration. - REDUNDANT means that all
+    three are connected and considered redundant. Provided by the
+    Machine Readable Workbook.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_SPIVID_PORT_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_SAFE_FREQUENCY</id>
+    <description>Frequency (binary in KHz) indicating the frequency
+    that the cores will be moved to in the event of the loss of the
+    OCC Heartbeat. This value needs to be the maximum of the DpoMin
+    frequency for proper PowerBus operation and the PowerSave value
+    for the present part. Provided by the Machine Readable Workbook
+    after system characterization. The value is translated to the
+    Pstate space. Producer: Machine Readable Workbook Consumers:
+    p8_build_gpstate_table.C DYNAMIC_ATTRIBUTE:
+    ATTR_PM_SAFE_PSTATE</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_SAFE_FREQUENCY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_FULL_CLOCK_SECTOR_BUFFER_FREQUENCY</id>
+    <description>SYSTEM Attribute Frequency (binary in MHz) for the
+    point at which clock sector buffers should be at full strength.
+    This is to support Vmin operation. Setting cannot overlap the
+    Low or High bands. Provided by the Machine Readable Workbook
+    after system characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>
+      ATTR_PM_RESONANT_CLOCK_FULL_CLOCK_SECTOR_BUFFER_FREQUENCY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_LOW_BAND_LOWER_FREQUENCY</id>
+    <description>SYSTEM Attribute Frequency (binary in MHz)) for
+    the lower end of the Low Frequency Resonant band Provided by
+    the Machine Readable Workbook after system
+    characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_RESONANT_CLOCK_LOW_BAND_LOWER_FREQUENCY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_LOW_BAND_UPPER_FREQUENCY</id>
+    <description>SYSTEM Attribute Frequency (binary in MHz) for the
+    upper end of the Low Frequency Resonant band Provided by the
+    Machine Readable Workbook after system
+    characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_RESONANT_CLOCK_LOW_BAND_UPPER_FREQUENCY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_HIGH_BAND_LOWER_FREQUENCY</id>
+    <description>SYSTEM Attribute Frequency (binary in MHz) for the
+    lower end of the High Frequency Resonant band Provided by the
+    Machine Readable Workbook after system
+    characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_RESONANT_CLOCK_HIGH_BAND_LOWER_FREQUENCY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_RESONANT_CLOCK_HIGH_BAND_UPPER_FREQUENCY</id>
+    <description>SYSTEM Attribute Frequency (binary in MHz)) for
+    the upper end of the High Frequency Resonant band Provided by
+    the Machine Readable Workbook after system
+    characterization.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_RESONANT_CLOCK_HIGH_BAND_UPPER_FREQUENCY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_PBAX_NODEID</id>
+    <description>DEPRECATED!!! Use PBAX_GROUPID instead PROC_CHIP
+    Attribute Receive PBAX Nodeid. Value that indicates this PBA's
+    PBAX Node affinity. This is matched to pbax_nodeid of the PMISC
+    Address phase. Provided by the Machine Readable
+    Workbook.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_PBAX_NODEID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PBAX_GROUPID</id>
+    <description>PROC_CHIP Attribute Receive PBAX Nodeid. Value
+    that indicates this PBA's PBAX Node affinity. This is matched
+    to pbax_nodeid of the PMISC Address phase. Provided by the
+    Machine Readable Workbook.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PBAX_GROUPID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PBAX_CHIPID</id>
+    <description>PROC_CHIP Attribute Receive PBAX Chipid. Value
+    that indicates this PBA's PBAX Chipid within the PBAX node. Is
+    matched to pbax_chipid of the Address phase if
+    pbax_type=unicast. Provided by the Machine Readable
+    Workbook.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PBAX_CHIPID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PBAX_BRDCST_ID_VECTOR</id>
+    <description>PROC_CHIP Attribute Receive PBAX Broadcast Group.
+    Vector that is indexed when decoded PMISC pbax_type=broadcast
+    with the decoded PMISC pbax_chipid value. If the bit in this
+    vector at the decoded bit location is a 1, then this receive
+    engine will participate in the broadcast operation. Provided by
+    the Machine Readable Workbook.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PBAX_BRDCST_ID_VECTOR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FREQ_CORE_MAX</id>
+    <description>SYSTEM Attribute Maximum frequency (binary in MHz)
+    that any processor in the system will run. Used to define the
+    top end of the PState range in the frequency space. From this,
+    the ATTR_PROCPM_PSTATE0_FREQUENCY is computed using
+    ATTR_SYSTEM_REFCLK_FREQUENCY to determine the step size.
+    Consumers: proc_build_gpstate_table.C (among others) Data is is
+    provided by MVPD #V and is calculated as the minimum of the
+    turbo frequencies</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_FREQ_CORE_MAX</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- End pm_plat_attributes.xml -->
+  <attribute>
+    <id>PROC_PCIE_IOP_CONFIG</id>
+    <description>PCIE IOP lane configuration creator: platform
+    consumer: proc_pcie_scominit firmware notes: Encoded PCIE IOP
+    lane configuration</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_IOP_CONFIG</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PHB_ACTIVE</id>
+    <description>PCIE PHB valid mask creator: platform consumer:
+    proc_pcie_scominit firmware notes: Bit mask defining set of
+    active/valid PHBs bit0=PHB0, bit1=PHB1, bit2=PHB2,
+    bit3=PHB3</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PHB_ACTIVE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>AVDD_ID</id>
+    <description>Memory AVDD voltage domain ID. All memory buffers
+    in the same AVDD voltage domain will share the same ID. IDs are
+    arbitrarily assigned, used for correlation between HB + HWSV,
+    and are generated by genHwsvMrwXml.pl</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VDD_ID</id>
+    <description>Memory VDD voltage domain ID. All memory buffers
+    in the same VDD voltage domain will share the same ID. IDs are
+    arbitrarily assigned, used for correlation between HB + HWSV,
+    and are generated by genHwsvMrwXml.pl</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VCS_ID</id>
+    <description>Memory VCS voltage domain ID. All memory buffers
+    in the same VCS voltage domain will share the same ID. IDs are
+    arbitrarily assigned, used for correlation between HB + HWSV,
+    and are generated by genHwsvMrwXml.pl</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VPP_ID</id>
+    <description>Memory VPP voltage domain ID. All memory buffers
+    in the same VPP voltage domain will share the same ID. IDs are
+    arbitrarily assigned, used for correlation between HB + HWSV,
+    and are generated by genHwsvMrwXml.pl</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VDDR_ID</id>
+    <description>Voltage Memory Rail Manager ID. Currently HB only
+    needs to configured the Vddr voltage rail manager during the
+    IPL. The ID is an arbitary value and needed as correlation
+    token between HB and HWSV. It will be generated by the
+    genHwsvMrwXml.pl.</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NEST_VDDR_ID</id>
+    <description>Nest VDDR Voltage Rail ID. The ID is an arbitrary
+    value and is needed as correlation token between HB and HWSV.
+    It will be generated by the genHwsvMrwXml.pl</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NEST_VIO_ID</id>
+    <description>Nest VIO Voltage Rail ID. The ID is an arbitrary
+    value and is needed as correlation token between HB and HWSV.
+    It will be generated by the genHwsvMrwXml.pl</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NEST_VDD_ID</id>
+    <description>Nest VDD Voltage Rail ID. The ID is an arbitrary
+    value and is needed as correlation token between HB and HWSV.
+    It will be generated by the genHwsvMrwXml.pl</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NEST_VDN_ID</id>
+    <description>Nest VDN Voltage Rail ID. The ID is an arbitrary
+    value and is needed as correlation token between HB and HWSV.
+    It will be generated by the genHwsvMrwXml.pl</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NEST_VCS_ID</id>
+    <description>Nest VCS Voltage Rail ID. The ID is an arbitrary
+    value and is needed as correlation token between HB and HWSV.
+    It will be generated by the genHwsvMrwXml.pl</description>
+    <simpleType>
+      <uint16_t>
+        <default>0</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <!--    Add attributes for sbe_config_update    -->
+  <attribute>
+    <id>ASYNC_NEST_FREQ_MHZ</id>
+    <description>The asynchronous nest frequency</description>
+    <simpleType>
+      <uint32_t>
+        <default>2000</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_ASYNC_NEST_FREQ_MHZ</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_ADU_UNTRUSTED_BAR_BASE_ADDR</id>
+    <description>ADU Untrusted BAR base address (secure mode)
+    creator: platform firmware notes: 64-bit address representing
+    BAR RA</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000000000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_ADU_UNTRUSTED_BAR_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_ADU_UNTRUSTED_BAR_SIZE</id>
+    <description>ADU Untrusted BAR size (secure mode) creator:
+    platform firmware notes: mask applied to RA 14:43</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000000000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_ADU_UNTRUSTED_BAR_SIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>SBE_IMAGE_MINIMUM_VALID_EXS</id>
+    <description>The minimum number of valid EXs that is required
+    to be used when customizing a SBE image. The customization will
+    fail if it cannot create an image with at least this many
+    EXs.</description>
+    <simpleType>
+      <uint32_t>
+        <default>3</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_SBE_IMAGE_MINIMUM_VALID_EXS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PSI_UNTRUSTED_BAR0_BASE_ADDR</id>
+    <description>PSI Untrusted BAR0 base address (secure mode)
+    creator: platform firmware notes: 64-bit address representing
+    BAR RA</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000000000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PSI_UNTRUSTED_BAR0_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PSI_UNTRUSTED_BAR0_SIZE</id>
+    <description>PSI Untrusted BAR0 size (secure mode) creator:
+    platform firmware notes: mask applied to RA 14:43</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000000000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PSI_UNTRUSTED_BAR0_SIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PSI_UNTRUSTED_BAR1_BASE_ADDR</id>
+    <description>PSI Untrusted BAR1 base address (secure mode)
+    creator: platform firmware notes: 64-bit address representing
+    BAR RA</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000000000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PSI_UNTRUSTED_BAR1_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PSI_UNTRUSTED_BAR1_SIZE</id>
+    <description>PSI Untrusted BAR1 size (secure mode) creator:
+    platform firmware notes: mask applied to RA 14:43</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000000000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PSI_UNTRUSTED_BAR1_SIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_SECURITY_SETUP_VECTOR</id>
+    <description>Secureboot 64-bit proc_sbe_security_setup_vector
+    used by proc_sbe_security_setup.S. 0s are an unsecure SBE image
+    creator: platform firmware notes: 64-bit
+    proc_sbe_security_setup_vector</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x8000000080000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_SECURITY_SETUP_VECTOR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- ===== Attributes supporting memory_attributes.xml HWPF Attributes ===== -->
+  <attribute>
+    <id>MSS_VDDR_PROGRAM</id>
+    <description>VDDR memory programming type 0 = POWERON - domain
+    is programmed as part of regular power on sequence, 1 = STATIC
+    - domain needs to be programmed, no special computation needed,
+    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
+    logic</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <attribute>
+    <id>MSS_VPP_PROGRAM</id>
+    <description>VPP memory programming type 0 = POWERON - domain
+    is programmed as part of regular power on sequence, 1 = STATIC
+    - domain needs to be programmed, no special computation needed,
+    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
+    logic</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <attribute>
+    <id>MSS_VCS_PROGRAM</id>
+    <description>VCS memory programming type 0 = POWERON - domain
+    is programmed as part of regular power on sequence, 1 = STATIC
+    - domain needs to be programmed, no special computation needed,
+    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
+    logic</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <attribute>
+    <id>MSS_AVDD_PROGRAM</id>
+    <description>AVDD memory programming type 0 = POWERON - domain
+    is programmed as part of regular power on sequence, 1 = STATIC
+    - domain needs to be programmed, no special computation needed,
+    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
+    logic</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <attribute>
+    <id>MSS_VDD_PROGRAM</id>
+    <description>VDD memory programming type 0 = POWERON - domain
+    is programmed as part of regular power on sequence, 1 = STATIC
+    - domain needs to be programmed, no special computation needed,
+    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
+    logic</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <!-- Calculated dynamic voltages -->
+  <!-- end of Dynamic voltage -->
+  <!-- TODO RTC 87603. These termination data EFF attributes have corresponding
      VPD attributes that come from CVPD. When all HWPs are using the VPD
      versions, these EFF versions can be deleted -->
-<!-- TODO RTC 87603 down to here -->
-<attribute>
-  <id>MSS_ZSERIES</id>
-  <description>Determines if the code is Zseries type or P Series.
-  The platform determines this and this attribute is mostly used in
-  the initfiles so that we can share the same initialization code
-  with the zSeries team</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_ZSERIES</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- Note: This looks incorrect because memory_attributes.xml says it is platInit (therefore we should set it up to a sensible value),
+  <!-- TODO RTC 87603 down to here -->
+  <attribute>
+    <id>MSS_ZSERIES</id>
+    <description>Determines if the code is Zseries type or P
+    Series. The platform determines this and this attribute is
+    mostly used in the initfiles so that we can share the same
+    initialization code with the zSeries team</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_ZSERIES</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- Note: This looks incorrect because memory_attributes.xml says it is platInit (therefore we should set it up to a sensible value),
      but recent discussions have concluded that a HWP will fill this in, this implementation is correct, memory_attributes.xml will eventually change. -->
-<attribute>
-  <id>MSS_INTERLEAVE_ENABLE</id>
-  <description>Used in the setting of groups. It is a bit vector.
-  If the value BITWISE_AND 0x01 = 0x01 then groups of 1 are
-  enabled, if the value BITWISE_AND 0x02 = 0x02, then groups of 2
-  are possible, if the value BITWISE_AND 0x04 = 0x04, then group of
-  3 are possible, if the value BITWISE_AND 0x08 = 0x08, then groups
-  of 4 are possible, if the value BITWISE_AND 0x20 = 0x20, then
-  groups of 6 are possible, if the value BITWISE_AND 0x80 = 0x80,
-  then groups of 8 are possible. If no groups can formed according
-  to this input, then an error will be thrown. Provided by the MRW
-  This attribute is based on Machine-Type-Model (MTM) and is setup
-  by the service processor.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0xAF</default>
-      <!-- Maximum interleaving -->
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_INTERLEAVE_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_INTERLEAVE_GRANULARITY</id>
-  <description>Determines the stride covered by each granule in an
-  interleaving group. The default stride -- 128B -- is the only
-  value intended for production FW use. All other combinations are
-  for experimental performance evaluation. Regardless of this
-  attribute value, groups of size 1, 3, and 6 will be forced to
-  128B stride based on the logic capabilities. 128_B = 0x00, 256_B
-  = 0x01, 512_B = 0x02, 1_KB = 0x03, 2_KB = 0x04, 4_KB = 0x05, 8_KB
-  = 0x06, 16_KB = 0x07, 32_KB = 0x08</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_INTERLEAVE_GRANULARITY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MBA_ADDR_INTERLEAVE_BIT</id>
-  <description>sets the Centaur address bits used to interleave
-  addresses between MBA01 and MBA23. valid values are 23 through
-  32.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MBA_ADDR_INTERLEAVE_BIT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MBA_CACHELINE_INTERLEAVE_MODE</id>
-  <description>centaur interleave mode. 1 = 256-BIT, 0 =
-  128-BIT.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MBA_CACHELINE_INTERLEAVE_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_PREFETCH_ENABLE</id>
-  <description>Value of on or off. Determines if prefetching
-  enabled or not. See chapter 7 of the Centaur
-  Workbook.</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_PREFETCH_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_CLEANER_ENABLE</id>
-  <description>Value of on or off. Determines if the cleaner of the
-  L4 cache (write modified entries to memory on idle cycles)
-  enabled or not. See chapter 7 of the Centaur
-  Workbook.</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_CLEANER_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>OBUS_RATIO_VALUE</id>
-  <description>Holds Obus ratio value</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_OBUS_RATIO_VALUE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!--TOOD RTC: 151938 Make sure that these are set up by parseMRW script-->
-<attribute>
-  <id>MSS_MRW_SUPPORTED_FREQ</id>
-  <description>List of memory frequencies supported by the current
-  system.</description>
-  <simpleType>
-    <uint32_t>
-      <default>1866,2133,2400,2667</default>
-    </uint32_t>
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_SUPPORTED_FREQ</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MEMVPD_POS</id>
-  <description>The position of the MCS target's VPD selector data,
-  relative to the EEPROM that contains its data. The VPD defition
-  supports up to 16 values per EEPROM. For systems with an EEPROM
-  per chip, this value should be equivalent to ATTR_CHIP_UNIT_POS.
-  For systems with a single EEPROM for all chips, the value should
-  follow the physical position in such a way to fit within the 16
-  available slots.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0xFF</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MEMVPD_POS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_ALLOW_SINGLE_PORT</id>
-  <description>When this value is true, then mss_eff config will
-  allow a single port to have one dimm and will allow ports to have
-  different sizes. Used in eff_config</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-      <array>2</array>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_ALLOW_SINGLE_PORT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- TODO RTC 87603. These phase rotator EFF attributes have corresponding
+  <attribute>
+    <id>MSS_INTERLEAVE_ENABLE</id>
+    <description>Used in the setting of groups. It is a bit vector.
+    If the value BITWISE_AND 0x01 = 0x01 then groups of 1 are
+    enabled, if the value BITWISE_AND 0x02 = 0x02, then groups of 2
+    are possible, if the value BITWISE_AND 0x04 = 0x04, then group
+    of 3 are possible, if the value BITWISE_AND 0x08 = 0x08, then
+    groups of 4 are possible, if the value BITWISE_AND 0x20 = 0x20,
+    then groups of 6 are possible, if the value BITWISE_AND 0x80 =
+    0x80, then groups of 8 are possible. If no groups can formed
+    according to this input, then an error will be thrown. Provided
+    by the MRW This attribute is based on Machine-Type-Model (MTM)
+    and is setup by the service processor.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0xAF</default>
+        <!-- Maximum interleaving -->
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_INTERLEAVE_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_INTERLEAVE_GRANULARITY</id>
+    <description>Determines the stride covered by each granule in
+    an interleaving group. The default stride -- 128B -- is the
+    only value intended for production FW use. All other
+    combinations are for experimental performance evaluation.
+    Regardless of this attribute value, groups of size 1, 3, and 6
+    will be forced to 128B stride based on the logic capabilities.
+    128_B = 0x00, 256_B = 0x01, 512_B = 0x02, 1_KB = 0x03, 2_KB =
+    0x04, 4_KB = 0x05, 8_KB = 0x06, 16_KB = 0x07, 32_KB =
+    0x08</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_INTERLEAVE_GRANULARITY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MBA_ADDR_INTERLEAVE_BIT</id>
+    <description>sets the Centaur address bits used to interleave
+    addresses between MBA01 and MBA23. valid values are 23 through
+    32.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MBA_ADDR_INTERLEAVE_BIT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MBA_CACHELINE_INTERLEAVE_MODE</id>
+    <description>centaur interleave mode. 1 = 256-BIT, 0 =
+    128-BIT.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MBA_CACHELINE_INTERLEAVE_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_PREFETCH_ENABLE</id>
+    <description>Value of on or off. Determines if prefetching
+    enabled or not. See chapter 7 of the Centaur
+    Workbook.</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_PREFETCH_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_CLEANER_ENABLE</id>
+    <description>Value of on or off. Determines if the cleaner of
+    the L4 cache (write modified entries to memory on idle cycles)
+    enabled or not. See chapter 7 of the Centaur
+    Workbook.</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_CLEANER_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>OBUS_RATIO_VALUE</id>
+    <description>Holds Obus ratio value</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_OBUS_RATIO_VALUE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!--TOOD RTC: 151938 Make sure that these are set up by parseMRW script-->
+  <attribute>
+    <id>MSS_MRW_SUPPORTED_FREQ</id>
+    <description>List of memory frequencies supported by the
+    current system.</description>
+    <simpleType>
+      <uint32_t>
+        <default>1866,2133,2400,2667</default>
+      </uint32_t>
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_SUPPORTED_FREQ</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MEMVPD_POS</id>
+    <description>The position of the MCS target's VPD selector
+    data, relative to the EEPROM that contains its data. The VPD
+    defition supports up to 16 values per EEPROM. For systems with
+    an EEPROM per chip, this value should be equivalent to
+    ATTR_CHIP_UNIT_POS. For systems with a single EEPROM for all
+    chips, the value should follow the physical position in such a
+    way to fit within the 16 available slots.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0xFF</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MEMVPD_POS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_ALLOW_SINGLE_PORT</id>
+    <description>When this value is true, then mss_eff config will
+    allow a single port to have one dimm and will allow ports to
+    have different sizes. Used in eff_config</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+        <array>2</array>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_ALLOW_SINGLE_PORT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- TODO RTC 87603. These phase rotator EFF attributes have corresponding
      VPD attributes that come from CVPD. When all HWPs are using the VPD
      versions, these EFF versions can be deleted -->
-<!-- TODO RTC 87603 down to here -->
-<attribute>
-  <id>MSS_DQS_SWIZZLE_TYPE</id>
-  <description>DQS Swizzle type is set by the platform to describe
-  what kind of DQS connection is being used for register acceses.
-  Type 0 is normal, type 1 is for systems with wiring like glacier
-  1, type 2 is for Pallmeto. Additional types maybe defined if new
-  boards have even different DQS swizzle features</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-    <array>2</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_DQS_SWIZZLE_TYPE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- ===== End Attributes supporting memory_attributes.xml HWPF Attributes ===== -->
-<attribute>
-  <id>EI_BUS_TX_LANE_INVERT</id>
-  <description>This attribute represents the polarity of a
-  differential wire pair on the DMI and A buses. creator: platform
-  (generated based on MRW data) See defintion in
-  common_attributes.xml for more information.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_EI_BUS_TX_LANE_INVERT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- ===== Supporting poreve_memory_attributes.xml ===== -->
-<attribute>
-  <id>SBE_SEEPROM_I2C_ADDRESS_BYTES</id>
-  <description>The number of address bytes required to address the
-  SEEPROM memory device that contains SBE IPL code. This will vary
-  by device based on the device capacity, and must be either 1, 2,
-  3 or 4.</description>
-  <simpleType>
-    <uint8_t>
-      <default>2</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_SBE_SEEPROM_I2C_ADDRESS_BYTES</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PNOR_I2C_ADDRESS_BYTES</id>
-  <description>The number of address bytes required to address the
-  PNOR memory device via the pseudo-I2C (LPC, ECCAX) controller.
-  This will vary by device based on the device capacity, and must
-  be either 0, 1, 2, 3 or 4. This attribute will be set to 0 for
-  chips with no PNOR attached (PoreVe will never run on these
-  chips). Provided by the Machine Readable Workbook</description>
-  <simpleType>
-    <uint8_t>
-      <default>4</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PNOR_I2C_ADDRESS_BYTES</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- ===== End supporting poreve_memory_attributes.xml ===== -->
-<!-- Support for sync_attributes.xml -->
-<!-- End support for sync_attributes.xml -->
-<!--    Support for proc_select_boot_master -->
-<attribute>
-  <id>MAX_PROC_CHIPS_PER_NODE</id>
-  <description>System attribute. The max proc chips per node
-  available in the system.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MAX_EXS_PER_PROC_CHIP</id>
-  <description>System attribute. The max EX units per proc chip
-  available in the system.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MAX_DIMMS_PER_MBA_PORT</id>
-  <description>System attribute. The max DIMMs per MBA Port
-  available in the system.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MAX_MBA_PORTS_PER_MBA</id>
-  <description>System attribute. The max MBA ports per MBA
-  available in the system.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MAX_MBAS_PER_MEMBUF_CHIP</id>
-  <description>System attribute. The max MBAS per membuf available
-  in the system.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MAX_CHIPLETS_PER_PROC</id>
-  <description>System attribute. The max chiplets per proc
-  available in the system.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MAX_MCS_PER_SYSTEM</id>
-  <description>System attribute. The max MCS units available in the
-  system.</description>
-  <simpleType>
-    <uint8_t>
-      <default>4</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>TEST_NEGATIVE_FCN</id>
-  <description>Attribute to test signed attribute functionality in
-  the system</description>
-  <simpleType>
-    <int8_t>
-      <default>-6</default>
-    </int8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <writeable />
-  <readable />
-</attribute>
-<!-- Note: This attribute is only used by FSP -->
-<attribute>
-  <id>DMI_REFCLOCK_SWIZZLE</id>
-  <description>Defines Murano/Venice/Naples FSI GP8 refclock enable
-  field bit offset (0:7) associated with this MCS chip
-  unit.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_DMI_REFCLOCK_SWIZZLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>EI_BUS_TX_MSBSWAP</id>
-  <description>Source: MRW: Downstream MSB Swap and Upstream MSB
-  Swap Usage: TX_MSBSWAP initfile setting for DMI and A buses This
-  attribute represents whether or not a single clock group bus such
-  as DMI and A bus was wired by the board designer using a feature
-  called MSB Swap where lane 0 of the TX chip wires to lane n-1 on
-  the RX chip where 'n' is the width of the bus. A basic
-  description of this capability is that the board designer can
-  save layers on the board wiring by crossing the wiring between
-  the two chips in a prescribed manner. In a non-MSB Swapped bus
-  Lane 0 on the TX chip wires to lane 0 on the RX chip, lane 1 to
-  lane 1 and so on. If a bus is MSB Swapped then lane 0 of the TX
-  chip wires to lane 'n-1' of the RX chip, lane 1 to lane 'n-2',
-  etc. Random or arbitrary wiring of TX to RX lanes on different
-  chips is NOT ALLOWED. The Master Chip of two connected chips is
-  defined as the chip with the smaller value of (100*Node + Pos).
-  The Slave Chip of two connected chips is defined as the chip with
-  the larger value of (100*Node + Pos). The Downstream direction is
-  defined as the direction from the Master chip to the Slave chip.
-  The Upstream direction is defined as the direction from the Slave
-  chip to the Master chip. The Downstream TX_MSBSWAP from the MRW
-  is a uint8 value. 0x01 means the Downstream bus is wired msb to
-  lsb etc. and 0x00 means the bus is wired normally, msb to msb,
-  lsb to lsb (lane0 to lane0). The Upstream TX_MSBSWAP from the MRW
-  is a uint8 value. 0x01 means the Upstream bus is wired msb to lsb
-  etc. and 0x00 means the bus is wired normally, msb to msb, lsb to
-  lsb (lane0 to lane0). It is up to the platform code to set up
-  each ATTR_EI_BUS_TX_MSBSWAP value for the correct target
-  endpoints.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_EI_BUS_TX_MSBSWAP</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- mcbist attributes -->
-<attribute>
-  <id>PROC_DCM_INSTALLED</id>
-  <description>PROC_CHIP Attribute If true, the chip is installed
-  on a Dual Chip Module Provided by the Machine Readable
-  Workbook</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_DCM_INSTALLED</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- === Attributes supporting erepair_thresholds.xml HWPF Attributes === -->
-<attribute>
-  <id>X_EREPAIR_THRESHOLD_FIELD</id>
-  <description>This attribute represents the eRepair threshold
-  value of X-Bus used in the field. creator: platform (generated
-  based on MRW data) See defintion in erepair_thresholds.xml for
-  more information.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_X_EREPAIR_THRESHOLD_FIELD</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>A_EREPAIR_THRESHOLD_FIELD</id>
-  <description>This attribute represents the eRepair threshold
-  value of A-Bus used in the field. creator: platform (generated
-  based on MRW data) See defintion in erepair_thresholds.xml for
-  more information.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_A_EREPAIR_THRESHOLD_FIELD</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>DMI_EREPAIR_THRESHOLD_FIELD</id>
-  <description>This attribute represents the eRepair threshold
-  value of DMI-Bus used in the field. creator: platform (generated
-  based on MRW data) See defintion in erepair_thresholds.xml for
-  more information.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_DMI_EREPAIR_THRESHOLD_FIELD</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>X_EREPAIR_THRESHOLD_MNFG</id>
-  <description>This attribute represents the eRepair threshold
-  value of X-Bus used by Manufacturing. creator: platform
-  (generated based on MRW data) See defintion in
-  erepair_thresholds.xml for more information.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_X_EREPAIR_THRESHOLD_MNFG</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>A_EREPAIR_THRESHOLD_MNFG</id>
-  <description>This attribute represents the eRepair threshold
-  value of A-Bus used by Manufacturing. creator: platform
-  (generated based on MRW data) See defintion in
-  erepair_thresholds.xml for more information.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_A_EREPAIR_THRESHOLD_MNFG</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>DMI_EREPAIR_THRESHOLD_MNFG</id>
-  <description>This attribute represents the eRepair threshold
-  value of DMI-Bus used by Manufacturing. creator: platform
-  (generated based on MRW data) See defintion in
-  erepair_thresholds.xml for more information.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_DMI_EREPAIR_THRESHOLD_MNFG</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- ===== End Attributes supporting erepair_thresholds.xml HWPF Attributes ===== -->
-<!-- Mem PLL attributes ===== -->
-<attribute>
-  <id>MEMB_TP_BNDY_PLL_SCAN_SELECT</id>
-  <description>Scan select for ring image for Centaur tp_bndy_pll
-  ring creator: platform firmware notes:</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x00100008</default>
-    </uint32_t>
-  </simpleType>
-  <readable />
-  <persistency>non-volatile</persistency>
-  <hwpfToHbAttrMap>
-    <id>ATTR_MEMB_TP_BNDY_PLL_SCAN_SELECT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_MBA</id>
-  <description>Machine Readable Workbook safe mode throttle value
-  for numerator cfg_nm_n_per_mba</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_MBA</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_CHIP</id>
-  <description>Machine Readable Workbook safe mode throttle value
-  for numerator cfg_nm_n_per_chip</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_CHIP</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_THERMAL_MEMORY_POWER_LIMIT</id>
-  <description>Machine Readable Workbook Thermal Memory Power Limit
-  Used to calculate throttles to be at or under the power limit Per
-  DIMM basis Consumers: eff_config_thermal and
-  bulk_pwr_throttles</description>
-  <simpleType>
-    <uint64_t>
-      <default>0xffffe000000006a4,0,0,0,0,0,0,0,0,0</default>
-    </uint64_t>
-    <array>10</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_THERMAL_MEMORY_POWER_LIMIT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>FRU_ID</id>
-  <description>FRU ID attribute used to report FRU information to
-  the BMC for each fru in the system.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <global />
-</attribute>
-<attribute>
-  <id>BMC_FRU_ID</id>
-  <description>BMC FRU ID attribute to report the system firmware
-  levels to the BMC.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>CENTAUR_ECID_FRU_ID</id>
-  <description>FRU ID attribute for centaur ECID data. This fru ID
-  is used to report the ECID data to the BMC and make it available
-  for systems which have then centaur chips soldered to the
-  backplane.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PLCK_IPL_ATTR_OVERRIDES_EXIST</id>
-  <description>Set to 1 by HWSV to indicate that attribute
-  overrides exist in a PLCK IPL (not an IPL by steps). This is read
-  by Hostboot to determine if it needs to request the attribute
-  overrides from HWSV before starting its IPL.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0x00</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>DUMMY_PERSISTENCY</id>
-  <description>Cached value to test persistency</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_DUMMY_PERSISTENCY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PEER_PATH</id>
-  <description>Entity path of the peer target of an
-  Abus</description>
-  <nativeType>
-    <name>EntityPath</name>
-  </nativeType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MEM_MIRROR_PLACEMENT_POLICY</id>
-  <description>Define placement policy/scheme for
-  non-mirrored/mirrored memory layout creator: platform consumer:
-  opt_memmap firmware notes: NORMAL = non-mirrored start: 0,
-  mirrored start: 512TB FLIPPED = mirrored start: 0, non-mirrored
-  start: 512TB SELECTIVE = non-mirrored/mirrored start
-  (interleaved): 0 DRAWER = non-mirrored start: 1TB*drawer,
-  mirrored start: 512TB+(1TB*drawer/2)</description>
-  <simpleType>
-    <uint8_t>
-      <!-- Normal -->
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MEM_MIRROR_PLACEMENT_POLICY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_AS_MMIO_BAR_BASE_ADDR</id>
-  <description>AS MMIO BAR base address value creator: platform
-  consumer: proc_setup_bars firmware notes: 64-bit address
-  representing BAR RA NOTE: BAR register covers RA
-  14:51</description>
-  <simpleType>
-    <uint64_t>
-      <default>0</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_AS_MMIO_BAR_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_AS_MMIO_BAR_ENABLE</id>
-  <description>AS MMIO BAR enable creator: platform consumer:
-  proc_setup_bars firmware notes: none</description>
-  <simpleType>
-    <uint8_t>
-      <!-- Disabled -->
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_AS_MMIO_BAR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_AS_MMIO_BAR_SIZE</id>
-  <description>AS MMIO BAR size value creator: platform consumer:
-  proc_setup_bars firmware notes: none</description>
-  <simpleType>
-    <uint64_t>
-      <!-- 2_MB -->
-      <default>0x0000000000200000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_AS_MMIO_BAR_SIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_MEM_SENSOR_CACHE_ADDR_MAP</id>
-  <description>Machine Readable Workbook value detailing the wiring
-  of the 8 dimm temperature sensors for non custom dimms, in DIMM
-  A0, A1,B0,B1,C0,C1,D0,D1 order. One nibble per sensor where bit0
-  (MSB) is the i2c bus the sensor is attached to (0 for master, 1
-  for spare) and bits 1:3 are for A2,A1,A0 of the sensor i2c
-  address (where A2 is MSB)</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_MEM_SENSOR_CACHE_ADDR_MAP</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>CDIMM_SENSOR_MAP_PRIMARY</id>
-  <description>Custom DIMM Sensor Map for Primary I2C Port (1 byte
-  of data): 0x00 No sensors attached 0x01 DIMM sensor 0 attached
-  0x02 DIMM sensor 1 attached 0x04 DIMM sensor 2 attached 0x08 DIMM
-  sensor 3 attached 0x10 DIMM sensor 4 attached 0x20 DIMM sensor 5
-  attached 0x40 DIMM sensor 6 attached 0x80 DIMM sensor 7 attached
-  Comes from the VPD MW Keyword</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_CDIMM_SENSOR_MAP_PRIMARY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>CDIMM_SENSOR_MAP_SECONDARY</id>
-  <description>Custom DIMM Sensor Map for Secondary I2C Port (1
-  byte of data): 0x00 No sensors attached 0x01 DIMM sensor 0
-  attached 0x02 DIMM sensor 1 attached 0x04 DIMM sensor 2 attached
-  0x08 DIMM sensor 3 attached 0x10 DIMM sensor 4 attached 0x20 DIMM
-  sensor 5 attached 0x40 DIMM sensor 6 attached 0x80 DIMM sensor 7
-  attached Comes from the VPD MW Keyword</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_CDIMM_SENSOR_MAP_SECONDARY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>CDM_POLICIES</id>
-  <description>Cec Degraded Mode Policy flags Use the CDM_POLICIES
-  enum to decode. If the appropriate bit is 1 then the policy mode
-  is enabled, and those type of Guard records are
-  disabled.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0x00</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <writeable />
-  <readable />
-</attribute>
-<enumerationType>
-  <id>CDM_POLICIES</id>
-  <description>Enumeration of CDM_POLICIES flags</description>
-  <enumerator>
-    <description>MFG_Guard policy: Used in MFG only to prevent and
-    disable the following: . Storing or creation of new Guard
-    records from Diagno`stic or other faults through error logs.
-    This is all domains, CEC processor/memory, VPD, FSP, etc. .
-    Storing or creation of Manual Guard record from user. NOTE:
-    this does not stop FCO. . Using an already stored System or
-    Manual Guard record from deconfiguring resources. This is all
-    domains, CEC processor/memory, VPD, FSP, etc.</description>
-    <name>MANUFACTURING_DISABLED</name>
-    <value>0x01</value>
-  </enumerator>
-  <enumerator>
-    <description>Predictive_Guard policy: Used in Field or
-    development to prevent and disable the following: . Storing or
-    creation of new Guard records from diagnostics or other faults
-    through error logs with the error_type of Predictive. . Using
-    an already stored System Guard record with error_type of
-    Predictive from deconfiguring resources.</description>
-    <name>PREDICTIVE_DISABLED</name>
-    <value>0x02</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>FIELD_CORE_OVERRIDE</id>
-  <description>Field Core Override (FCO) is the override value for
-  the number of functional cores allowed on the system. FCO is used
-  when customers order a system with N cores but they only want to
-  enable less than N cores to lower software license costs. A field
-  in the anchor VPD is set by manufacturing to specify the maximum
-  number of cores to enable. The number is maintained, even if some
-  cores are garded out due to error. A value of 0 means all cores
-  allowed;</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>HOSTSVC_PLID</id>
-  <description>Value of the next PLID that host service should
-  send</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x89000000</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>RUN_MAX_MEM_PATTERNS</id>
-  <description>Policy indicating whether to perform the maximum
-  amount of memory pattern testing possible or not. Set to 0x01 to
-  perform the maximum amount of memory pattern testing possible.
-  Set to 0x00 to perform the default amount of memory pattern
-  testing.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>LAB_USE_JTAG_MODE</id>
-  <description>This attribute controls how the procedures operate
-  in JTAG mode under an environment called cronus flex. For normal
-  operation, this attribute should be set to FALSE. Platforms
-  should initialize this attribute to FALSE.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_LAB_USE_JTAG_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!--
+  <!-- TODO RTC 87603 down to here -->
+  <attribute>
+    <id>MSS_DQS_SWIZZLE_TYPE</id>
+    <description>DQS Swizzle type is set by the platform to
+    describe what kind of DQS connection is being used for register
+    acceses. Type 0 is normal, type 1 is for systems with wiring
+    like glacier 1, type 2 is for Pallmeto. Additional types maybe
+    defined if new boards have even different DQS swizzle
+    features</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+      <array>2</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_DQS_SWIZZLE_TYPE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- ===== End Attributes supporting memory_attributes.xml HWPF Attributes ===== -->
+  <attribute>
+    <id>EI_BUS_TX_LANE_INVERT</id>
+    <description>This attribute represents the polarity of a
+    differential wire pair on the DMI and A buses. creator:
+    platform (generated based on MRW data) See defintion in
+    common_attributes.xml for more information.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_EI_BUS_TX_LANE_INVERT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- ===== Supporting poreve_memory_attributes.xml ===== -->
+  <attribute>
+    <id>SBE_SEEPROM_I2C_ADDRESS_BYTES</id>
+    <description>The number of address bytes required to address
+    the SEEPROM memory device that contains SBE IPL code. This will
+    vary by device based on the device capacity, and must be either
+    1, 2, 3 or 4.</description>
+    <simpleType>
+      <uint8_t>
+        <default>2</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_SBE_SEEPROM_I2C_ADDRESS_BYTES</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PNOR_I2C_ADDRESS_BYTES</id>
+    <description>The number of address bytes required to address
+    the PNOR memory device via the pseudo-I2C (LPC, ECCAX)
+    controller. This will vary by device based on the device
+    capacity, and must be either 0, 1, 2, 3 or 4. This attribute
+    will be set to 0 for chips with no PNOR attached (PoreVe will
+    never run on these chips). Provided by the Machine Readable
+    Workbook</description>
+    <simpleType>
+      <uint8_t>
+        <default>4</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PNOR_I2C_ADDRESS_BYTES</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- ===== End supporting poreve_memory_attributes.xml ===== -->
+  <!-- Support for sync_attributes.xml -->
+  <!-- End support for sync_attributes.xml -->
+  <!--    Support for proc_select_boot_master -->
+  <attribute>
+    <id>MAX_PROC_CHIPS_PER_NODE</id>
+    <description>System attribute. The max proc chips per node
+    available in the system.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MAX_EXS_PER_PROC_CHIP</id>
+    <description>System attribute. The max EX units per proc chip
+    available in the system.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MAX_DIMMS_PER_MBA_PORT</id>
+    <description>System attribute. The max DIMMs per MBA Port
+    available in the system.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MAX_MBA_PORTS_PER_MBA</id>
+    <description>System attribute. The max MBA ports per MBA
+    available in the system.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MAX_MBAS_PER_MEMBUF_CHIP</id>
+    <description>System attribute. The max MBAS per membuf
+    available in the system.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MAX_CHIPLETS_PER_PROC</id>
+    <description>System attribute. The max chiplets per proc
+    available in the system.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MAX_MCS_PER_SYSTEM</id>
+    <description>System attribute. The max MCS units available in
+    the system.</description>
+    <simpleType>
+      <uint8_t>
+        <default>4</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>TEST_NEGATIVE_FCN</id>
+    <description>Attribute to test signed attribute functionality
+    in the system</description>
+    <simpleType>
+      <int8_t>
+        <default>-6</default>
+      </int8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <writeable />
+    <readable />
+  </attribute>
+  <!-- Note: This attribute is only used by FSP -->
+  <attribute>
+    <id>DMI_REFCLOCK_SWIZZLE</id>
+    <description>Defines Murano/Venice/Naples FSI GP8 refclock
+    enable field bit offset (0:7) associated with this MCS chip
+    unit.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_DMI_REFCLOCK_SWIZZLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>EI_BUS_TX_MSBSWAP</id>
+    <description>Source: MRW: Downstream MSB Swap and Upstream MSB
+    Swap Usage: TX_MSBSWAP initfile setting for DMI and A buses
+    This attribute represents whether or not a single clock group
+    bus such as DMI and A bus was wired by the board designer using
+    a feature called MSB Swap where lane 0 of the TX chip wires to
+    lane n-1 on the RX chip where 'n' is the width of the bus. A
+    basic description of this capability is that the board designer
+    can save layers on the board wiring by crossing the wiring
+    between the two chips in a prescribed manner. In a non-MSB
+    Swapped bus Lane 0 on the TX chip wires to lane 0 on the RX
+    chip, lane 1 to lane 1 and so on. If a bus is MSB Swapped then
+    lane 0 of the TX chip wires to lane 'n-1' of the RX chip, lane
+    1 to lane 'n-2', etc. Random or arbitrary wiring of TX to RX
+    lanes on different chips is NOT ALLOWED. The Master Chip of two
+    connected chips is defined as the chip with the smaller value
+    of (100*Node + Pos). The Slave Chip of two connected chips is
+    defined as the chip with the larger value of (100*Node + Pos).
+    The Downstream direction is defined as the direction from the
+    Master chip to the Slave chip. The Upstream direction is
+    defined as the direction from the Slave chip to the Master
+    chip. The Downstream TX_MSBSWAP from the MRW is a uint8 value.
+    0x01 means the Downstream bus is wired msb to lsb etc. and 0x00
+    means the bus is wired normally, msb to msb, lsb to lsb (lane0
+    to lane0). The Upstream TX_MSBSWAP from the MRW is a uint8
+    value. 0x01 means the Upstream bus is wired msb to lsb etc. and
+    0x00 means the bus is wired normally, msb to msb, lsb to lsb
+    (lane0 to lane0). It is up to the platform code to set up each
+    ATTR_EI_BUS_TX_MSBSWAP value for the correct target
+    endpoints.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_EI_BUS_TX_MSBSWAP</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- mcbist attributes -->
+  <attribute>
+    <id>PROC_DCM_INSTALLED</id>
+    <description>PROC_CHIP Attribute If true, the chip is installed
+    on a Dual Chip Module Provided by the Machine Readable
+    Workbook</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_DCM_INSTALLED</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- === Attributes supporting erepair_thresholds.xml HWPF Attributes === -->
+  <attribute>
+    <id>X_EREPAIR_THRESHOLD_FIELD</id>
+    <description>This attribute represents the eRepair threshold
+    value of X-Bus used in the field. creator: platform (generated
+    based on MRW data) See defintion in erepair_thresholds.xml for
+    more information.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_X_EREPAIR_THRESHOLD_FIELD</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>A_EREPAIR_THRESHOLD_FIELD</id>
+    <description>This attribute represents the eRepair threshold
+    value of A-Bus used in the field. creator: platform (generated
+    based on MRW data) See defintion in erepair_thresholds.xml for
+    more information.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_A_EREPAIR_THRESHOLD_FIELD</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>DMI_EREPAIR_THRESHOLD_FIELD</id>
+    <description>This attribute represents the eRepair threshold
+    value of DMI-Bus used in the field. creator: platform
+    (generated based on MRW data) See defintion in
+    erepair_thresholds.xml for more information.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_DMI_EREPAIR_THRESHOLD_FIELD</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>X_EREPAIR_THRESHOLD_MNFG</id>
+    <description>This attribute represents the eRepair threshold
+    value of X-Bus used by Manufacturing. creator: platform
+    (generated based on MRW data) See defintion in
+    erepair_thresholds.xml for more information.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_X_EREPAIR_THRESHOLD_MNFG</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>A_EREPAIR_THRESHOLD_MNFG</id>
+    <description>This attribute represents the eRepair threshold
+    value of A-Bus used by Manufacturing. creator: platform
+    (generated based on MRW data) See defintion in
+    erepair_thresholds.xml for more information.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_A_EREPAIR_THRESHOLD_MNFG</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>DMI_EREPAIR_THRESHOLD_MNFG</id>
+    <description>This attribute represents the eRepair threshold
+    value of DMI-Bus used by Manufacturing. creator: platform
+    (generated based on MRW data) See defintion in
+    erepair_thresholds.xml for more information.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_DMI_EREPAIR_THRESHOLD_MNFG</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- ===== End Attributes supporting erepair_thresholds.xml HWPF Attributes ===== -->
+  <!-- Mem PLL attributes ===== -->
+  <attribute>
+    <id>MEMB_TP_BNDY_PLL_SCAN_SELECT</id>
+    <description>Scan select for ring image for Centaur tp_bndy_pll
+    ring creator: platform firmware notes:</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x00100008</default>
+      </uint32_t>
+    </simpleType>
+    <readable />
+    <persistency>non-volatile</persistency>
+    <hwpfToHbAttrMap>
+      <id>ATTR_MEMB_TP_BNDY_PLL_SCAN_SELECT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_MBA</id>
+    <description>Machine Readable Workbook safe mode throttle value
+    for numerator cfg_nm_n_per_mba</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_MBA</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_CHIP</id>
+    <description>Machine Readable Workbook safe mode throttle value
+    for numerator cfg_nm_n_per_chip</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_CHIP</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_THERMAL_MEMORY_POWER_LIMIT</id>
+    <description>Machine Readable Workbook Thermal Memory Power
+    Limit Used to calculate throttles to be at or under the power
+    limit Per DIMM basis Consumers: eff_config_thermal and
+    bulk_pwr_throttles</description>
+    <simpleType>
+      <uint64_t>
+        <default>0xffffe000000006a4,0,0,0,0,0,0,0,0,0</default>
+      </uint64_t>
+      <array>10</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_THERMAL_MEMORY_POWER_LIMIT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>FRU_ID</id>
+    <description>FRU ID attribute used to report FRU information to
+    the BMC for each fru in the system.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <global />
+  </attribute>
+  <attribute>
+    <id>BMC_FRU_ID</id>
+    <description>BMC FRU ID attribute to report the system firmware
+    levels to the BMC.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>CENTAUR_ECID_FRU_ID</id>
+    <description>FRU ID attribute for centaur ECID data. This fru
+    ID is used to report the ECID data to the BMC and make it
+    available for systems which have then centaur chips soldered to
+    the backplane.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PLCK_IPL_ATTR_OVERRIDES_EXIST</id>
+    <description>Set to 1 by HWSV to indicate that attribute
+    overrides exist in a PLCK IPL (not an IPL by steps). This is
+    read by Hostboot to determine if it needs to request the
+    attribute overrides from HWSV before starting its
+    IPL.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0x00</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>DUMMY_PERSISTENCY</id>
+    <description>Cached value to test persistency</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_DUMMY_PERSISTENCY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PEER_PATH</id>
+    <description>Entity path of the peer target of an
+    Abus</description>
+    <nativeType>
+      <name>EntityPath</name>
+    </nativeType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MEM_MIRROR_PLACEMENT_POLICY</id>
+    <description>Define placement policy/scheme for
+    non-mirrored/mirrored memory layout creator: platform consumer:
+    opt_memmap firmware notes: NORMAL = non-mirrored start: 0,
+    mirrored start: 512TB FLIPPED = mirrored start: 0, non-mirrored
+    start: 512TB SELECTIVE = non-mirrored/mirrored start
+    (interleaved): 0 DRAWER = non-mirrored start: 1TB*drawer,
+    mirrored start: 512TB+(1TB*drawer/2)</description>
+    <simpleType>
+      <uint8_t>
+        <!-- Normal -->
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MEM_MIRROR_PLACEMENT_POLICY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_AS_MMIO_BAR_BASE_ADDR</id>
+    <description>AS MMIO BAR base address value creator: platform
+    consumer: proc_setup_bars firmware notes: 64-bit address
+    representing BAR RA NOTE: BAR register covers RA
+    14:51</description>
+    <simpleType>
+      <uint64_t>
+        <default>0</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_AS_MMIO_BAR_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_AS_MMIO_BAR_ENABLE</id>
+    <description>AS MMIO BAR enable creator: platform consumer:
+    proc_setup_bars firmware notes: none</description>
+    <simpleType>
+      <uint8_t>
+        <!-- Disabled -->
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_AS_MMIO_BAR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_AS_MMIO_BAR_SIZE</id>
+    <description>AS MMIO BAR size value creator: platform consumer:
+    proc_setup_bars firmware notes: none</description>
+    <simpleType>
+      <uint64_t>
+        <!-- 2_MB -->
+        <default>0x0000000000200000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_AS_MMIO_BAR_SIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_MEM_SENSOR_CACHE_ADDR_MAP</id>
+    <description>Machine Readable Workbook value detailing the
+    wiring of the 8 dimm temperature sensors for non custom dimms,
+    in DIMM A0, A1,B0,B1,C0,C1,D0,D1 order. One nibble per sensor
+    where bit0 (MSB) is the i2c bus the sensor is attached to (0
+    for master, 1 for spare) and bits 1:3 are for A2,A1,A0 of the
+    sensor i2c address (where A2 is MSB)</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_MEM_SENSOR_CACHE_ADDR_MAP</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>CDIMM_SENSOR_MAP_PRIMARY</id>
+    <description>Custom DIMM Sensor Map for Primary I2C Port (1
+    byte of data): 0x00 No sensors attached 0x01 DIMM sensor 0
+    attached 0x02 DIMM sensor 1 attached 0x04 DIMM sensor 2
+    attached 0x08 DIMM sensor 3 attached 0x10 DIMM sensor 4
+    attached 0x20 DIMM sensor 5 attached 0x40 DIMM sensor 6
+    attached 0x80 DIMM sensor 7 attached Comes from the VPD MW
+    Keyword</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_CDIMM_SENSOR_MAP_PRIMARY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>CDIMM_SENSOR_MAP_SECONDARY</id>
+    <description>Custom DIMM Sensor Map for Secondary I2C Port (1
+    byte of data): 0x00 No sensors attached 0x01 DIMM sensor 0
+    attached 0x02 DIMM sensor 1 attached 0x04 DIMM sensor 2
+    attached 0x08 DIMM sensor 3 attached 0x10 DIMM sensor 4
+    attached 0x20 DIMM sensor 5 attached 0x40 DIMM sensor 6
+    attached 0x80 DIMM sensor 7 attached Comes from the VPD MW
+    Keyword</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_CDIMM_SENSOR_MAP_SECONDARY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>CDM_POLICIES</id>
+    <description>Cec Degraded Mode Policy flags Use the
+    CDM_POLICIES enum to decode. If the appropriate bit is 1 then
+    the policy mode is enabled, and those type of Guard records are
+    disabled.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0x00</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <writeable />
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>CDM_POLICIES</id>
+    <description>Enumeration of CDM_POLICIES flags</description>
+    <enumerator>
+      <description>MFG_Guard policy: Used in MFG only to prevent
+      and disable the following: . Storing or creation of new Guard
+      records from Diagno`stic or other faults through error logs.
+      This is all domains, CEC processor/memory, VPD, FSP, etc. .
+      Storing or creation of Manual Guard record from user. NOTE:
+      this does not stop FCO. . Using an already stored System or
+      Manual Guard record from deconfiguring resources. This is all
+      domains, CEC processor/memory, VPD, FSP, etc.</description>
+      <name>MANUFACTURING_DISABLED</name>
+      <value>0x01</value>
+    </enumerator>
+    <enumerator>
+      <description>Predictive_Guard policy: Used in Field or
+      development to prevent and disable the following: . Storing
+      or creation of new Guard records from diagnostics or other
+      faults through error logs with the error_type of Predictive.
+      . Using an already stored System Guard record with error_type
+      of Predictive from deconfiguring resources.</description>
+      <name>PREDICTIVE_DISABLED</name>
+      <value>0x02</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>FIELD_CORE_OVERRIDE</id>
+    <description>Field Core Override (FCO) is the override value
+    for the number of functional cores allowed on the system. FCO
+    is used when customers order a system with N cores but they
+    only want to enable less than N cores to lower software license
+    costs. A field in the anchor VPD is set by manufacturing to
+    specify the maximum number of cores to enable. The number is
+    maintained, even if some cores are garded out due to error. A
+    value of 0 means all cores allowed;</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>HOSTSVC_PLID</id>
+    <description>Value of the next PLID that host service should
+    send</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x89000000</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>RUN_MAX_MEM_PATTERNS</id>
+    <description>Policy indicating whether to perform the maximum
+    amount of memory pattern testing possible or not. Set to 0x01
+    to perform the maximum amount of memory pattern testing
+    possible. Set to 0x00 to perform the default amount of memory
+    pattern testing.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>LAB_USE_JTAG_MODE</id>
+    <description>This attribute controls how the procedures operate
+    in JTAG mode under an environment called cronus flex. For
+    normal operation, this attribute should be set to FALSE.
+    Platforms should initialize this attribute to
+    FALSE.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_LAB_USE_JTAG_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!--
 <attribute>
     <id>MSS_DRAM_ACTIVATE_POWER_PERCENT</id>
     <description>DRAM Activation power percentage to determine the ras and cas weights for throttle controls
@@ -4296,2222 +4306,2180 @@
     </hwpfToHbAttrMap>
 </attribute>
 -->
-<attribute>
-  <id>PROC_BOOT_VOLTAGE_VID</id>
-  <!-- deprecated -->
-  <description>Proc Boot Voltage</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_BOOT_VOLTAGE_VID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>DISABLE_I2C_ACCESS</id>
-  <description>Set to skip physical access to i2c interface in SBE
-  execution. Consumed by SBE hooks to permit skipping of selected
-  code when running on a test platform (i.e., wafer) which does not
-  have a physical SEEPROM connected.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_DISABLE_I2C_ACCESS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_REFCLOCK_RCVR_TERM</id>
-  <description>Defines system specific value of processor refclock
-  receiver termination (FSI GP4 bits 8:9)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_REFCLOCK_RCVR_TERM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PCI_REFCLOCK_RCVR_TERM</id>
-  <description>Defines system specific value of PCI refclock
-  receiver termination (FSI GP4 bits 10:11)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PCI_REFCLOCK_RCVR_TERM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>DD1_SLOW_PCI_REF_CLOCK</id>
-  <description>Valid only for Nimbus DD1 If set (=1), run the PCI
-  Ref clock at 94MHz in order to enable experimental GEN4 support.
-  If not set (=0), run the PCI Ref clock at 100MHz</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <!-- SBE requirement only -->
-  <hwpfToHbAttrMap>
-    <id>ATTR_DD1_SLOW_PCI_REF_CLOCK</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MEMB_DMI_REFCLOCK_RCVR_TERM</id>
-  <description>Defines system specific value of DMI refclock
-  receiver termination (FSI GP4 bits 8:9)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MEMB_DMI_REFCLOCK_RCVR_TERM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MEMB_DDR_REFCLOCK_RCVR_TERM</id>
-  <description>Defines system specific value of DDR refclock
-  receiver termination (FSI GP4 bits 10:11)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MEMB_DDR_REFCLOCK_RCVR_TERM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MEM_FILTER_PLL_SOURCE</id>
-  <description>Defines source of MEM filter PLL input (FSI GP4 bit
-  23)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MEM_FILTER_PLL_SOURCE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>MULTI_SCOM_BUFFER_MAX_SIZE_BIT</id>
-  <description>Enumeration indicating the multi scome buffer size.
-  The values can be combined using a bitwise 'OR'. The values will
-  need to be kept in sync with the FAPI enumerator values. Also the
-  enumeration type is used by the ATTR_MULTI_SCOM_BUFFER_MAX_SIZE.
-  Should note that the MULTI_SCOM_BUFFER_MAX_SIZE values are of
-  type uint32_t</description>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_1KB</name>
-    <value>0x00000400</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_2KB</name>
-    <value>0x00000800</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_4KB</name>
-    <value>0x00001000</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_8KB</name>
-    <value>0x00002000</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_16KB</name>
-    <value>0x00004000</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_32KB</name>
-    <value>0x00008000</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_64KB</name>
-    <value>0x00010000</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_128KB</name>
-    <value>0x00020000</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_256KB</name>
-    <value>0x00040000</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_512KB</name>
-    <value>0x00080000</value>
-  </enumerator>
-  <enumerator>
-    <name>MULTI_SCOM_BUFFER_SIZE_1MB</name>
-    <value>0x00100000</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>DMI_DFE_OVERRIDE</id>
-  <description>Defines where to apply DMI bus DFE override settings
-  for HW244323.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_DMI_DFE_OVERRIDE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>CPM_TURBO_BOOST_PERCENT</id>
-  <description>Percent of Boost Above Turbo for CPMs - (binary in
-  0.1 percent steps) Used in generating extra Pstate tables beyond
-  those that would result from #V data. Producer: DEF file as this
-  is CCIN based Consumers: p8_build_gpstate_table.C,
-  p8_cpm_cal_load.C Platform default: 0</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_CPM_TURBO_BOOST_PERCENT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_UNDERVOLTING_FRQ_MINIMUM</id>
-  <description>Override for Minimum frequency for which
-  undervolting is allowed. If value = 0, the value of VPD CPMin
-  data point is passed to OCC FW via Pstate SuperStructure. If
-  value != 0, this value will be passed to OCC FW via Pstate
-  SuperStructure as the floor frequency for enabled CPMs. Will be
-  internally rounded to the nearest ATTR_PROC_REFCLK_FREQUENCY / 8
-  value. Consumer: OCC FW; OCC Lab Tools Provided by the Machine
-  Readable Workbook.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_UNDERVOLTING_FRQ_MINIMUM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_UNDERVOLTING_FREQ_MAXIMUM</id>
-  <description>Override for Maximum frequency for which
-  undervolting is allowed. If value = 0, the value of VPD Turbo
-  data point is passed to OCC FW via Pstate SuperStructure. If
-  value != 0, this value will be passed to OCC FW via Pstate
-  SuperStructure as the ceiling frequency for enabled CPMs. Will be
-  internally rounded to the nearest ATTR_PROC_REFCLK_FREQUENCY / 8
-  value. Consumer: OCC FW; OCC Lab Tools Provided by the Machine
-  Readable Workbook.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_UNDERVOLTING_FREQ_MAXIMUM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_WINKLE_ENTRY</id>
-  <description>Setting depends on di/dt charateristics of the
-  system. Set Assisted if power off serialization is needed and
-  WINKLE_TYPE=Fast; Set to Hardware if the system can handle the
-  unrelated powering off between cores. Hardware setting decreases
-  entry latency Producer: MRWB Consumer:
-  p8_poreslw_init.C</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_WINKLE_ENTRY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_WINKLE_EXIT</id>
-  <description>Setting depends on di/dt charateristics of the
-  system and the setting of ATTR_PM_WINKLE_TYPE. Set to Assisted if
-  power on serialization is needed and WINKLE_TYPE=Fast; Set to
-  Hardware if the system can handle the unrelated powering off
-  between cores. Hardware setting decreases entry latency. Must be
-  set to Assisted if ATTR_PM_WINKLE_TYPE=Deep as this necessary for
-  restore. Setting to Hardware is a test mode for Fast only.
-  Producer: MRWB Consumer: p8_poreslw_init.C</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_WINKLE_EXIT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>PROC_MASTER_TYPE</id>
-  <description>Enumeration indicating the role of proc as
-  master/alt_master/not_master</description>
-  <enumerator>
-    <name>ACTING_MASTER</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>MASTER_CANDIDATE</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>NOT_MASTER</name>
-    <value>2</value>
-  </enumerator>
-  <default>NOT_MASTER</default>
-</enumerationType>
-<attribute>
-  <id>PROC_MASTER_TYPE</id>
-  <description>Type of Master, ACTING_MASTER or MASTER_CANDIDATE or
-  NOT_MASTER</description>
-  <simpleType>
-    <uint8_t>
-      <default>NOT_MASTER</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <hasStringConversion />
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>EFFECTIVE_EC</id>
-  <description>Holds the effective EC of the system. Effective EC
-  is the lowest EC among all the functional procs in the system.
-  Some cards may "downbin" the effective ECs of their contained
-  processors, which could lower the effective EC of the system
-  beyond what would occur when considering processor ECs
-  alone</description>
-  <simpleType>
-    <uint8_t>
-      <default>0x10</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MRU_ID</id>
-  <description>MRU ID attribute for chip/unit class</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x00</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT</id>
-  <description>Machine Readable Workbook DIMM power curve percent
-  uplift for this system</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT_IDLE</id>
-  <description>Machine Readable Workbook DIMM power curve percent
-  uplife idle for this system</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT_IDLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_MEM_THROTTLE_DENOMINATOR</id>
-  <description>Machine Readable Workbook throttle value for
-  denominator cfg_nm_m</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_MEM_THROTTLE_DENOMINATOR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_MAX_DRAM_DATABUS_UTIL</id>
-  <description>Machine Readable Workbook value for maximum dram
-  data bus utilization in centi percent (c%). Used to determine
-  memory throttle values.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x00002328</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_MAX_DRAM_DATABUS_UTIL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_SYSTEM_IVRM_VPD_MIN_LEVEL</id>
-  <description>Version level of #M that represents the minimum for
-  IVRM characterized parts. If this value is non-zero and the #M
-  version level is less than this value, IVRMs are disabled. If the
-  #M version is greater than or equal to this value, the IVRMs are
-  allowed to be enable from a level of part perspective. Producer:
-  MRWB Consumer: p8_build_pstate_datablock.C</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_SYSTEM_IVRM_VPD_MIN_LEVEL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_STRICT_MBA_PLUG_RULE_CHECKING</id>
-  <description>The MRW for a system should set this to TRUE for
-  systems that must obey plug rules. Lab environments should
-  default this to off and allow the user to override using normal
-  methods to test.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_STRICT_MBA_PLUG_RULE_CHECKING</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_MBA_CACHELINE_INTERLEAVE_MODE_CONTROL</id>
-  <description>At a system level, this attribute controls if
-  interleaving is required, requested or never. The
-  MRW.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_MBA_CACHELINE_INTERLEAVE_MODE_CONTROL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>REDUNDANT_CLOCKS</id>
-  <description>1 = System has redundant clock oscillators 0 =
-  System does not have redundant clock oscillators From the Machine
-  Readable Workbook</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_REDUNDANT_CLOCKS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_HW_MIRRORING_ENABLE</id>
-  <description>0 : HW mirroring is disabled. 1 : HW mirroring is
-  enabled. Provided by the MRW.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_HW_MIRRORING_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MNFG_DMI_MIN_EYE_WIDTH</id>
-  <description>System attribute. 6 bit rx_min_eye_width value for
-  DMI bus interfaces during system manufacturing; used for both
-  centaur and p8 creator: platform firmware notes: Attribute value
-  is in the Machine Readable Workbook</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MNFG_DMI_MIN_EYE_WIDTH</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MNFG_DMI_MIN_EYE_HEIGHT</id>
-  <description>System attribute. 8 bit rx_min_eye_height value for
-  DMI bus interfaces during system manufacturing; used for both
-  centaur and p8 creator: platform firmware notes: Attribute value
-  is in the Machine Readable Workbook</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MNFG_DMI_MIN_EYE_HEIGHT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MNFG_ABUS_MIN_EYE_WIDTH</id>
-  <description>System attribute 6 bit rx_min_eye_width value for A
-  bus interfaces during system manufacturing creator: platform
-  firmware notes: Attribute value is in the Machine Readable
-  Workbook</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MNFG_ABUS_MIN_EYE_WIDTH</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MNFG_ABUS_MIN_EYE_HEIGHT</id>
-  <description>System attribute 8 bit rx_min_eye_height value for A
-  bus interfaces during system manufacturing creator: platform
-  firmware notes: Attribute value is in the Machine Readable
-  Workbook</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MNFG_ABUS_MIN_EYE_HEIGHT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MNFG_XBUS_MIN_EYE_WIDTH</id>
-  <description>System attribute 6 bit rx_min_eye_width value for X
-  bus interfaces during system manufacturing creator: platform
-  firmware notes: Attribute value is in the Machine Readable
-  Workbook</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MNFG_XBUS_MIN_EYE_WIDTH</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>HB_RSV_MEM_SIZE_MB</id>
-  <description>The amount of mainstore that PHYP needs to preserve
-  per node during MPIPL.</description>
-  <simpleType>
-    <uint32_t>
-      <default>256</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MRW_CDIMM_MASTER_I2C_TEMP_SENSOR_ENABLE</id>
-  <description>Used for Custom DIMMs to not enable the reading of
-  the dimm temperature sensor on the master i2c bus</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_CDIMM_MASTER_I2C_TEMP_SENSOR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_CDIMM_SPARE_I2C_TEMP_SENSOR_ENABLE</id>
-  <description>Used for Custom DIMMs to not enable the reading of
-  the dimm temperature sensor on the spare i2c bus</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_CDIMM_SPARE_I2C_TEMP_SENSOR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>DO_ABUS_DECONFIG</id>
-  <description>Indicates if system should consider abus logic when
-  deconfiguring in _deconfigureAssocProc(), will be overwritten on
-  multi-node system</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<!-- For reconfig loop testing -->
-<attribute>
-  <id>MSS_CENT_AVDD_SLOPE_ACTIVE</id>
-  <description>Units: uV/Membuf</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_AVDD_SLOPE_ACTIVE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_CENT_AVDD_SLOPE_INACTIVE</id>
-  <description>Units: uV/Membuf</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_AVDD_SLOPE_INACTIVE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_CENT_AVDD_INTERCEPT</id>
-  <description>Units: mV</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_AVDD_SLOPE_INTERCEPT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_CENT_VDD_SLOPE_ACTIVE</id>
-  <description>Units: uV/Membuf</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_CENT_VDD_SLOPE_INACTIVE</id>
-  <description>Units: uV/Membuf</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_CENT_VDD_INTERCEPT</id>
-  <description>Units: mV</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_CENT_VCS_SLOPE_ACTIVE</id>
-  <description>Units: uV/Membuf</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_CENT_VCS_SLOPE_INACTIVE</id>
-  <description>Units: uV/Membuf</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_CENT_VCS_INTERCEPT</id>
-  <description>Units: mV</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_VPP_SLOPE</id>
-  <description>Units: uV/DRAM</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_VPP_INTERCEPT</id>
-  <description>Units: mV</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_VPP_SLOPE_POST_DRAM_INIT</id>
-  <description>Units: uV/DRAM</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_VPP_INTERCEPT_POST_DRAM_INIT</id>
-  <description>Units: mV</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_DDR3_VDDR_SLOPE</id>
-  <description>Units: 1/Amps</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_DDR3_VDDR_INTERCEPT</id>
-  <description>Units: mV</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MRW_DDR3_VDDR_MAX_LIMIT</id>
-  <description>Maximum voltage limit for the dynamic VID DDR3 VDDR
-  voltage setpoint. In mV.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_DDR3_VDDR_SLOPE_POST_DRAM_INIT</id>
-  <description>Units: 1/Amps</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_DDR3_VDDR_INTERCEPT_POST_DRAM_INIT</id>
-  <description>Units: mV</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MRW_DDR3_VDDR_MAX_LIMIT_POST_DRAM_INIT</id>
-  <description>Maximum voltage limit for the dynamic VID DDR3 VDDR
-  voltage setpoint. In mV.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_DDR4_VDDR_SLOPE</id>
-  <description>Units: 1/Amps</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_DDR4_VDDR_INTERCEPT</id>
-  <description>Units: mV</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MRW_DDR4_VDDR_MAX_LIMIT</id>
-  <description>Maximum voltage limit for the dynamic VID DDR4 VDDR
-  voltage setpoint. In mV.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_DDR4_VDDR_SLOPE_POST_DRAM_INIT</id>
-  <description>Units: 1/Amps</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MSS_VOLT_DDR4_VDDR_INTERCEPT_POST_DRAM_INIT</id>
-  <description>Units: mV</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>MRW_DDR4_VDDR_MAX_LIMIT_POST_DRAM_INIT</id>
-  <description>Maximum voltage limit for the dynamic VID DDR4 VDDR
-  voltage setpoint. In mV.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<enumerationType>
-  <id>MSS_MRW_POWER_CONTROL_REQUESTED</id>
-  <description>Enumeration defining the type of power control
-  requested</description>
-  <enumerator>
-    <name>OFF</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>POWER_DOWN</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>STR</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>PD_AND_STR</name>
-    <value>3</value>
-  </enumerator>
-  <default>OFF</default>
-</enumerationType>
-<attribute>
-  <id>MSS_MRW_POWER_CONTROL_REQUESTED</id>
-  <description>Memory power control settings programmed during IPL
-  Used by OCC when exiting idle powersave mode Producer: MRW 0x00 =
-  OFF 0x01 = POWER_DOWN 0x02 = STR 0x03 = PD_AND_STR</description>
-  <simpleType>
-    <uint8_t>
-      <default>OFF</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_POWER_CONTROL_REQUESTED</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
-  <description>Enumeration defining the type of power control
-  requested</description>
-  <enumerator>
-    <name>OFF</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>POWER_DOWN</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>STR</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>PD_AND_STR</name>
-    <value>3</value>
-  </enumerator>
-  <default>NONE</default>
-</enumerationType>
-<attribute>
-  <id>MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
-  <description>Memory power control settings for IDLE powersave
-  mode Used by OCC when entering idle powersave mode Producer: MRW
-  0x00 = OFF 0x01 = POWER_DOWN 0x02 = STR 0x03 =
-  PD_AND_STR</description>
-  <simpleType>
-    <uint8_t>
-      <default>OFF</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>OCC_MASTER_CAPABLE</id>
-  <description>This attribute is to determine whether an occ is
-  master capable. An OCC is master capable if it's parent processor
-  is wired to the APSS.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-      <!-- false -->
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MSS_DRAMINIT_RESET_DISABLE</id>
-  <description>A disable switch for resetting the phy delay values
-  at the beginning of calling mss_draminit_training.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_DRAMINIT_RESET_DISABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>ISDIMM_POWER_CURVE_ALGORITHM_VERSION</id>
-  <description>version of algorithm used to calculate ISDIMM power
-  curves</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_ISDIMM_POWER_CURVE_ALGORITHM_VERSION</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_LANE_MASK</id>
-  <description>Effective PCIE Lane Mask Creator: Firmware Purpose:
-  Holds the effective PCIE lane mask of each PEC after taking into
-  account any IOP bifurcations. If no IOP bifurcations present,
-  this is just the value of the PEC_PCIE_LANE_MASK_NON_BIFURCATED
-  attribute Data Format: x4 array of uint16_t values. The uint16_t
-  value is a mask for lane 0, the next for lane 1 and so on until
-  lane 3. A lane set mask indicates which groups of lanes are
-  assigned to an IOP. For instance, lane set 0 value of 0xFFFF and
-  lane set 1 value of 0x0000 for PEC0 means PEC0 is a x16. Lane set
-  0 value of 0xFF00 and lane set 1 value of 0x00FF for PEC0, means
-  the IOP is bifurcated into two x8s.</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>PEC_PCIE_IOP_REVERSAL</id>
-  <description>Effective PCIE IOP reversal configuration Creator:
-  Firmware Purpose: Holds the effective PCIE IOP reversal value
-  after taking into account any IOP bifurcations. If no IOP
-  bifurcations present, this is just the value of the
-  PROC_PCIE_IOP_REVERSAL_NON_BIFURCATED attribute. Data Format: x4
-  array of uint8_t values. The first uint8_t value is for lane set
-  0, the second for lane set 1 and so on. The given index in the
-  array is a mask which specifies which bit to invert in the lane
-  swap settings for the given PEC/lane set.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>PEC_PCIE_IOP_REVERSAL_NON_BIFURCATED</id>
-  <description>Base PCIE IOP reversal configuration Creator:
-  Firmware Purpose: Holds the base PCIE IOP reversal value without
-  considering IOP bifurcation. Data Format: x4 array of uint8_t
-  values. The first uint8_t value is for lane set 0, the second for
-  lane set 1 and so on. The given index in the array is a mask
-  which specifies which bit to invert in the lane swap settings for
-  the given lane set.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PEC_PCIE_IOP_SWAP_NON_BIFURCATED</id>
-  <description>Base PCIE IOP swap configuration value Creator: MRW
-  Purpose: Holds the base IOP swap configuration value without
-  considering IOP bifurcation. The swap value controls how PCIE
-  lanes are recordered when the leave the IOP, to provide lane
-  routing flexibility. Data Format: A uint8_t value. The value
-  specifices for the hardware how to swap the PCIE lanes for the
-  given PEC.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
-  <description>PCIE Lane Mask base configuration Creator: MRW
-  Purpose: Holds the base PCIE lane mask assuming no dynamic IOP
-  bifurcations. Data Format: x4 array of uint16_t values. The first
-  uint8_t value is lane set 0, the second for lane set 2 and so on.
-  A lane set mask indicates which groups of lanes are assigned to
-  an IOP. For instance, lane set 0 value of 0xFFFF and lane set 1
-  value of 0x0000 means the PEC is a x16. Lane set 0 value of
-  0xFF00 and lane set 1 value of 0x00FF, means the PEC is split
-  into two x8s.</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PEC_PCIE_IOP_REVERSAL_BIFURCATED</id>
-  <description>Base PCIE IOP reversal configuration Creator:
-  Firmware Purpose: Holds the PCIE IOP reversal value for cases
-  where the IOP is bifurcated Data Format: x4 array of uint8_t
-  values. The first uint8_t value is lane set 0, the second for
-  lane set 2 and so on. The given index in the array is a mask
-  which specifies which bit to invert in the lane swap settings for
-  the given lane set</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PEC_PCIE_IOP_SWAP_BIFURCATED</id>
-  <description>Bifurcated PCIE IOP swap configuration value
-  Creator: MRW Purpose: Holds the base IOP swap configuration value
-  for the IOPs in the case where they are bifurcated. The swap
-  value controls how PCIE lanes are recordered when the leave the
-  IOP, to provide lane routing flexibility. Data Format: A uint8_t
-  value. The value specifices for the hardware how to swap the PCIE
-  lanes for the given PEC.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PEC_PCIE_LANE_MASK_BIFURCATED</id>
-  <description>PCIE Lane Mask bifurcated configuration Creator: MRW
-  Purpose: Holds the PCIE lane mask assuming IOPs are bifurcated.
-  Data Format: x4 array of uint16_t values. The first uint8_t value
-  is lane set 0, the second for lane set 2 and so on. A lane set
-  mask indicates which groups of lanes are assigned to an IOP. For
-  instance, lane set 0 value of 0xFF00 and lane set 1 value of
-  0x00FF means the IOP is bifurcated into two x8s.</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PROC_PCIE_IS_SLOT</id>
-  <description>Indicates whether PCIE lanes terminate at a
-  pluggable slot Creator: MRW Purpose: Used by FW to know whether
-  the given PCIE lanes terminate at a pluggable slot or not. If
-  this is the case, and the platform supports bifurcation, the
-  card's VPD should be interrogated to determine whether to
-  bifurcate the IOP or not. Data Format: x4 array of uint8_t
-  values. The first value indicates whether lane set 0 terminates
-  at a pluggable slot. The next three values indicate the same for
-  lane sets 1-3. A value of 1 at a given array index indicates the
-  lanes terminate at a pluggable slot, 0 otherwise.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>CDM_DOMAIN</id>
-  <description>Enumeration specifying a target's CEC degraded mode
-  domain</description>
-  <enumerator>
-    <name>NONE</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>CPU</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>DIMM</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>FABRIC</name>
-    <value>3</value>
-  </enumerator>
-  <enumerator>
-    <name>MEM</name>
-    <value>4</value>
-  </enumerator>
-  <enumerator>
-    <name>IO</name>
-    <value>5</value>
-  </enumerator>
-  <enumerator>
-    <name>NODE</name>
-    <value>6</value>
-  </enumerator>
-  <enumerator>
-    <name>CLOCK</name>
-    <value>7</value>
-  </enumerator>
-  <enumerator>
-    <name>PSI</name>
-    <value>8</value>
-  </enumerator>
-  <enumerator>
-    <name>FSP</name>
-    <value>9</value>
-  </enumerator>
-  <enumerator>
-    <name>ALL</name>
-    <value>10</value>
-  </enumerator>
-  <default>NONE</default>
-</enumerationType>
-<attribute>
-  <id>CDM_DOMAIN</id>
-  <description>Specifies a target's CEC degraded mode domain. For
-  example, all DIMMs are part of the DIMM CEC degraded mode
-  domain.</description>
-  <simpleType>
-    <enumeration>
-      <id>CDM_DOMAIN</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-</attribute>
-<attribute>
-  <id>I2C_BUS_SPEED_ARRAY</id>
-  <description>Designates the speed at which a given I2C bus should
-  run. Creator: MRW Purpose: Used by FW to know the fastest
-  possible bus speed that all of the devices on a given bus are
-  able to use. Data Format: 4x4 array of uint16_t values. The first
-  index indicates the engine number of the bus. The second index
-  indicates the port number of the bus. The value in the array is
-  the I2C bus speed used for that engine/port combination in
-  KHz.</description>
-  <simpleType>
-    <uint16_t>
-      <default>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>
-    </uint16_t>
-    <array>4,4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>SUPPORTED_HOT_PLUG</id>
-  <description>Enumeration indication which Hot Plug Controllers
-  are supported by the current system.</description>
-  <enumerator>
-    <name>NA</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>MAX5961</name>
-    <value>0x01</value>
-  </enumerator>
-  <enumerator>
-    <name>PCA9551</name>
-    <value>0x02</value>
-  </enumerator>
-  <default>NA</default>
-</enumerationType>
-<attribute>
-  <id>HOT_PLUG_POWER_CONTROLLER_INFO</id>
-  <description>Hot Plug Controller values for a specific processor.
-  Purpose: Holds information about the hot plug controllers so that
-  a Hardware procedure is able to turn them on and off. Data
-  Format: up to 8 Hot Plug Controllers x 7 variables of information
-  This data is at the processor level. The needed information and
-  their individual sizes are as follows: (1) I2C Master processor
-  engine (uint8_t) (2) I2C Master processor port (uint8_t) (3) Bus
-  Speed (uint16_t value: 2 uint8_t values: MSB, LSB) (4) Slave
-  address (uint8_t) (5) Device type (uint8_t: see
-  SUPPORTED_HOT_PLUG enum) (6) I2C Master processor node (uint8_t)
-  (7) I2C Master processor position (uint8_t) Thus, the information
-  will be 8 bytes.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-      0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-      0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>
-    </uint8_t>
-    <array>8,8</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_HOT_PLUG_POWER_CONTROLLER_INFO</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>OPT_MEMMAP_GROUP_POLICY</id>
-  <description>Controls scope of grouping performed in memory map
-  calculations Possible values defined in FAPI
-  ATTR_OPT_MEMMAP_GROUP_POLICY</description>
-  <simpleType>
-    <uint8_t>
-      <default>0x00</default>
-    </uint8_t>
-    <!-- CHIP_AS_GROUP -->
-  </simpleType>
-  <readable />
-  <persistency>non-volatile</persistency>
-  <hwpfToHbAttrMap>
-    <id>ATTR_OPT_MEMMAP_GROUP_POLICY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>TPM_REQUIRED</id>
-  <description>Setting to require(0x1) or not require(0x0) a
-  functional TPM to boot the system.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PROC_PCIE_NUM_PHB</id>
-  <description>creator: platform Number of PCIe PHB units present
-  on target Murano/Venice: 3 Naples: 4 Nimbus: 6 Cumulus:
-  6</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_NUM_PHB</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_NUM_IOP</id>
-  <description>creator: platform Number of PCIe IOP units present
-  on target Murano/Venice: 2 Naples: 3 Nimbus: 3</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_NUM_IOP</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_NUM_PEC</id>
-  <description>creator: platform Number of PCIe PEC units present
-  on target Nimbus: 3</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_NUM_PEC</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_NUM_LANES</id>
-  <description>creator: platform Number of PCIe I/O lanes supported
-  by target Murano: 24 Venice: 32 Naples: 40 Nimbus:
-  48</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_NUM_LANES</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- === start configurable threshold attributes for PRD === -->
-<attribute>
-  <id>MNFG_TH_P8EX_L2_CACHE_CES</id>
-  <description>This attribute represents the Maximum number of L2
-  Cache CEs allowed during Manufacturing. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_P8EX_L2_DIR_CES</id>
-  <description>This attribute represents the Maximum number of L2
-  Directory CEs allowed during Manufacturing. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_P8EX_L3_CACHE_CES</id>
-  <description>This attribute represents the Maximum number of L3
-  Cache CEs allowed during Manufacturing. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>3</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_P8EX_L3_DIR_CES</id>
-  <description>This attribute represents the Maximum number of L3
-  Directory CEs allowed during Manufacturing. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>FIELD_TH_P8EX_L2_LINE_DELETES</id>
-  <description>This attribute represents the Maximum number of L2
-  Line Deletes allowed in the Field. creator: platform (generated
-  based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>6</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>FIELD_TH_P8EX_L3_LINE_DELETES</id>
-  <description>This attribute represents the Maximum number of L3
-  Line Deletes allowed in the Field. creator: platform (generated
-  based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>6</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>FIELD_TH_P8EX_L2_COL_REPAIRS</id>
-  <description>This attribute represents the Maximum number of L2
-  Column Repairs allowed in the Field. creator: platform (generated
-  based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>7</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>FIELD_TH_P8EX_L3_COL_REPAIRS</id>
-  <description>This attribute represents the Maximum number of L3
-  Column Repairs allowed in the Field. creator: platform (generated
-  based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>7</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_P8EX_L2_LINE_DELETES</id>
-  <description>This attribute represents the Maximum number of L2
-  Line Deletes allowed during Manufacturing. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_P8EX_L3_LINE_DELETES</id>
-  <description>This attribute represents the Maximum number of L3
-  Line Deletes allowed during Manufacturing. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_P8EX_L2_COL_REPAIRS</id>
-  <description>This attribute represents the Maximum number of L2
-  Column Repairs allowed during Manufacturing. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_P8EX_L3_COL_REPAIRS</id>
-  <description>This attribute represents the Maximum number of L3
-  Column Repairs allowed during Manufacturing. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_CEN_MBA_RT_SOFT_CE_TH_ALGO</id>
-  <description>This attribute represents the Base threshold (for
-  2GB DRAM ) of Memory CEs allowed during runtime. creator:
-  platform (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>2</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_CEN_MBA_IPL_SOFT_CE_TH_ALGO</id>
-  <description>This attribute represents the Base threshold (for
-  2GB DRAM ) of Memory CEs allowed during IPL. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>2</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_CEN_MBA_RT_RCE_PER_RANK</id>
-  <description>This attribute represents the maximum number of
-  Memory RCEs allowed per Rank during runtime. creator: platform
-  (generated based on MRW data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>2</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_CEN_L4_CACHE_CES</id>
-  <description>This attribute represents the maximum number of L4
-  Cache CEs allowed. creator: platform (generated based on MRW
-  data)</description>
-  <simpleType>
-    <uint8_t>
-      <default>2</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_RCD_PARITY_ERRORS</id>
-  <description>With MNFG thresholds enabled, PRD will make a
-  predictive callout when an RCD parity error (recovery enabled)
-  attention count is equal to this value. A value of 0 defaults to
-  the max threshold of 0xff.</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_MEMORY_IUES</id>
-  <description>With MNFG thresholds enabled, PRD will make a
-  predictive callout when a memory intermittent UE attention count
-  is equal to this value. A value of 0 defaults to the max
-  threshold of 0xff.</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MNFG_TH_MEMORY_IMPES</id>
-  <description>With MNFG thresholds enabled, PRD will make a
-  predictive callout when a memory intermittent MPE attention count
-  is equal to this value. A value of 0 defaults to the max
-  threshold of 0xff.</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<!-- === end configurable threshold attributes for PRD === -->
-<!-- === start RCD parity error reconfig loop attributes for PRD/MDIA === -->
-<attribute>
-  <id>RCD_PARITY_RECONFIG_LOOPS_ALLOWED</id>
-  <description>The number of reconfig loops allowed due to RCD
-  parity errors when recovery is disabled. PRD will make a
-  predictive callout and stop issuing reconfigs due to RCD parity
-  errors when RCD_PARITY_RECONFIG_LOOP_COUNT is greater than this
-  value. A value of 0 indicates that no reconfig loops are allowed
-  due to RCD parity errors.</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>RCD_PARITY_RECONFIG_LOOP_COUNT</id>
-  <description>PRD will increment this count and issue a reconfig
-  loop each time an RCD parity error (recovery disabled) is
-  detected during Memory Diagnostics. This value will be cleared at
-  the end of Memory Diagnostics if it is able to complete without
-  the need to issue a reconfig loop.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<!-- === end RCD parity error reconfig loop attributes for PRD/MDIA === -->
-<attribute>
-  <id>RESOURCE_IS_CRITICAL</id>
-  <description>Used to tell if a resource is critical to perform an
-  IPL. If this attribute is set to 1 and the target is
-  deconfigured, the IPL MUST terminate.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>BRAZOS_RX_FIFO_OVERRIDE</id>
-  <description>Defines where to apply Brazos rx_fifo_final_l2u_dly
-  override settings for SW299500.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_BRAZOS_RX_FIFO_OVERRIDE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- === Manufacturing threshold Attributes of PRD === -->
-<attribute>
-  <id>MSS_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
-  <description>Machine Readable Workbook enablement of the HWP code
-  to adjust the VMEM regulator power limit based on number of
-  installed DIMMs.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>
-    ATTR_MSS_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_MAX_NUMBER_DIMMS_POSSIBLE_PER_VMEM_REGULATOR</id>
-  <description>Machine Readable Workbook value for the maximum
-  possible number of dimms that can be installed under any of the
-  VMEM regulators.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>
-    ATTR_MSS_MRW_MAX_NUMBER_DIMMS_POSSIBLE_PER_VMEM_REGULATOR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>WOF_ENABLED</id>
-  <description>Defines if the Workload Optimization Frequency (WOF)
-  system feature where OCC algorithms will change (typically boost)
-  the operational frequency based on measured power available and
-  any currently idling cores.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_WOF_ENABLED</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!--HWSV needs to update names so we can remove this-->
-<!--HWSV needs to update names so we can remove this-->
-<!--HWSV needs to update names so we can remove this-->
-<!--HWSV needs to update names so we can remove this-->
-<!--HWSV needs to update names so we can remove this-->
-<!--HWSV needs to update names so we can remove this-->
-<!--Deprecated-->
-<!--Deprecated-->
-<attribute>
-  <id>PHB_MMIO_ADDRS_64</id>
-  <description>PHB0-PHB5 64 bits addresses MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-    <array>6</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PHB_MMIO_ADDRS_32</id>
-  <description>PHB0-PHB5 32 bit addresses MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-    <array>6</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>` 
-<attribute>
-  <id>PHB_XIVE_ESB_ADDRS</id>
-  <description>PHB0-PHB5 XIVE ESB addresses MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-    <array>6</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PHB_REG_ADDRS</id>
-  <description>PHB0-PHB5 Register Space addresses MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-    <array>6</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>XIVE_ROUTING_ESB_ADDR</id>
-  <description>XIVE Routing ESB address MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>XIVE_ROUTING_END_ADDR</id>
-  <description>XIVE Routing END address MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>XIVE_PRESENTATION_NVT_ADDR</id>
-  <description>XIVE Presentation NVT address MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VAS_HYPERVISOR_WINDOW_CONTEXT_ADDR</id>
-  <description>VAS - Hypervisor Window Contexts address MMIO
-  consumed by PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VAS_USER_WINDOW_CONTEXT_ADDR</id>
-  <description>VAS - User Window Context address MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>LPC_BUS_ADDR</id>
-  <description>LPC Bus address - MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NVIDIA_NPU_PRIVILEGED_ADDR</id>
-  <description>Nvidia Link - NPU Privileged Regs address MMIO
-  consumed by PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NVIDIA_NPU_USER_REG_ADDR</id>
-  <description>Nvidia Link - NPU User Regs address MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NVIDIA_PHY0_REG_ADDR</id>
-  <description>Nvidia Link - Phy 0 Regs address MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NVIDIA_PHY1_REG_ADDR</id>
-  <description>Nvidia Link - Phy 1 Regs address MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>XIVE_CONTROLLER_BAR_ADDR</id>
-  <description>XIVE - Controller Bar address MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>XIVE_PRESENTATION_BAR_ADDR</id>
-  <description>XIVE - Presentation Bar address MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>XIVE_THREAD_MGMT1_BAR_ADDR</id>
-  <description>XIVE - Thread Management Bar address register 1 MMIO
-  consumed by HB/PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PSI_HB_ESB_ADDR</id>
-  <description>PSIHB - ESB space address - MMIO consumed by
-  PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>NX_RNG_ADDR</id>
-  <description>NX - RNG space - MMIO consumed by PHYP</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>ICACHE_LINE_SIZE</id>
-  <description>Icache Line Size in bytes</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>ICACHE_BLOCK_SIZE</id>
-  <description>ICache Block Size in bytes</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>ICACHE_SIZE</id>
-  <description>ICache Size in KB</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>ICACHE_ASSOC_SETS</id>
-  <description>ICache Assoc Sets</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>DCACHE_LINE_SIZE</id>
-  <description>DCache Line Size in bytes</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>DCACHE_ASSOC_SETS</id>
-  <description>DCache Associative Sets</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>L2_CACHE_LINE_SIZE</id>
-  <description>L2 Cache Line Size in bytes</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>L2_CACHE_SIZE</id>
-  <description>L2 Cache Size in KB</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>L2_CACHE_ASSOC_SETS</id>
-  <description>L2 Cache Assoc Sets</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>L3_CACHE_LINE_SIZE</id>
-  <description>L3 Cache Line Size in bytes</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>L3_CACHE_SIZE</id>
-  <description>L3 Cache Size in KB</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>TIME_BASE</id>
-  <description>Time Base frequency in MHZ</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x800000</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>TLB_DATA_ENTRIES</id>
-  <description>TLB Data Entries</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>TLB_DATA_ASSOC_SETS</id>
-  <description>TLB Data Associative Sets</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>TLB_INSTR_ENTRIES</id>
-  <description>TLB Instruction Entries</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>TLB_INSTR_ASSOC_SETS</id>
-  <description>TLB Instruction Associative Sets</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>TLB_RESERVE_SIZE</id>
-  <description>Reserve Size in bytes</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>DATA_CACHE_SIZE</id>
-  <description>L1 Data Cache Size in KB</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>DATA_CACHE_LINE_SIZE</id>
-  <description>L1 Data Cache Line Size in bytes</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>THREAD_COUNT</id>
-  <description>Thread Count</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x4</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PFET_POWERUP_DELAY_NS</id>
-  <description>Time (in nanoseconds) between PFET controller steps
-  (7 of them) when turning the PFES ON</description>
-  <simpleType>
-    <uint32_t>
-      <!-- Will be set by HWP -->
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <readable />
-  <persistency>non-volatile</persistency>
-  <hwpfToHbAttrMap>
-    <id>ATTR_PFET_POWERUP_DELAY_NS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!--<attribute>
+  <attribute>
+    <id>PROC_BOOT_VOLTAGE_VID</id>
+    <!-- deprecated -->
+    <description>Proc Boot Voltage</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_BOOT_VOLTAGE_VID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>DISABLE_I2C_ACCESS</id>
+    <description>Set to skip physical access to i2c interface in
+    SBE execution. Consumed by SBE hooks to permit skipping of
+    selected code when running on a test platform (i.e., wafer)
+    which does not have a physical SEEPROM connected.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_DISABLE_I2C_ACCESS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_REFCLOCK_RCVR_TERM</id>
+    <description>Defines system specific value of processor
+    refclock receiver termination (FSI GP4 bits 8:9)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_REFCLOCK_RCVR_TERM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PCI_REFCLOCK_RCVR_TERM</id>
+    <description>Defines system specific value of PCI refclock
+    receiver termination (FSI GP4 bits 10:11)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PCI_REFCLOCK_RCVR_TERM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>DD1_SLOW_PCI_REF_CLOCK</id>
+    <description>Valid only for Nimbus DD1 If set (=1), run the PCI
+    Ref clock at 94MHz in order to enable experimental GEN4
+    support. If not set (=0), run the PCI Ref clock at
+    100MHz</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <!-- SBE requirement only -->
+    <hwpfToHbAttrMap>
+      <id>ATTR_DD1_SLOW_PCI_REF_CLOCK</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MEMB_DMI_REFCLOCK_RCVR_TERM</id>
+    <description>Defines system specific value of DMI refclock
+    receiver termination (FSI GP4 bits 8:9)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MEMB_DMI_REFCLOCK_RCVR_TERM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MEMB_DDR_REFCLOCK_RCVR_TERM</id>
+    <description>Defines system specific value of DDR refclock
+    receiver termination (FSI GP4 bits 10:11)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MEMB_DDR_REFCLOCK_RCVR_TERM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MEM_FILTER_PLL_SOURCE</id>
+    <description>Defines source of MEM filter PLL input (FSI GP4
+    bit 23)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MEM_FILTER_PLL_SOURCE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>MULTI_SCOM_BUFFER_MAX_SIZE_BIT</id>
+    <description>Enumeration indicating the multi scome buffer
+    size. The values can be combined using a bitwise 'OR'. The
+    values will need to be kept in sync with the FAPI enumerator
+    values. Also the enumeration type is used by the
+    ATTR_MULTI_SCOM_BUFFER_MAX_SIZE. Should note that the
+    MULTI_SCOM_BUFFER_MAX_SIZE values are of type
+    uint32_t</description>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_1KB</name>
+      <value>0x00000400</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_2KB</name>
+      <value>0x00000800</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_4KB</name>
+      <value>0x00001000</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_8KB</name>
+      <value>0x00002000</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_16KB</name>
+      <value>0x00004000</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_32KB</name>
+      <value>0x00008000</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_64KB</name>
+      <value>0x00010000</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_128KB</name>
+      <value>0x00020000</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_256KB</name>
+      <value>0x00040000</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_512KB</name>
+      <value>0x00080000</value>
+    </enumerator>
+    <enumerator>
+      <name>MULTI_SCOM_BUFFER_SIZE_1MB</name>
+      <value>0x00100000</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>DMI_DFE_OVERRIDE</id>
+    <description>Defines where to apply DMI bus DFE override
+    settings for HW244323.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_DMI_DFE_OVERRIDE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>CPM_TURBO_BOOST_PERCENT</id>
+    <description>Percent of Boost Above Turbo for CPMs - (binary in
+    0.1 percent steps) Used in generating extra Pstate tables
+    beyond those that would result from #V data. Producer: DEF file
+    as this is CCIN based Consumers: p8_build_gpstate_table.C,
+    p8_cpm_cal_load.C Platform default: 0</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_CPM_TURBO_BOOST_PERCENT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_UNDERVOLTING_FRQ_MINIMUM</id>
+    <description>Override for Minimum frequency for which
+    undervolting is allowed. If value = 0, the value of VPD CPMin
+    data point is passed to OCC FW via Pstate SuperStructure. If
+    value != 0, this value will be passed to OCC FW via Pstate
+    SuperStructure as the floor frequency for enabled CPMs. Will be
+    internally rounded to the nearest ATTR_PROC_REFCLK_FREQUENCY /
+    8 value. Consumer: OCC FW; OCC Lab Tools Provided by the
+    Machine Readable Workbook.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_UNDERVOLTING_FRQ_MINIMUM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_UNDERVOLTING_FREQ_MAXIMUM</id>
+    <description>Override for Maximum frequency for which
+    undervolting is allowed. If value = 0, the value of VPD Turbo
+    data point is passed to OCC FW via Pstate SuperStructure. If
+    value != 0, this value will be passed to OCC FW via Pstate
+    SuperStructure as the ceiling frequency for enabled CPMs. Will
+    be internally rounded to the nearest ATTR_PROC_REFCLK_FREQUENCY
+    / 8 value. Consumer: OCC FW; OCC Lab Tools Provided by the
+    Machine Readable Workbook.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_UNDERVOLTING_FREQ_MAXIMUM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_WINKLE_ENTRY</id>
+    <description>Setting depends on di/dt charateristics of the
+    system. Set Assisted if power off serialization is needed and
+    WINKLE_TYPE=Fast; Set to Hardware if the system can handle the
+    unrelated powering off between cores. Hardware setting
+    decreases entry latency Producer: MRWB Consumer:
+    p8_poreslw_init.C</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_WINKLE_ENTRY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_WINKLE_EXIT</id>
+    <description>Setting depends on di/dt charateristics of the
+    system and the setting of ATTR_PM_WINKLE_TYPE. Set to Assisted
+    if power on serialization is needed and WINKLE_TYPE=Fast; Set
+    to Hardware if the system can handle the unrelated powering off
+    between cores. Hardware setting decreases entry latency. Must
+    be set to Assisted if ATTR_PM_WINKLE_TYPE=Deep as this
+    necessary for restore. Setting to Hardware is a test mode for
+    Fast only. Producer: MRWB Consumer:
+    p8_poreslw_init.C</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_WINKLE_EXIT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>PROC_MASTER_TYPE</id>
+    <description>Enumeration indicating the role of proc as
+    master/alt_master/not_master</description>
+    <enumerator>
+      <name>ACTING_MASTER</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>MASTER_CANDIDATE</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>NOT_MASTER</name>
+      <value>2</value>
+    </enumerator>
+    <default>NOT_MASTER</default>
+  </enumerationType>
+  <attribute>
+    <id>PROC_MASTER_TYPE</id>
+    <description>Type of Master, ACTING_MASTER or MASTER_CANDIDATE
+    or NOT_MASTER</description>
+    <simpleType>
+      <uint8_t>
+        <default>NOT_MASTER</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <hasStringConversion />
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>EFFECTIVE_EC</id>
+    <description>Holds the effective EC of the system. Effective EC
+    is the lowest EC among all the functional procs in the system.
+    Some cards may "downbin" the effective ECs of their contained
+    processors, which could lower the effective EC of the system
+    beyond what would occur when considering processor ECs
+    alone</description>
+    <simpleType>
+      <uint8_t>
+        <default>0x10</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MRU_ID</id>
+    <description>MRU ID attribute for chip/unit class</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x00</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT</id>
+    <description>Machine Readable Workbook DIMM power curve percent
+    uplift for this system</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT_IDLE</id>
+    <description>Machine Readable Workbook DIMM power curve percent
+    uplife idle for this system</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT_IDLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_MEM_THROTTLE_DENOMINATOR</id>
+    <description>Machine Readable Workbook throttle value for
+    denominator cfg_nm_m</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_MEM_THROTTLE_DENOMINATOR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_MAX_DRAM_DATABUS_UTIL</id>
+    <description>Machine Readable Workbook value for maximum dram
+    data bus utilization in centi percent (c%). Used to determine
+    memory throttle values.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x00002328</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_MAX_DRAM_DATABUS_UTIL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_SYSTEM_IVRM_VPD_MIN_LEVEL</id>
+    <description>Version level of #M that represents the minimum
+    for IVRM characterized parts. If this value is non-zero and the
+    #M version level is less than this value, IVRMs are disabled.
+    If the #M version is greater than or equal to this value, the
+    IVRMs are allowed to be enable from a level of part
+    perspective. Producer: MRWB Consumer:
+    p8_build_pstate_datablock.C</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_SYSTEM_IVRM_VPD_MIN_LEVEL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_STRICT_MBA_PLUG_RULE_CHECKING</id>
+    <description>The MRW for a system should set this to TRUE for
+    systems that must obey plug rules. Lab environments should
+    default this to off and allow the user to override using normal
+    methods to test.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_STRICT_MBA_PLUG_RULE_CHECKING</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_MBA_CACHELINE_INTERLEAVE_MODE_CONTROL</id>
+    <description>At a system level, this attribute controls if
+    interleaving is required, requested or never. The
+    MRW.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_MBA_CACHELINE_INTERLEAVE_MODE_CONTROL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>REDUNDANT_CLOCKS</id>
+    <description>1 = System has redundant clock oscillators 0 =
+    System does not have redundant clock oscillators From the
+    Machine Readable Workbook</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_REDUNDANT_CLOCKS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_HW_MIRRORING_ENABLE</id>
+    <description>0 : HW mirroring is disabled. 1 : HW mirroring is
+    enabled. Provided by the MRW.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_HW_MIRRORING_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MNFG_DMI_MIN_EYE_WIDTH</id>
+    <description>System attribute. 6 bit rx_min_eye_width value for
+    DMI bus interfaces during system manufacturing; used for both
+    centaur and p8 creator: platform firmware notes: Attribute
+    value is in the Machine Readable Workbook</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MNFG_DMI_MIN_EYE_WIDTH</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MNFG_DMI_MIN_EYE_HEIGHT</id>
+    <description>System attribute. 8 bit rx_min_eye_height value
+    for DMI bus interfaces during system manufacturing; used for
+    both centaur and p8 creator: platform firmware notes: Attribute
+    value is in the Machine Readable Workbook</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MNFG_DMI_MIN_EYE_HEIGHT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MNFG_ABUS_MIN_EYE_WIDTH</id>
+    <description>System attribute 6 bit rx_min_eye_width value for
+    A bus interfaces during system manufacturing creator: platform
+    firmware notes: Attribute value is in the Machine Readable
+    Workbook</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MNFG_ABUS_MIN_EYE_WIDTH</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MNFG_ABUS_MIN_EYE_HEIGHT</id>
+    <description>System attribute 8 bit rx_min_eye_height value for
+    A bus interfaces during system manufacturing creator: platform
+    firmware notes: Attribute value is in the Machine Readable
+    Workbook</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MNFG_ABUS_MIN_EYE_HEIGHT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MNFG_XBUS_MIN_EYE_WIDTH</id>
+    <description>System attribute 6 bit rx_min_eye_width value for
+    X bus interfaces during system manufacturing creator: platform
+    firmware notes: Attribute value is in the Machine Readable
+    Workbook</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MNFG_XBUS_MIN_EYE_WIDTH</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>HB_RSV_MEM_SIZE_MB</id>
+    <description>The amount of mainstore that PHYP needs to
+    preserve per node during MPIPL.</description>
+    <simpleType>
+      <uint32_t>
+        <default>256</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MRW_CDIMM_MASTER_I2C_TEMP_SENSOR_ENABLE</id>
+    <description>Used for Custom DIMMs to not enable the reading of
+    the dimm temperature sensor on the master i2c bus</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_CDIMM_MASTER_I2C_TEMP_SENSOR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_CDIMM_SPARE_I2C_TEMP_SENSOR_ENABLE</id>
+    <description>Used for Custom DIMMs to not enable the reading of
+    the dimm temperature sensor on the spare i2c bus</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_CDIMM_SPARE_I2C_TEMP_SENSOR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>DO_ABUS_DECONFIG</id>
+    <description>Indicates if system should consider abus logic
+    when deconfiguring in _deconfigureAssocProc(), will be
+    overwritten on multi-node system</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <!-- For reconfig loop testing -->
+  <attribute>
+    <id>MSS_CENT_AVDD_SLOPE_ACTIVE</id>
+    <description>Units: uV/Membuf</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_AVDD_SLOPE_ACTIVE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_CENT_AVDD_SLOPE_INACTIVE</id>
+    <description>Units: uV/Membuf</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_AVDD_SLOPE_INACTIVE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_CENT_AVDD_INTERCEPT</id>
+    <description>Units: mV</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_AVDD_SLOPE_INTERCEPT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_CENT_VDD_SLOPE_ACTIVE</id>
+    <description>Units: uV/Membuf</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_CENT_VDD_SLOPE_INACTIVE</id>
+    <description>Units: uV/Membuf</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_CENT_VDD_INTERCEPT</id>
+    <description>Units: mV</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_CENT_VCS_SLOPE_ACTIVE</id>
+    <description>Units: uV/Membuf</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_CENT_VCS_SLOPE_INACTIVE</id>
+    <description>Units: uV/Membuf</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_CENT_VCS_INTERCEPT</id>
+    <description>Units: mV</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VPP_SLOPE</id>
+    <description>Units: uV/DRAM</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VPP_INTERCEPT</id>
+    <description>Units: mV</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VPP_SLOPE_POST_DRAM_INIT</id>
+    <description>Units: uV/DRAM</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_VPP_INTERCEPT_POST_DRAM_INIT</id>
+    <description>Units: mV</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_DDR3_VDDR_SLOPE</id>
+    <description>Units: 1/Amps</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_DDR3_VDDR_INTERCEPT</id>
+    <description>Units: mV</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MRW_DDR3_VDDR_MAX_LIMIT</id>
+    <description>Maximum voltage limit for the dynamic VID DDR3
+    VDDR voltage setpoint. In mV.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_DDR3_VDDR_SLOPE_POST_DRAM_INIT</id>
+    <description>Units: 1/Amps</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_DDR3_VDDR_INTERCEPT_POST_DRAM_INIT</id>
+    <description>Units: mV</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MRW_DDR3_VDDR_MAX_LIMIT_POST_DRAM_INIT</id>
+    <description>Maximum voltage limit for the dynamic VID DDR3
+    VDDR voltage setpoint. In mV.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_DDR4_VDDR_SLOPE</id>
+    <description>Units: 1/Amps</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_DDR4_VDDR_INTERCEPT</id>
+    <description>Units: mV</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MRW_DDR4_VDDR_MAX_LIMIT</id>
+    <description>Maximum voltage limit for the dynamic VID DDR4
+    VDDR voltage setpoint. In mV.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_DDR4_VDDR_SLOPE_POST_DRAM_INIT</id>
+    <description>Units: 1/Amps</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MSS_VOLT_DDR4_VDDR_INTERCEPT_POST_DRAM_INIT</id>
+    <description>Units: mV</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>MRW_DDR4_VDDR_MAX_LIMIT_POST_DRAM_INIT</id>
+    <description>Maximum voltage limit for the dynamic VID DDR4
+    VDDR voltage setpoint. In mV.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <enumerationType>
+    <id>MSS_MRW_POWER_CONTROL_REQUESTED</id>
+    <description>Enumeration defining the type of power control
+    requested</description>
+    <enumerator>
+      <name>OFF</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>POWER_DOWN</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>STR</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>PD_AND_STR</name>
+      <value>3</value>
+    </enumerator>
+    <default>OFF</default>
+  </enumerationType>
+  <attribute>
+    <id>MSS_MRW_POWER_CONTROL_REQUESTED</id>
+    <description>Memory power control settings programmed during
+    IPL Used by OCC when exiting idle powersave mode Producer: MRW
+    0x00 = OFF 0x01 = POWER_DOWN 0x02 = STR 0x03 =
+    PD_AND_STR</description>
+    <simpleType>
+      <uint8_t>
+        <default>OFF</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_POWER_CONTROL_REQUESTED</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
+    <description>Enumeration defining the type of power control
+    requested</description>
+    <enumerator>
+      <name>OFF</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>POWER_DOWN</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>STR</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>PD_AND_STR</name>
+      <value>3</value>
+    </enumerator>
+    <default>NONE</default>
+  </enumerationType>
+  <attribute>
+    <id>MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
+    <description>Memory power control settings for IDLE powersave
+    mode Used by OCC when entering idle powersave mode Producer:
+    MRW 0x00 = OFF 0x01 = POWER_DOWN 0x02 = STR 0x03 =
+    PD_AND_STR</description>
+    <simpleType>
+      <uint8_t>
+        <default>OFF</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>OCC_MASTER_CAPABLE</id>
+    <description>This attribute is to determine whether an occ is
+    master capable. An OCC is master capable if it's parent
+    processor is wired to the APSS.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+        <!-- false -->
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MSS_DRAMINIT_RESET_DISABLE</id>
+    <description>A disable switch for resetting the phy delay
+    values at the beginning of calling
+    mss_draminit_training.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_DRAMINIT_RESET_DISABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>ISDIMM_POWER_CURVE_ALGORITHM_VERSION</id>
+    <description>version of algorithm used to calculate ISDIMM
+    power curves</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_ISDIMM_POWER_CURVE_ALGORITHM_VERSION</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_MASK</id>
+    <description>Effective PCIE Lane Mask Creator: Firmware
+    Purpose: Holds the effective PCIE lane mask of each PEC after
+    taking into account any IOP bifurcations. If no IOP
+    bifurcations present, this is just the value of the
+    PEC_PCIE_LANE_MASK_NON_BIFURCATED attribute Data Format: x4
+    array of uint16_t values. The uint16_t value is a mask for lane
+    0, the next for lane 1 and so on until lane 3. A lane set mask
+    indicates which groups of lanes are assigned to an IOP. For
+    instance, lane set 0 value of 0xFFFF and lane set 1 value of
+    0x0000 for PEC0 means PEC0 is a x16. Lane set 0 value of 0xFF00
+    and lane set 1 value of 0x00FF for PEC0, means the IOP is
+    bifurcated into two x8s.</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL</id>
+    <description>Effective PCIE IOP reversal configuration Creator:
+    Firmware Purpose: Holds the effective PCIE IOP reversal value
+    after taking into account any IOP bifurcations. If no IOP
+    bifurcations present, this is just the value of the
+    PROC_PCIE_IOP_REVERSAL_NON_BIFURCATED attribute. Data Format:
+    x4 array of uint8_t values. The first uint8_t value is for lane
+    set 0, the second for lane set 1 and so on. The given index in
+    the array is a mask which specifies which bit to invert in the
+    lane swap settings for the given PEC/lane set.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL_NON_BIFURCATED</id>
+    <description>Base PCIE IOP reversal configuration Creator:
+    Firmware Purpose: Holds the base PCIE IOP reversal value
+    without considering IOP bifurcation. Data Format: x4 array of
+    uint8_t values. The first uint8_t value is for lane set 0, the
+    second for lane set 1 and so on. The given index in the array
+    is a mask which specifies which bit to invert in the lane swap
+    settings for the given lane set.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_SWAP_NON_BIFURCATED</id>
+    <description>Base PCIE IOP swap configuration value Creator:
+    MRW Purpose: Holds the base IOP swap configuration value
+    without considering IOP bifurcation. The swap value controls
+    how PCIE lanes are recordered when the leave the IOP, to
+    provide lane routing flexibility. Data Format: A uint8_t value.
+    The value specifices for the hardware how to swap the PCIE
+    lanes for the given PEC.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
+    <description>PCIE Lane Mask base configuration Creator: MRW
+    Purpose: Holds the base PCIE lane mask assuming no dynamic IOP
+    bifurcations. Data Format: x4 array of uint16_t values. The
+    first uint8_t value is lane set 0, the second for lane set 2
+    and so on. A lane set mask indicates which groups of lanes are
+    assigned to an IOP. For instance, lane set 0 value of 0xFFFF
+    and lane set 1 value of 0x0000 means the PEC is a x16. Lane set
+    0 value of 0xFF00 and lane set 1 value of 0x00FF, means the PEC
+    is split into two x8s.</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_REVERSAL_BIFURCATED</id>
+    <description>Base PCIE IOP reversal configuration Creator:
+    Firmware Purpose: Holds the PCIE IOP reversal value for cases
+    where the IOP is bifurcated Data Format: x4 array of uint8_t
+    values. The first uint8_t value is lane set 0, the second for
+    lane set 2 and so on. The given index in the array is a mask
+    which specifies which bit to invert in the lane swap settings
+    for the given lane set</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_IOP_SWAP_BIFURCATED</id>
+    <description>Bifurcated PCIE IOP swap configuration value
+    Creator: MRW Purpose: Holds the base IOP swap configuration
+    value for the IOPs in the case where they are bifurcated. The
+    swap value controls how PCIE lanes are recordered when the
+    leave the IOP, to provide lane routing flexibility. Data
+    Format: A uint8_t value. The value specifices for the hardware
+    how to swap the PCIE lanes for the given PEC.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PEC_PCIE_LANE_MASK_BIFURCATED</id>
+    <description>PCIE Lane Mask bifurcated configuration Creator:
+    MRW Purpose: Holds the PCIE lane mask assuming IOPs are
+    bifurcated. Data Format: x4 array of uint16_t values. The first
+    uint8_t value is lane set 0, the second for lane set 2 and so
+    on. A lane set mask indicates which groups of lanes are
+    assigned to an IOP. For instance, lane set 0 value of 0xFF00
+    and lane set 1 value of 0x00FF means the IOP is bifurcated into
+    two x8s.</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_IS_SLOT</id>
+    <description>Indicates whether PCIE lanes terminate at a
+    pluggable slot Creator: MRW Purpose: Used by FW to know whether
+    the given PCIE lanes terminate at a pluggable slot or not. If
+    this is the case, and the platform supports bifurcation, the
+    card's VPD should be interrogated to determine whether to
+    bifurcate the IOP or not. Data Format: x4 array of uint8_t
+    values. The first value indicates whether lane set 0 terminates
+    at a pluggable slot. The next three values indicate the same
+    for lane sets 1-3. A value of 1 at a given array index
+    indicates the lanes terminate at a pluggable slot, 0
+    otherwise.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>CDM_DOMAIN</id>
+    <description>Enumeration specifying a target's CEC degraded
+    mode domain</description>
+    <enumerator>
+      <name>NONE</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>CPU</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>DIMM</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>FABRIC</name>
+      <value>3</value>
+    </enumerator>
+    <enumerator>
+      <name>MEM</name>
+      <value>4</value>
+    </enumerator>
+    <enumerator>
+      <name>IO</name>
+      <value>5</value>
+    </enumerator>
+    <enumerator>
+      <name>NODE</name>
+      <value>6</value>
+    </enumerator>
+    <enumerator>
+      <name>CLOCK</name>
+      <value>7</value>
+    </enumerator>
+    <enumerator>
+      <name>PSI</name>
+      <value>8</value>
+    </enumerator>
+    <enumerator>
+      <name>FSP</name>
+      <value>9</value>
+    </enumerator>
+    <enumerator>
+      <name>ALL</name>
+      <value>10</value>
+    </enumerator>
+    <default>NONE</default>
+  </enumerationType>
+  <attribute>
+    <id>CDM_DOMAIN</id>
+    <description>Specifies a target's CEC degraded mode domain. For
+    example, all DIMMs are part of the DIMM CEC degraded mode
+    domain.</description>
+    <simpleType>
+      <enumeration>
+        <id>CDM_DOMAIN</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+  </attribute>
+  <attribute>
+    <id>I2C_BUS_SPEED_ARRAY</id>
+    <description>Designates the speed at which a given I2C bus
+    should run. Creator: MRW Purpose: Used by FW to know the
+    fastest possible bus speed that all of the devices on a given
+    bus are able to use. Data Format: 4x4 array of uint16_t values.
+    The first index indicates the engine number of the bus. The
+    second index indicates the port number of the bus. The value in
+    the array is the I2C bus speed used for that engine/port
+    combination in KHz.</description>
+    <simpleType>
+      <uint16_t>
+        <default>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>
+      </uint16_t>
+      <array>4,4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>SUPPORTED_HOT_PLUG</id>
+    <description>Enumeration indication which Hot Plug Controllers
+    are supported by the current system.</description>
+    <enumerator>
+      <name>NA</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>MAX5961</name>
+      <value>0x01</value>
+    </enumerator>
+    <enumerator>
+      <name>PCA9551</name>
+      <value>0x02</value>
+    </enumerator>
+    <default>NA</default>
+  </enumerationType>
+  <attribute>
+    <id>HOT_PLUG_POWER_CONTROLLER_INFO</id>
+    <description>Hot Plug Controller values for a specific
+    processor. Purpose: Holds information about the hot plug
+    controllers so that a Hardware procedure is able to turn them
+    on and off. Data Format: up to 8 Hot Plug Controllers x 7
+    variables of information This data is at the processor level.
+    The needed information and their individual sizes are as
+    follows: (1) I2C Master processor engine (uint8_t) (2) I2C
+    Master processor port (uint8_t) (3) Bus Speed (uint16_t value:
+    2 uint8_t values: MSB, LSB) (4) Slave address (uint8_t) (5)
+    Device type (uint8_t: see SUPPORTED_HOT_PLUG enum) (6) I2C
+    Master processor node (uint8_t) (7) I2C Master processor
+    position (uint8_t) Thus, the information will be 8
+    bytes.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>
+      </uint8_t>
+      <array>8,8</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_HOT_PLUG_POWER_CONTROLLER_INFO</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>OPT_MEMMAP_GROUP_POLICY</id>
+    <description>Controls scope of grouping performed in memory map
+    calculations Possible values defined in FAPI
+    ATTR_OPT_MEMMAP_GROUP_POLICY</description>
+    <simpleType>
+      <uint8_t>
+        <default>0x00</default>
+      </uint8_t>
+      <!-- CHIP_AS_GROUP -->
+    </simpleType>
+    <readable />
+    <persistency>non-volatile</persistency>
+    <hwpfToHbAttrMap>
+      <id>ATTR_OPT_MEMMAP_GROUP_POLICY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>TPM_REQUIRED</id>
+    <description>Setting to require(0x1) or not require(0x0) a
+    functional TPM to boot the system.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_PHB</id>
+    <description>creator: platform Number of PCIe PHB units present
+    on target Murano/Venice: 3 Naples: 4 Nimbus: 6 Cumulus:
+    6</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_NUM_PHB</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_IOP</id>
+    <description>creator: platform Number of PCIe IOP units present
+    on target Murano/Venice: 2 Naples: 3 Nimbus: 3</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_NUM_IOP</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_PEC</id>
+    <description>creator: platform Number of PCIe PEC units present
+    on target Nimbus: 3</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_NUM_PEC</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_NUM_LANES</id>
+    <description>creator: platform Number of PCIe I/O lanes
+    supported by target Murano: 24 Venice: 32 Naples: 40 Nimbus:
+    48</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_NUM_LANES</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- === start configurable threshold attributes for PRD === -->
+  <attribute>
+    <id>MNFG_TH_P8EX_L2_CACHE_CES</id>
+    <description>This attribute represents the Maximum number of L2
+    Cache CEs allowed during Manufacturing. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_P8EX_L2_DIR_CES</id>
+    <description>This attribute represents the Maximum number of L2
+    Directory CEs allowed during Manufacturing. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_P8EX_L3_CACHE_CES</id>
+    <description>This attribute represents the Maximum number of L3
+    Cache CEs allowed during Manufacturing. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>3</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_P8EX_L3_DIR_CES</id>
+    <description>This attribute represents the Maximum number of L3
+    Directory CEs allowed during Manufacturing. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>FIELD_TH_P8EX_L2_LINE_DELETES</id>
+    <description>This attribute represents the Maximum number of L2
+    Line Deletes allowed in the Field. creator: platform (generated
+    based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>6</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>FIELD_TH_P8EX_L3_LINE_DELETES</id>
+    <description>This attribute represents the Maximum number of L3
+    Line Deletes allowed in the Field. creator: platform (generated
+    based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>6</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>FIELD_TH_P8EX_L2_COL_REPAIRS</id>
+    <description>This attribute represents the Maximum number of L2
+    Column Repairs allowed in the Field. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>7</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>FIELD_TH_P8EX_L3_COL_REPAIRS</id>
+    <description>This attribute represents the Maximum number of L3
+    Column Repairs allowed in the Field. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>7</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_P8EX_L2_LINE_DELETES</id>
+    <description>This attribute represents the Maximum number of L2
+    Line Deletes allowed during Manufacturing. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_P8EX_L3_LINE_DELETES</id>
+    <description>This attribute represents the Maximum number of L3
+    Line Deletes allowed during Manufacturing. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_P8EX_L2_COL_REPAIRS</id>
+    <description>This attribute represents the Maximum number of L2
+    Column Repairs allowed during Manufacturing. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_P8EX_L3_COL_REPAIRS</id>
+    <description>This attribute represents the Maximum number of L3
+    Column Repairs allowed during Manufacturing. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_CEN_MBA_RT_SOFT_CE_TH_ALGO</id>
+    <description>This attribute represents the Base threshold (for
+    2GB DRAM ) of Memory CEs allowed during runtime. creator:
+    platform (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>2</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_CEN_MBA_IPL_SOFT_CE_TH_ALGO</id>
+    <description>This attribute represents the Base threshold (for
+    2GB DRAM ) of Memory CEs allowed during IPL. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>2</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_CEN_MBA_RT_RCE_PER_RANK</id>
+    <description>This attribute represents the maximum number of
+    Memory RCEs allowed per Rank during runtime. creator: platform
+    (generated based on MRW data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>2</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_CEN_L4_CACHE_CES</id>
+    <description>This attribute represents the maximum number of L4
+    Cache CEs allowed. creator: platform (generated based on MRW
+    data)</description>
+    <simpleType>
+      <uint8_t>
+        <default>2</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_RCD_PARITY_ERRORS</id>
+    <description>With MNFG thresholds enabled, PRD will make a
+    predictive callout when an RCD parity error (recovery enabled)
+    attention count is equal to this value. A value of 0 defaults
+    to the max threshold of 0xff.</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_MEMORY_IUES</id>
+    <description>With MNFG thresholds enabled, PRD will make a
+    predictive callout when a memory intermittent UE attention
+    count is equal to this value. A value of 0 defaults to the max
+    threshold of 0xff.</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MNFG_TH_MEMORY_IMPES</id>
+    <description>With MNFG thresholds enabled, PRD will make a
+    predictive callout when a memory intermittent MPE attention
+    count is equal to this value. A value of 0 defaults to the max
+    threshold of 0xff.</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <!-- === end configurable threshold attributes for PRD === -->
+  <!-- === start RCD parity error reconfig loop attributes for PRD/MDIA === -->
+  <attribute>
+    <id>RCD_PARITY_RECONFIG_LOOPS_ALLOWED</id>
+    <description>The number of reconfig loops allowed due to RCD
+    parity errors when recovery is disabled. PRD will make a
+    predictive callout and stop issuing reconfigs due to RCD parity
+    errors when RCD_PARITY_RECONFIG_LOOP_COUNT is greater than this
+    value. A value of 0 indicates that no reconfig loops are
+    allowed due to RCD parity errors.</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>RCD_PARITY_RECONFIG_LOOP_COUNT</id>
+    <description>PRD will increment this count and issue a reconfig
+    loop each time an RCD parity error (recovery disabled) is
+    detected during Memory Diagnostics. This value will be cleared
+    at the end of Memory Diagnostics if it is able to complete
+    without the need to issue a reconfig loop.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <!-- === end RCD parity error reconfig loop attributes for PRD/MDIA === -->
+  <attribute>
+    <id>RESOURCE_IS_CRITICAL</id>
+    <description>Used to tell if a resource is critical to perform
+    an IPL. If this attribute is set to 1 and the target is
+    deconfigured, the IPL MUST terminate.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>BRAZOS_RX_FIFO_OVERRIDE</id>
+    <description>Defines where to apply Brazos
+    rx_fifo_final_l2u_dly override settings for
+    SW299500.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_BRAZOS_RX_FIFO_OVERRIDE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- === Manufacturing threshold Attributes of PRD === -->
+  <attribute>
+    <id>MSS_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
+    <description>Machine Readable Workbook enablement of the HWP
+    code to adjust the VMEM regulator power limit based on number
+    of installed DIMMs.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>
+      ATTR_MSS_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_MAX_NUMBER_DIMMS_POSSIBLE_PER_VMEM_REGULATOR</id>
+    <description>Machine Readable Workbook value for the maximum
+    possible number of dimms that can be installed under any of the
+    VMEM regulators.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>
+      ATTR_MSS_MRW_MAX_NUMBER_DIMMS_POSSIBLE_PER_VMEM_REGULATOR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>WOF_ENABLED</id>
+    <description>Defines if the Workload Optimization Frequency
+    (WOF) system feature where OCC algorithms will change
+    (typically boost) the operational frequency based on measured
+    power available and any currently idling cores.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_WOF_ENABLED</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!--HWSV needs to update names so we can remove this-->
+  <!--HWSV needs to update names so we can remove this-->
+  <!--HWSV needs to update names so we can remove this-->
+  <!--HWSV needs to update names so we can remove this-->
+  <!--HWSV needs to update names so we can remove this-->
+  <!--HWSV needs to update names so we can remove this-->
+  <!--Deprecated-->
+  <!--Deprecated-->
+  <attribute>
+    <id>VAS_HYPERVISOR_WINDOW_CONTEXT_ADDR</id>
+    <description>VAS - Hypervisor Window Contexts address MMIO
+    consumed by PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VAS_USER_WINDOW_CONTEXT_ADDR</id>
+    <description>VAS - User Window Context address MMIO consumed by
+    PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>LPC_BUS_ADDR</id>
+    <description>LPC Bus address - MMIO consumed by
+    PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NVIDIA_NPU_PRIVILEGED_ADDR</id>
+    <description>Nvidia Link - NPU Privileged Regs address MMIO
+    consumed by PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NVIDIA_NPU_USER_REG_ADDR</id>
+    <description>Nvidia Link - NPU User Regs address MMIO consumed
+    by PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NVIDIA_PHY0_REG_ADDR</id>
+    <description>Nvidia Link - Phy 0 Regs address MMIO consumed by
+    PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NVIDIA_PHY1_REG_ADDR</id>
+    <description>Nvidia Link - Phy 1 Regs address MMIO consumed by
+    PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>XIVE_CONTROLLER_BAR_ADDR</id>
+    <description>XIVE - Controller Bar address MMIO consumed by
+    PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>XIVE_THREAD_MGMT1_BAR_ADDR</id>
+    <description>XIVE - Thread Management Bar address register 1
+    MMIO consumed by HB/PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PSI_HB_ESB_ADDR</id>
+    <description>PSIHB - ESB space address - MMIO consumed by
+    PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>NX_RNG_ADDR</id>
+    <description>NX - RNG space - MMIO consumed by
+    PHYP</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>FUSED_CORE_MODE</id>
+    <description>Enum for FUSED_CORE_MODE</description>
+    <enumerator>
+      <name>SMT4_DEFAULT</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>SMT4_ONLY</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>SMT8_ONLY</name>
+      <value>2</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>FUSED_CORE_MODE</id>
+    <description>Stores the SMT setting used to determine fused
+    mode. SMT4_DEFAULT: Nimbus_DD1, boot in SMT4 but can change to
+    SMT8 SMT4_ONLY: Nimbus_DD2/Cumulus, set based on PVR info
+    SMT8_ONLY: Nimbus_DD2/Cumulus, set based on PVR
+    info</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>ICACHE_LINE_SIZE</id>
+    <description>Icache Line Size in bytes</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>ICACHE_BLOCK_SIZE</id>
+    <description>ICache Block Size in bytes</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>ICACHE_SIZE</id>
+    <description>ICache Size in KB</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>ICACHE_ASSOC_SETS</id>
+    <description>ICache Assoc Sets</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>DCACHE_LINE_SIZE</id>
+    <description>DCache Line Size in bytes</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>DCACHE_ASSOC_SETS</id>
+    <description>DCache Associative Sets</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>L2_CACHE_LINE_SIZE</id>
+    <description>L2 Cache Line Size in bytes</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>L2_CACHE_SIZE</id>
+    <description>L2 Cache Size in KB</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>L2_CACHE_ASSOC_SETS</id>
+    <description>L2 Cache Assoc Sets</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>L3_CACHE_LINE_SIZE</id>
+    <description>L3 Cache Line Size in bytes</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>L3_CACHE_SIZE</id>
+    <description>L3 Cache Size in KB</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>TIME_BASE</id>
+    <description>Time Base frequency in MHZ</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x800000</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>TLB_DATA_ENTRIES</id>
+    <description>TLB Data Entries</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>TLB_DATA_ASSOC_SETS</id>
+    <description>TLB Data Associative Sets</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>TLB_INSTR_ENTRIES</id>
+    <description>TLB Instruction Entries</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>TLB_INSTR_ASSOC_SETS</id>
+    <description>TLB Instruction Associative Sets</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>TLB_RESERVE_SIZE</id>
+    <description>Reserve Size in bytes</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>DATA_CACHE_SIZE</id>
+    <description>L1 Data Cache Size in KB</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>DATA_CACHE_LINE_SIZE</id>
+    <description>L1 Data Cache Line Size in bytes</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>THREAD_COUNT</id>
+    <description>Thread Count</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x4</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PFET_POWERUP_DELAY_NS</id>
+    <description>Time (in nanoseconds) between PFET controller
+    steps (7 of them) when turning the PFES ON</description>
+    <simpleType>
+      <uint32_t>
+        <!-- Will be set by HWP -->
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <readable />
+    <persistency>non-volatile</persistency>
+    <hwpfToHbAttrMap>
+      <id>ATTR_PFET_POWERUP_DELAY_NS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!--<attribute>
     <id>FREQ_PROC_REFCLOCK_KHZ</id>
     <description>
       The frequency of the processor refclock in kHz.
@@ -6530,7 +6498,7 @@
     <readable/>
     <writeable/>
 </attribute>-->
-<!--<attribute>
+  <!--<attribute>
     <id>FREQ_MEM_REFCLOCK</id>
     <description>
       The frequency of the memory refclock in MHz.
@@ -6550,51 +6518,52 @@
     <readable/>
     <writeable/>
 </attribute>-->
-<attribute>
-  <id>REQUIRED_SYNCH_MODE</id>
-  <description>Specify the system policy to enforce synchronous
-  mode between memory and nest. This drives the value of
-  ATTR_MC_SYNC_MODE. 0 = UNDETERMINED : Run synchronously if the
-  dimm and nest freq matches 1 = ALWAYS : Require matching
-  frequencies and deconfigure memory that does not match the nest 2
-  = NEVER : Do not run synchronously, even if the frequencies
-  match</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_REQUIRED_SYNCH_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MAX_ALLOWED_DIMM_FREQ</id>
-  <description>Maximum frequency (in MHz) that this system can run
-  the DIMMs at. There are 5 possible values determined by the dimm
-  configuration. For configurations which have mixed rank
-  configurations, the lowest frequency based on ranks of either
-  DIMM is chosen. For example if there was a 1R and a 2R DIMM
-  installed, and 1R dual drop was a lower max freq than 2R dual
-  drop, then the 1R max freq would be the max allowed. [0]=One
-  rank, single drop [1]=Two rank, single drop [2]=Four rank, single
-  drop [3]=One rank, dual drop [4]=Two rank, dual drop A value of
-  zero would indicate an unsupported configuration.</description>
-  <simpleType>
-    <uint32_t>
-      <default>2400,2400,2400,2400,2400</default>
-    </uint32_t>
-    <array>5</array>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_MAX_ALLOWED_DIMM_FREQ</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<!--<attribute>
+  <attribute>
+    <id>REQUIRED_SYNCH_MODE</id>
+    <description>Specify the system policy to enforce synchronous
+    mode between memory and nest. This drives the value of
+    ATTR_MC_SYNC_MODE. 0 = UNDETERMINED : Run synchronously if the
+    dimm and nest freq matches 1 = ALWAYS : Require matching
+    frequencies and deconfigure memory that does not match the nest
+    2 = NEVER : Do not run synchronously, even if the frequencies
+    match</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_REQUIRED_SYNCH_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MAX_ALLOWED_DIMM_FREQ</id>
+    <description>Maximum frequency (in MHz) that this system can
+    run the DIMMs at. There are 5 possible values determined by the
+    dimm configuration. For configurations which have mixed rank
+    configurations, the lowest frequency based on ranks of either
+    DIMM is chosen. For example if there was a 1R and a 2R DIMM
+    installed, and 1R dual drop was a lower max freq than 2R dual
+    drop, then the 1R max freq would be the max allowed. [0]=One
+    rank, single drop [1]=Two rank, single drop [2]=Four rank,
+    single drop [3]=One rank, dual drop [4]=Two rank, dual drop A
+    value of zero would indicate an unsupported
+    configuration.</description>
+    <simpleType>
+      <uint32_t>
+        <default>2400,2400,2400,2400,2400</default>
+      </uint32_t>
+      <array>5</array>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_MAX_ALLOWED_DIMM_FREQ</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <!--<attribute>
     <id>PROC_DPLL_DIVIDER</id>
     <description>
       The product of the DPLL internal prescalar divide (CD_DIV124_DC)
@@ -6615,401 +6584,403 @@
     <readable/>
     <writeable/>
 </attribute>-->
-<attribute>
-  <id>VDD_AVSBUS_BUSNUM</id>
-  <description>Defines the AVSBus (0 or 1) which has the core VDD
-  rail VRM Producer: Machine Readable Workbook Consumers:
-  p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock
-  -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_VDD_AVSBUS_BUSNUM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VDN_AVSBUS_BUSNUM</id>
-  <description>Defines the AVSBus (0 or 1) which has the chip VDN
-  rail VRM Producer: Machine Readable Workbook Consumers:
-  p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock
-  -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_VDN_AVSBUS_BUSNUM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VDD_AVSBUS_RAIL</id>
-  <description>Defines the AVSBus rail selector number (0 - 15) for
-  the VDD VRM on the bus defined by ATTR_AVSBUS_VDD_BUSNUM.
-  Producer: Machine Readable Workbook Consumers: p9_set_evid;
-  p9_set_voltage (tool); p9_build_pstate_datablock -&gt; Pstate
-  Parameter Block (PSPB) for PGPE</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_VDD_AVSBUS_RAIL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VDN_AVSBUS_RAIL</id>
-  <description>Defines the AVSBus rail selector number (0 - 15) for
-  the VDN VRM on the bus defined by ATTR_AVSBUS_VDN_BUSNUM.
-  Producer: Machine Readable Workbook Consumers:
-  p9_set_avsbus_voltage (tool); p9_build_pstate_datablock -&gt;
-  Pstate Parameter Block (PSPB) for PGPE</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_VDN_AVSBUS_RAIL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VCS_AVSBUS_RAIL</id>
-  <description>Defines the AVSBus rail selector number (0 - 15) for
-  the VCS VRM on the bus defined by ATTR_AVSBUS_VCS_BUSNUM.
-  Producer: Machine Readable Workbook Consumers:
-  p9_set_avsbus_voltage (tool); p9_build_pstate_datablock -&gt;
-  Pstate Parameter Block (PSPB) for PGPE</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_VCS_AVSBUS_RAIL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VCS_AVSBUS_BUSNUM</id>
-  <description>Defines the AVSBus (0 or 1) which has the core VCS
-  rail VRM Producer: Machine Readable Workbook Consumers:
-  p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock
-  -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_VCS_AVSBUS_BUSNUM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>VCS_I2C_BUSNUM</id>
-  <description>Defines the I2C bus number (0 - 15) that has the VCS
-  VRM. Producer: Machine Readable Workbook Consumers: p9_set_evid;
-  sp9_set_voltage (tool)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_VCS_I2C_BUSNUM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PM_APSS_CHIP_SELECT</id>
-  <description>Defines which of the PSS chip selects (0 or 1) that
-  the APSS is connected Provided by the Machine Readable Workbook.
-  Consumer: p9_pm_pss_init</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_APSS_CHIP_SELECT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>PM_APSS_CHIP_SELECT</id>
-  <description>Enumeration for the
-  ATTR_PM_APSS_CHIP_SELECT</description>
-  <enumerator>
-    <name>NONE</name>
-    <value>0xFF</value>
-  </enumerator>
-  <enumerator>
-    <name>CS0</name>
-    <value>0x00</value>
-  </enumerator>
-  <enumerator>
-    <name>CS1</name>
-    <value>0x01</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>STOP5_DISABLE</id>
-  <description>Control CME response to execution of PowerPC STOP
-  instruction if OFF, treat STOP5 as STOP5 if ON, treat STOP5 as
-  STOP4 Producer: ??? Consumer: p8_hcode_image_build.C Platform
-  default: ON</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_STOP5_DISABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>SYSTEM_IVRMS_ENABLED</id>
-  <description>System control to allow (if all other attribute
-  tests yield true values) or categorically disallow IVRM
-  enablement Producer: MRWB Consumers: p9_build_pstate_datablock
-  -&gt; Pstate Parameter Block (PSPB) for PGPE/OCC CME Quad Pstate
-  Region (CQPR) for CM Quad Manager</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_SYSTEM_IVRMS_ENABLED</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>SYSTEM_WOF_ENABLED</id>
-  <description>System control to allow Work Load Optimized
-  Frequency (WOF) algorithms to modify frequency based on active
-  core count and other inputs. Producer: MRWB Consumers:
-  p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for
-  PGPE/OCC Platform default: FALSE</description>
-  <simpleType>
-    <uint8_t>
-      <default>OFF</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_SYSTEM_WOF_ENABLED</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<enumerationType>
-  <id>SYSTEM_WOF_ENABLED</id>
-  <description>Enumeration for Work Load Optimized
-  Frequency</description>
-  <enumerator>
-    <name>OFF</name>
-    <value>0x00</value>
-  </enumerator>
-  <enumerator>
-    <name>ON</name>
-    <value>0x01</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>WOF_ENABLE_FRATIO</id>
-  <description>If wof_enabled, defines the Frequency Ratio
-  calculation performed. (THIS IS NOT SUPPORTED IN P9 GA1!).
-  Producer: MRWB Consumers: p9_hcode_image_build.C</description>
-  <simpleType>
-    <uint8_t>
-      <default>FIXED</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_WOF_ENABLE_FRATIO</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<enumerationType>
-  <id>WOF_ENABLE_FRATIO</id>
-  <description>Enumeration for Work Load Optimized Frequency
-  ratio</description>
-  <enumerator>
-    <name>FIXED</name>
-    <value>0x00</value>
-  </enumerator>
-  <enumerator>
-    <name>STEPPED</name>
-    <value>0x01</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>WOF_ENABLE_VRATIO</id>
-  <description>If wof_enabled, defines the Voltage Ratio
-  calculation performed. THIS IS NOT SUPPORTED AT PRESENT. GA1
-  SUPPORT IS TBD). Producer: MRWB Consumers:
-  p9_hcode_image_build.C</description>
-  <simpleType>
-    <uint8_t>
-      <default>FIXED</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_WOF_ENABLE_VRATIO</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<enumerationType>
-  <id>WOF_ENABLE_VRATIO</id>
-  <description>Enumeration for Work Load Optimized Frequency
-  ratio</description>
-  <enumerator>
-    <name>FIXED</name>
-    <value>0x00</value>
-  </enumerator>
-  <enumerator>
-    <name>STEPPED</name>
-    <value>0x01</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>WOF_VRATIO_SELECT</id>
-  <description>If wof_enabled AND ATTR_WOF_ENABLE_VRATIO =
-  CALCULATED, this attribute selects the Vratio calculation type.
-  ACTIVE_CORES: Vratio is the number of active cores to the number
-  of good cores FULL: Vratio is Vaverage to Vclip(Fclip) where
-  Vclip(Fclip) is the normal interpolated regulator voltage
-  (including load line uplife @ RDP current) derated with presently
-  measured Idd current (from the AVSBus) and the loadline.
-  Producer: MRWB Consumers: p9_hcode_image_build.C</description>
-  <simpleType>
-    <uint8_t>
-      <default>ACTIVE_CORES</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_WOF_VRATIO_SELECT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<enumerationType>
-  <id>WOF_VRATIO_SELECT</id>
-  <description>Enumeration for Work Load Optimized Frequency
-  ratio</description>
-  <enumerator>
-    <name>ACTIVE_CORES</name>
-    <value>0x00</value>
-  </enumerator>
-  <enumerator>
-    <name>FULL</name>
-    <value>0x01</value>
-  </enumerator>
-</enumerationType>
-<enumerationType>
-  <id>WOF_POWER_LIMIT</id>
-  <description>Enumeration to select WOF Power Limit</description>
-  <enumerator>
-    <name>NOMINAL</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>TURBO</name>
-    <value>1</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>WOF_POWER_LIMIT</id>
-  <description>System control to set the power limit for Workload
-  Optimized Frequency (WOF) algorithms. This is used to select the
-  proper VFRT tables. Producer: TMGT Consumers: FW that selects
-  VFRT tables</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>WOF_TABLE_LID_NUMBER</id>
-  <description>LID id used to load tables for Workload Optimized
-  Frequency (WOF) algorithms. Producer: TMGT Consumers: FW that
-  selects VFRT tables</description>
-  <simpleType>
-    <uint32_t>
-      <!-- @todo-RTC:172776-Get rid of default value that points to ZZ -->
-      <default>0x81E00440</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>SYS_VFRT_STATIC_DATA_ENABLE</id>
-  <description>Enables pstate parameter block code to use the
-  static system vfrt data Consumer: p9_pstate_parameter_block.C 0 =
-  OFF, 1 = ON Platform default: OFF 
-  <!--
+  <attribute>
+    <id>VDD_AVSBUS_BUSNUM</id>
+    <description>Defines the AVSBus (0 or 1) which has the core VDD
+    rail VRM Producer: Machine Readable Workbook Consumers:
+    p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock
+    -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_VDD_AVSBUS_BUSNUM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VDN_AVSBUS_BUSNUM</id>
+    <description>Defines the AVSBus (0 or 1) which has the chip VDN
+    rail VRM Producer: Machine Readable Workbook Consumers:
+    p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock
+    -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_VDN_AVSBUS_BUSNUM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VDD_AVSBUS_RAIL</id>
+    <description>Defines the AVSBus rail selector number (0 - 15)
+    for the VDD VRM on the bus defined by ATTR_AVSBUS_VDD_BUSNUM.
+    Producer: Machine Readable Workbook Consumers: p9_set_evid;
+    p9_set_voltage (tool); p9_build_pstate_datablock -&gt; Pstate
+    Parameter Block (PSPB) for PGPE</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_VDD_AVSBUS_RAIL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VDN_AVSBUS_RAIL</id>
+    <description>Defines the AVSBus rail selector number (0 - 15)
+    for the VDN VRM on the bus defined by ATTR_AVSBUS_VDN_BUSNUM.
+    Producer: Machine Readable Workbook Consumers:
+    p9_set_avsbus_voltage (tool); p9_build_pstate_datablock -&gt;
+    Pstate Parameter Block (PSPB) for PGPE</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_VDN_AVSBUS_RAIL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VCS_AVSBUS_RAIL</id>
+    <description>Defines the AVSBus rail selector number (0 - 15)
+    for the VCS VRM on the bus defined by ATTR_AVSBUS_VCS_BUSNUM.
+    Producer: Machine Readable Workbook Consumers:
+    p9_set_avsbus_voltage (tool); p9_build_pstate_datablock -&gt;
+    Pstate Parameter Block (PSPB) for PGPE</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_VCS_AVSBUS_RAIL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VCS_AVSBUS_BUSNUM</id>
+    <description>Defines the AVSBus (0 or 1) which has the core VCS
+    rail VRM Producer: Machine Readable Workbook Consumers:
+    p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock
+    -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_VCS_AVSBUS_BUSNUM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VCS_I2C_BUSNUM</id>
+    <description>Defines the I2C bus number (0 - 15) that has the
+    VCS VRM. Producer: Machine Readable Workbook Consumers:
+    p9_set_evid; sp9_set_voltage (tool)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_VCS_I2C_BUSNUM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PM_APSS_CHIP_SELECT</id>
+    <description>Defines which of the PSS chip selects (0 or 1)
+    that the APSS is connected Provided by the Machine Readable
+    Workbook. Consumer: p9_pm_pss_init</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_APSS_CHIP_SELECT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>PM_APSS_CHIP_SELECT</id>
+    <description>Enumeration for the
+    ATTR_PM_APSS_CHIP_SELECT</description>
+    <enumerator>
+      <name>NONE</name>
+      <value>0xFF</value>
+    </enumerator>
+    <enumerator>
+      <name>CS0</name>
+      <value>0x00</value>
+    </enumerator>
+    <enumerator>
+      <name>CS1</name>
+      <value>0x01</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>STOP5_DISABLE</id>
+    <description>Control CME response to execution of PowerPC STOP
+    instruction if OFF, treat STOP5 as STOP5 if ON, treat STOP5 as
+    STOP4 Producer: ??? Consumer: p8_hcode_image_build.C Platform
+    default: OFF</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_STOP5_DISABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>SYSTEM_IVRMS_ENABLED</id>
+    <description>System control to allow (if all other attribute
+    tests yield true values) or categorically disallow IVRM
+    enablement Producer: MRWB Consumers: p9_build_pstate_datablock
+    -&gt; Pstate Parameter Block (PSPB) for PGPE/OCC CME Quad
+    Pstate Region (CQPR) for CM Quad Manager</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_SYSTEM_IVRMS_ENABLED</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>SYSTEM_WOF_ENABLED</id>
+    <description>System control to allow Work Load Optimized
+    Frequency (WOF) algorithms to modify frequency based on active
+    core count and other inputs. Producer: MRWB Consumers:
+    p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB)
+    for PGPE/OCC Platform default: FALSE</description>
+    <simpleType>
+      <uint8_t>
+        <default>OFF</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_SYSTEM_WOF_ENABLED</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <enumerationType>
+    <id>SYSTEM_WOF_ENABLED</id>
+    <description>Enumeration for Work Load Optimized
+    Frequency</description>
+    <enumerator>
+      <name>OFF</name>
+      <value>0x00</value>
+    </enumerator>
+    <enumerator>
+      <name>ON</name>
+      <value>0x01</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>WOF_ENABLE_FRATIO</id>
+    <description>If wof_enabled, defines the Frequency Ratio
+    calculation performed. (THIS IS NOT SUPPORTED IN P9 GA1!).
+    Producer: MRWB Consumers: p9_hcode_image_build.C</description>
+    <simpleType>
+      <uint8_t>
+        <default>FIXED</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_WOF_ENABLE_FRATIO</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <enumerationType>
+    <id>WOF_ENABLE_FRATIO</id>
+    <description>Enumeration for Work Load Optimized Frequency
+    ratio</description>
+    <enumerator>
+      <name>FIXED</name>
+      <value>0x00</value>
+    </enumerator>
+    <enumerator>
+      <name>STEPPED</name>
+      <value>0x01</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>WOF_ENABLE_VRATIO</id>
+    <description>If wof_enabled, defines the Voltage Ratio
+    calculation performed. THIS IS NOT SUPPORTED AT PRESENT. GA1
+    SUPPORT IS TBD). Producer: MRWB Consumers:
+    p9_hcode_image_build.C</description>
+    <simpleType>
+      <uint8_t>
+        <default>FIXED</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_WOF_ENABLE_VRATIO</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <enumerationType>
+    <id>WOF_ENABLE_VRATIO</id>
+    <description>Enumeration for Work Load Optimized Frequency
+    ratio</description>
+    <enumerator>
+      <name>FIXED</name>
+      <value>0x00</value>
+    </enumerator>
+    <enumerator>
+      <name>STEPPED</name>
+      <value>0x01</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>WOF_VRATIO_SELECT</id>
+    <description>If wof_enabled AND ATTR_WOF_ENABLE_VRATIO =
+    CALCULATED, this attribute selects the Vratio calculation type.
+    ACTIVE_CORES: Vratio is the number of active cores to the
+    number of good cores FULL: Vratio is Vaverage to Vclip(Fclip)
+    where Vclip(Fclip) is the normal interpolated regulator voltage
+    (including load line uplife @ RDP current) derated with
+    presently measured Idd current (from the AVSBus) and the
+    loadline. Producer: MRWB Consumers:
+    p9_hcode_image_build.C</description>
+    <simpleType>
+      <uint8_t>
+        <default>ACTIVE_CORES</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_WOF_VRATIO_SELECT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <enumerationType>
+    <id>WOF_VRATIO_SELECT</id>
+    <description>Enumeration for Work Load Optimized Frequency
+    ratio</description>
+    <enumerator>
+      <name>ACTIVE_CORES</name>
+      <value>0x00</value>
+    </enumerator>
+    <enumerator>
+      <name>FULL</name>
+      <value>0x01</value>
+    </enumerator>
+  </enumerationType>
+  <enumerationType>
+    <id>WOF_POWER_LIMIT</id>
+    <description>Enumeration to select WOF Power
+    Limit</description>
+    <enumerator>
+      <name>NOMINAL</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>TURBO</name>
+      <value>1</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>WOF_POWER_LIMIT</id>
+    <description>System control to set the power limit for Workload
+    Optimized Frequency (WOF) algorithms. This is used to select
+    the proper VFRT tables. Producer: TMGT Consumers: FW that
+    selects VFRT tables</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>WOF_TABLE_LID_NUMBER</id>
+    <description>LID id used to load tables for Workload Optimized
+    Frequency (WOF) algorithms. Producer: TMGT Consumers: FW that
+    selects VFRT tables</description>
+    <simpleType>
+      <uint32_t>
+        <!-- @todo-RTC:172776-Get rid of default value that points to ZZ -->
+        <default>0x81E00440</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>SYS_VFRT_STATIC_DATA_ENABLE</id>
+    <description>Enables pstate parameter block code to use the
+    static system vfrt data Consumer: p9_pstate_parameter_block.C 0
+    = OFF, 1 = ON Platform default: OFF 
+    <!--
         @todo RTC 169662 at some point in the program, this default may be switched to
          the opposite setting.  However, coordination needs to occur with all CIs
          as this will enable functions that may not be modeled across the board.
      --></description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_SYS_VFRT_STATIC_DATA_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>SYSTEM_RESCLK_STEP_DELAY</id>
-  <description>Minimum delay (in nanoseconds) between resonant
-  clock transition steps Producer: MRWB Consumers:
-  p9_build_pstate_datablock -&gt; CME Quad Pstate Region (CQPR) for
-  CM Quad Manager Platform default: 0</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_SYSTEM_RESCLK_STEP_DELAY</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<!--<attribute>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_SYS_VFRT_STATIC_DATA_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>SYSTEM_RESCLK_STEP_DELAY</id>
+    <description>Minimum delay (in nanoseconds) between resonant
+    clock transition steps Producer: MRWB Consumers:
+    p9_build_pstate_datablock -&gt; CME Quad Pstate Region (CQPR)
+    for CM Quad Manager Platform default: 0</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_SYSTEM_RESCLK_STEP_DELAY</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <!--<attribute>
     <id>PFET_POWERUP_DELAY_NS</id>
     <description>
       Time (in nanoseconds) between PFET controller steps (7 of them) when turning
@@ -7033,3640 +7004,3698 @@
     <readable/>
     <writeable/>
 </attribute>-->
-<attribute>
-  <id>PFET_POWERDOWN_DELAY_NS</id>
-  <description>Time (in nanoseconds) between PFET controller steps
-  (7 of them) when turning the PFES OFF Producer: MRWB Consumers:
-  p9_pm_pfet_init Platform default:</description>
-  <simpleType>
-    <uint32_t>
-      <!-- Will be set by HWP -->
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_PFET_POWERDOWN_DELAY_NS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PFET_VDD_VOFF_SEL</id>
-  <description>Selection of the OFF setting for the core and cache
-  chiplet VDD PFET controllers Producer: MRWB Consumers:
-  p9_pm_pfet_init Platform default:</description>
-  <simpleType>
-    <uint8_t>
-      <!-- Will be set by HWP -->
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_PFET_VDD_VOFF_SEL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>PFET_VDD_VOFF_SEL</id>
-  <description>Enumeration indicating the OFF setting for the core
-  and cache chiplet DD PFET controllers</description>
-  <enumerator>
-    <name>NOOFF</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT1TO7OFF</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT2TO7OFF</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT3TO7OFF</name>
-    <value>3</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT4TO7OFF</name>
-    <value>4</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT5TO7OFF</name>
-    <value>5</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT6TO7OFF</name>
-    <value>6</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT7TO7OFF</name>
-    <value>7</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLOFF</name>
-    <value>8</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>PFET_VCS_VOFF_SEL</id>
-  <description>Selection of the OFF setting for the core and cache
-  chiplet VCS PFET controllers Producer: MRWB Consumers:
-  p9_pm_pfet_init Platform default:</description>
-  <simpleType>
-    <uint8_t>
-      <!-- Will be set by HWP -->
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_PFET_VCS_VOFF_SEL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>PFET_VCS_VOFF_SEL</id>
-  <description>Enumeration indicating the OFF setting for the core
-  and cache chiplet VCS PFET controllers</description>
-  <enumerator>
-    <name>NOOFF</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT1TO7OFF</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT2TO7OFF</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT3TO7OFF</name>
-    <value>3</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT4TO7OFF</name>
-    <value>4</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT5TO7OFF</name>
-    <value>5</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT6TO7OFF</name>
-    <value>6</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLBUT7TO7OFF</name>
-    <value>7</value>
-  </enumerator>
-  <enumerator>
-    <name>ALLOFF</name>
-    <value>8</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>VCS_I2C_RAIL</id>
-  <description>Step delay (binary in microseconds) after a voltage
-  change Consumer: p9_build_pstate_datablock -&gt; Pstate Parameter
-  Block (PSPB) for PGPE Provided by the Machine Readable Workbook
-  after system characterization.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_VCS_I2C_RAIL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>FAPI_POS</id>
-  <description>Enumeration defining special FAPI_POS
-  values</description>
-  <enumerator>
-    <name>NA</name>
-    <value>0xFFFFFFFF</value>
-  </enumerator>
-  <default>NA</default>
-</enumerationType>
-<attribute>
-  <id>FAPI_POS</id>
-  <description>Logical position of target within a system. This is
-  derived from the SMP location of each processor and each target's
-  relationship to a proc. - PROC = based on SMP groupid+chipid -
-  MEMBUF = PROC:FAPI_POS * [max membuf per proc] - 1st level child
-  unit = [parent chip]:FAPI_POS * [max children of this type per
-  chip] - 2nd+ level child unit = [immediate parent unit]:FAPI_POS
-  * [max units below parent] Note: This should not be used
-  algorithmically by HWPs directly. Note: Value ignores physical
-  drawer boundaries, the value is unique across the entire system.
-  This data is derived from the MRW. Default of NA is 0xFFFFFFFF
-  (to avoid confusion with legitimate 0 values)</description>
-  <simpleType>
-    <uint32_t>
-      <default>0xFFFFFFFF</default>
-    </uint32_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_FAPI_POS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>I2C_BUS_DIV_REF</id>
-  <description>Ref clock I2C bus divider consumed by code running
-  out of OTPROM</description>
-  <simpleType>
-    <uint16_t>
-      <default>0x0003</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <writeable />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_I2C_BUS_DIV_REF</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>NEST_PLL_BUCKET</id>
-  <description>Select Nest I2C and pll setting from one of the
-  supported frequencies</description>
-  <simpleType>
-    <uint8_t>
-      <default>0x05</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <writeable />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_NEST_PLL_BUCKET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
+  <attribute>
+    <id>PFET_POWERDOWN_DELAY_NS</id>
+    <description>Time (in nanoseconds) between PFET controller
+    steps (7 of them) when turning the PFES OFF Producer: MRWB
+    Consumers: p9_pm_pfet_init Platform default:</description>
+    <simpleType>
+      <uint32_t>
+        <!-- Will be set by HWP -->
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_PFET_POWERDOWN_DELAY_NS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PFET_VDD_VOFF_SEL</id>
+    <description>Selection of the OFF setting for the core and
+    cache chiplet VDD PFET controllers Producer: MRWB Consumers:
+    p9_pm_pfet_init Platform default:</description>
+    <simpleType>
+      <uint8_t>
+        <!-- Will be set by HWP -->
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_PFET_VDD_VOFF_SEL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>PFET_VDD_VOFF_SEL</id>
+    <description>Enumeration indicating the OFF setting for the
+    core and cache chiplet DD PFET controllers</description>
+    <enumerator>
+      <name>NOOFF</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT1TO7OFF</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT2TO7OFF</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT3TO7OFF</name>
+      <value>3</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT4TO7OFF</name>
+      <value>4</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT5TO7OFF</name>
+      <value>5</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT6TO7OFF</name>
+      <value>6</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT7TO7OFF</name>
+      <value>7</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLOFF</name>
+      <value>8</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>PFET_VCS_VOFF_SEL</id>
+    <description>Selection of the OFF setting for the core and
+    cache chiplet VCS PFET controllers Producer: MRWB Consumers:
+    p9_pm_pfet_init Platform default:</description>
+    <simpleType>
+      <uint8_t>
+        <!-- Will be set by HWP -->
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_PFET_VCS_VOFF_SEL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>PFET_VCS_VOFF_SEL</id>
+    <description>Enumeration indicating the OFF setting for the
+    core and cache chiplet VCS PFET controllers</description>
+    <enumerator>
+      <name>NOOFF</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT1TO7OFF</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT2TO7OFF</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT3TO7OFF</name>
+      <value>3</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT4TO7OFF</name>
+      <value>4</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT5TO7OFF</name>
+      <value>5</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT6TO7OFF</name>
+      <value>6</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLBUT7TO7OFF</name>
+      <value>7</value>
+    </enumerator>
+    <enumerator>
+      <name>ALLOFF</name>
+      <value>8</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>VCS_I2C_RAIL</id>
+    <description>Step delay (binary in microseconds) after a
+    voltage change Consumer: p9_build_pstate_datablock -&gt; Pstate
+    Parameter Block (PSPB) for PGPE Provided by the Machine
+    Readable Workbook after system characterization.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_VCS_I2C_RAIL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>FAPI_POS</id>
+    <description>Enumeration defining special FAPI_POS
+    values</description>
+    <enumerator>
+      <name>NA</name>
+      <value>0xFFFFFFFF</value>
+    </enumerator>
+    <default>NA</default>
+  </enumerationType>
+  <attribute>
+    <id>FAPI_POS</id>
+    <description>Logical position of target within a system. This
+    is derived from the SMP location of each processor and each
+    target's relationship to a proc. - PROC = based on SMP
+    groupid+chipid - MEMBUF = PROC:FAPI_POS * [max membuf per proc]
+    - 1st level child unit = [parent chip]:FAPI_POS * [max children
+    of this type per chip] - 2nd+ level child unit = [immediate
+    parent unit]:FAPI_POS * [max units below parent] Note: This
+    should not be used algorithmically by HWPs directly. Note:
+    Value ignores physical drawer boundaries, the value is unique
+    across the entire system. This data is derived from the MRW.
+    Default of NA is 0xFFFFFFFF (to avoid confusion with legitimate
+    0 values)</description>
+    <simpleType>
+      <uint32_t>
+        <default>0xFFFFFFFF</default>
+      </uint32_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_FAPI_POS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>I2C_BUS_DIV_REF</id>
+    <description>Ref clock I2C bus divider consumed by code running
+    out of OTPROM</description>
+    <simpleType>
+      <uint16_t>
+        <default>0x0003</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <writeable />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_I2C_BUS_DIV_REF</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>NEST_PLL_BUCKET</id>
+    <description>Select Nest I2C and pll setting from one of the
+    supported frequencies</description>
+    <simpleType>
+      <uint8_t>
+        <default>0x05</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <writeable />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_NEST_PLL_BUCKET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
      @todo: RTC:167266 set attributes from HWP nest PLL bucket data
      ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== -->
-<!-- ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
+  <!-- ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
      @todo: RTC:167266 set attributes from HWP nest PLL bucket data
      ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== -->
-<attribute>
-  <id>SBE_UPDATE_DISABLE</id>
-  <description>Control execution of updateProcessorSbeSeeproms() if
-  0, enable SBE update of processor SEEPROM if 1, disable SBE
-  update of processor SEEPROM Consumer: sbe_update.C Default:
-  0</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_SBE_UPDATE_DISABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<!-- Deprecated -->
-<!--SBE ONLY-->
-<!--Deprecated-->
-<!--Deprecated-->
-<!--Deprecated-->
-<!-- Deprecated -->
-<!-- Deprecated -->
-<!--Deprecated-->
-<!--Deprecated-->
-<!--Deprecated-->
-<attribute>
-  <id>BOOT_FREQ_MULT</id>
-  <description>EQ boot frequency multiplier</description>
-  <simpleType>
-    <uint16_t>
-      <default>150</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_BOOT_FREQ_MULT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!--Deprecated-->
-<!--Deprecated-->
-<!--SBE ONLY-->
-<!--Deprecated-->
-<!--Deprecated-->
-<!--SBE ONLY-->
-<!-- Deprecated -->
-<attribute>
-  <id>I2C_BUS_DIV_NEST</id>
-  <description>I2C Bus speed based on nest freq, ref
-  clock</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_I2C_BUS_DIV_NEST</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- Deprecated -->
-<!--SBE ONLY-->
-<!-- Deprecated -->
-<attribute>
-  <id>MB_BIT_RATE_DIVISOR_REFCLK</id>
-  <description>MB_BIT_RATE_DIVISOR_REFCLK</description>
-  <simpleType>
-    <uint8_t>
-      <default>133</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MB_BIT_RATE_DIVISOR_REFCLK</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!--SBE ONLY-->
-<!--SBE ONLY-->
-<!--SBE ONLY-->
-<!--SBE ONLY-->
-<!--SBE ONLY-->
-<!--SBE ONLY-->
-<!-- Deprecated -->
-<!-- Deprecated -->
-<!-- Deprecated -->
-<!-- Deprecated -->
-<!-- name changed in ekb, need to have both to push interim commits through -->
-<attribute>
-  <id>PROC_FABRIC_SYSTEM_ID</id>
-  <description>Logical fabric system ID associated with this chip.
-  Would only need to be a non-zero to support CCSM (coherent
-  cluster shared memory) system topologies Provided by the
-  MRW.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FABRIC_SYSTEM_ID</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>CLOCK_PLL_MUX</id>
-  <description>setup clock mux settings</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <writeable />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_CLOCK_PLL_MUX</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>CLOCK_PLL_MUX0</id>
-  <description>Clock Mux#0 settings</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_CLOCK_PLL_MUX0</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!--SBE ONLY-->
-<!--SBE ONLY-->
-<attribute>
-  <id>CHIPLET_ID</id>
-  <description>The address offset which each Chiplet types
-  pervasive address space used to represent the a chiplet. 0x00 to
-  0x0F =&gt; For P9 all non-core and non-cache chiplets 0x10 to
-  0x1F =&gt; All Cache Chiplets 0x20 to 0x37 =&gt; All Core
-  Chiplets 0x38 to 0x3F =&gt; Multicast Operation</description>
-  <simpleType>
-    <uint8_t>
-      <default>0xFF</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>SYSTEM_IPL_PHASE</id>
-  <description>Define context for current phase of system IPL.
-  Provided by the platform. HB_IPL = 0x1,HB_RUNTIME =
-  0x2,CACHE_CONTAINED = 0x4</description>
-  <simpleType>
-    <uint8_t>
-      <default>0x01</default>
-    </uint8_t>
-  </simpleType>
-  <hwpfToHbAttrMap>
-    <id>ATTR_SYSTEM_IPL_PHASE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>PARENT_PERVASIVE</id>
-  <description>Physical entity path of the target's associated
-  pervasive target</description>
-  <nativeType>
-    <name>EntityPath</name>
-  </nativeType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <virtual />
-</attribute>
-<!-- ********************************************************************** -->
-<enumerationType>
-  <id>PROC_FABRIC_A_BUS_WIDTH</id>
-  <description>Enumeration indicating the
-  PROC_FABRIC_A_BUS_WIDTH</description>
-  <!--  Note: Values must match numbers from nest_attributes.xml -->
-  <enumerator>
-    <name>2_BYTE</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>4_BYTE</name>
-    <value>2</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>PROC_FABRIC_A_BUS_WIDTH</id>
-  <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-  <description>Processor SMP A bus width. Provided by the MRW.
-  2_BYTE = 0x01, 4_BYTE = 0x02</description>
-  <simpleType>
-    <uint8_t>
-      <default>4_BYTE</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FABRIC_A_BUS_WIDTH</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>PROC_FABRIC_X_BUS_WIDTH</id>
-  <description>Enumeration indicating the
-  PROC_FABRIC_X_BUS_WIDTH</description>
-  <!--  Note: Values must match numbers from nest_attributes.xml -->
-  <enumerator>
-    <name>2_BYTE</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>4_BYTE</name>
-    <value>2</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>PROC_FABRIC_X_BUS_WIDTH</id>
-  <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-  <description>Processor SMP X bus width. Provided by the MRW.
-  2_BYTE = 0x01, 4_BYTE = 0x02</description>
-  <simpleType>
-    <uint8_t>
-      <default>4_BYTE</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FABRIC_X_BUS_WIDTH</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_FABRIC_CCSM_MODE</id>
-  <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-  <description>Processor SMP topology configuration. 0 = default =
-  1 or 2 hop topology (PHYP image spans system) Provided by the
-  MRW. OFF = 0x0 (default)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FABRIC_CCSM_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>OPTICS_CONFIG_MODE</id>
-  <!-- <targetType>TARGET_TYPE_OBUS</targetType> -->
-  <description>Per-link optics configuration 0 = SMP (default) 1 =
-  CAPI 2.0 2 = NV 2.0 Provided by the MRW.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_OPTICS_CONFIG_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>PROC_FABRIC_SMP_OPTICS_MODE</id>
-  <description>Enumeration indicating the
-  PROC_FABRIC_SMP_OPTICS_MODE</description>
-  <!--  Note: Values must match numbers from nest_attributes.xml -->
-  <enumerator>
-    <name>OPTICS_IS_X_BUS</name>
-    <value>0x0</value>
-  </enumerator>
-  <enumerator>
-    <name>OPTICS_IS_A_BUS</name>
-    <value>0x1</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>PROC_FABRIC_SMP_OPTICS_MODE</id>
-  <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-  <description>Processor SMP optics mode. 0 = Optics_is_X_bus
-  (default) 1 = Optics_is_A_bus Provided by the MRW.
-  OPTICS_IS_X_BUS = 0x0, OPTICS_IS_A_BUS = 0x1</description>
-  <simpleType>
-    <uint8_t>
-      <default>OPTICS_IS_X_BUS</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FABRIC_SMP_OPTICS_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>PROC_FABRIC_CAPI_MODE</id>
-  <description>Enumeration indicating the
-  PROC_FABRIC_CAPI_MODE</description>
-  <!--  Note: Values must match numbers from nest_attributes.xml -->
-  <enumerator>
-    <name>OFF</name>
-    <value>0x0</value>
-  </enumerator>
-  <enumerator>
-    <name>ON</name>
-    <value>0x1</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>PROC_FABRIC_CAPI_MODE</id>
-  <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-  <description>Processor CAPI attachment protocol mode. 0 = no:
-  SMPA CAPI attachment (default) 1 = yes: SMPA CAPI attachment
-  Provided by the MRW.</description>
-  <simpleType>
-    <uint8_t>
-      <default>OFF</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FABRIC_CAPI_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_BAR_ENABLE</id>
-  <!-- TARGET_TYPE_PHB -->
-  <description>PCIE MMIO BAR enable creator: platform consumer:
-  p9_pcie_config firmware notes: Array index: BAR number (0:2)
-  index 0~1 for MMIO BAR0/1 index 2 for PHB register space DISABLE
-  = 0x0, ENABLE = 0x1</description>
-  <simpleType>
-    <uint8_t />
-    <array>3</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_BAR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_BAR_BASE_ADDR</id>
-  <!-- TARGET_TYPE_PHB -->
-  <description>PCIE MMIO BAR base address value creator: platform
-  consumer: p9_setup_bars firmware notes: 64-bit address
-  representing BAR RA Array index: BAR number (0:2) NOTE: BAR0/1
-  registers cover RA 8:47 NOTE: BAR2 registers covers RA 8:49 index
-  0~1 for BAR0/1 index 2 for PHB index 3 for
-  interrupt</description>
-  <simpleType>
-    <uint64_t />
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_BAR_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_BAR_SIZE</id>
-  <!-- TARGET_TYPE_PHB -->
-  <description>PCIE MMIO BAR size values creator: platform
-  consumer: p9_pcie_config firmware notes: Array index: BAR number
-  (0:2) NOTE: supported MMIO BAR0/1 sizes are from 64KB-32PB NOTE:
-  only supported PHB register size is 16KB 32_PB =
-  0x8000000000000000, 16_PB = 0xC000000000000000, 8_PB =
-  0xE000000000000000, 4_PB = 0xF000000000000000, 2_PB =
-  0xF800000000000000, 1_PB = 0xFC00000000000000, 512_TB =
-  0xFE00000000000000, 256_TB = 0xFF00000000000000, 128_TB =
-  0xFF80000000000000, 64_TB = 0xFFC0000000000000, 32_TB =
-  0xFFE0000000000000, 16_TB = 0xFFF0000000000000, 8_TB =
-  0xFFF8000000000000, 4_TB = 0xFFFC000000000000, 2_TB =
-  0xFFFE000000000000, 1_TB = 0xFFFF000000000000, 512_GB =
-  0xFFFF800000000000, 256_GB = 0xFFFFC00000000000, 128_GB =
-  0xFFFFE00000000000, 64_GB = 0xFFFFF00000000000, 32_GB =
-  0xFFFFF80000000000, 16_GB = 0xFFFFFC0000000000, 8_GB =
-  0xFFFFFE0000000000, 4_GB = 0xFFFFFF0000000000, 2_GB =
-  0xFFFFFF8000000000, 1_GB = 0xFFFFFFC000000000, 512_MB =
-  0xFFFFFFE000000000, 256_MB = 0xFFFFFFF000000000, 128_MB =
-  0xFFFFFFF800000000, 64_MB = 0xFFFFFFFC00000000, 32_MB =
-  0xFFFFFFFE00000000, 16_MB = 0xFFFFFFFF00000000, 8_MB =
-  0xFFFFFFFF80000000, 4_MB = 0xFFFFFFFFC0000000, 2_MB =
-  0xFFFFFFFFE0000000, 1_MB = 0xFFFFFFFFF0000000, 512_KB =
-  0xFFFFFFFFF8000000, 256_KB = 0xFFFFFFFFFC000000, 128_KB =
-  0xFFFFFFFFFE000000, 64_KB = 0xFFFFFFFFFF000000, 16_KB =
-  0xFFFFFFFFFFFFFFFF</description>
-  <simpleType>
-    <uint64_t />
-    <array>3</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_BAR_SIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_HOTPLUG_I2C_DEVICE_ADDRESS</id>
-  <!-- TARGET_TYPE_PROC_CHIP -->
-  <description>I2C device address for PCIE hotplug controller
-  creator: platform consumer: p9_pcie_hotplug</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_HOTPLUG_I2C_DEVICE_ADDRESS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_HOTPLUG_ENABLE_ACTIONS</id>
-  <!-- TARGET_TYPE_PROC_CHIP -->
-  <description>Sequence of PCIE hotplug controller register writes
-  required to enable slot power creator: platform consumer:
-  p9_pcie_hotplug firmware notes: Primary array index: Sequence
-  number Secondary array index: Address (0) / Data
-  (1)</description>
-  <simpleType>
-    <uint8_t />
-    <array>8,2</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_HOTPLUG_ENABLE_ACTIONS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_HOTPLUG_NUM_ENABLE_ACTIONS</id>
-  <!-- TARGET_TYPE_PROC_CHIP -->
-  <description>Number of valid entries in primary index of
-  ATTR_PROC_PCIE_HOTPLUG_ENABLE_ACTIONS creator: platform consumer:
-  p9_pcie_hotplug ZERO = 0x0, ONE = 0x1, TWO = 0x2, THREE = 0x3,
-  FOUR = 0x4, FIVE = 0x5, SIX = 0x6, SEVEN = 0x7, EIGHT =
-  0x8</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_HOTPLUG_NUM_ENABLE_ACTIONS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_HOTPLUG_DISABLE_ACTIONS</id>
-  <!-- TARGET_TYPE_PROC_CHIP -->
-  <description>Sequence of PCIE hotplug controller register writes
-  required to disable slot power creator: platform consumer:
-  p9_pcie_hotplug firmware notes: Primary array index: Sequence
-  number Secondary array index: Address (0) / Data
-  (1)</description>
-  <simpleType>
-    <uint8_t />
-    <array>8,2</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_HOTPLUG_DISABLE_ACTIONS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_HOTPLUG_NUM_DISABLE_ACTIONS</id>
-  <!-- TARGET_TYPE_PROC_CHIP -->
-  <description>Number of valid entries in primary index of
-  ATTR_PROC_PCIE_HOTPLUG_DISABLE_ACTIONS creator: platform
-  consumer: p9_pcie_hotplug ZERO = 0x0, ONE = 0x1, TWO = 0x2, THREE
-  = 0x3, FOUR = 0x4, FIVE = 0x5, SIX = 0x6, SEVEN = 0x7, EIGHT =
-  0x8</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_HOTPLUG_NUM_DISABLE_ACTIONS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>PCS rx cdr gains creator: platform consumer:
-  p9_pcie_scominit firmware notes: The value of rx cdr gains for
-  PCS. Array index: Configuration number index 0~3 for
-  CONFIG0~3</description>
-  <simpleType>
-    <uint8_t />
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_CDR_GAIN</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_PK_INIT</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>PCS rx vga peak init value creator: platform
-  consumer: p9_pcie_scominit firmware notes: The value of rx vga
-  peak init for PCS. Array index: Configuration number index 0~3
-  for CONFIG0~3 lane 0~15 for each PCIE Lane</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-    <array>4,16</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_PK_INIT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_INIT_GAIN</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>PCS rx vga gain init value creator: platform
-  consumer: p9_pcie_scominit firmware notes: The value of rx vga
-  gain init for PCS. Array index: Configuration number index 0~3
-  for CONFIG0~3 lane 0~15 for each PCIE Lane</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-    <array>4,16</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_INIT_GAIN</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_SIGDET_LVL</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>PCS rx sigdet lvl value creator: platform consumer:
-  p9_pcie_scominit firmware notes: The value of rx sigdet lvl for
-  PCS. Array index: Configuration number index 0~3 for
-  CONFIG0~3</description>
-  <simpleType>
-    <uint8_t>
-      <default>0x0B</default>
-    </uint8_t>
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_SIGDET_LVL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_ROT_RST_FW</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS RX ROT rstfw latch creator: platform
-  consumer: p9_pcie_scominit firmware notes: 0 normal, flywheel is
-  enabled (default) 1 assert reset to the phase rotator flywheel
-  (disable the flywheel)</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_ROT_RST_FW</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>PCS rx loff control creator: platform consumer:
-  p9_pcie_scominit firmware notes: The value of rx loff control for
-  PCS. Array index: Configuration number index 0~3 for
-  CONFIG0~3</description>
-  <simpleType>
-    <uint16_t />
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>PCS rx vga control register3 creator: platform
-  consumer: p9_pcie_scominit firmware notes: The value of rx vga
-  control register3. Array index: Configuration number index 0~3
-  for CONFIG0~3</description>
-  <simpleType>
-    <uint16_t />
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS RX ROT CNTL CDR lookahead creator:
-  platform consumer: p9_pcie_scominit firmware notes: 0 for
-  disable, 1 for enable</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS RX ROT CNTL CDR ssc creator: platform
-  consumer: p9_pcie_scominit firmware notes: 0 for disable, 1 for
-  enable</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS pclck control plla creator: platform
-  consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS pclck control pllb creator: platform
-  consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS tx dclck rotator override creator:
-  platform consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint16_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_TX_DCLCK_ROT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS tx fifo config offset creator: platform
-  consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS tx pcie receiver detect control
-  register 1 creator: platform consumer:
-  p9_pcie_scominit</description>
-  <simpleType>
-    <uint16_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS tx pcie receiver detect control
-  register 2 creator: platform consumer:
-  p9_pcie_scominit</description>
-  <simpleType>
-    <uint16_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS tx power sequence enable creator:
-  platform consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS rx phase rotator control creator:
-  platform consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint16_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS rx vga control register 1 creator:
-  platform consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint16_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS rx vga control register 2 creator:
-  platform consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint16_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS rx sigdet control creator: platform
-  consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint16_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS system control creator: platform
-  consumer: p9_pcie_scominit</description>
-  <simpleType>
-    <uint16_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_SYSTEM_CNTL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_PCS_M_CNTL</id>
-  <!-- TARGET_TYPE_PEC -->
-  <description>Value of PCS m1-m4 control creator: platform
-  consumer: p9_pcie_scominit Array index: 0 -&gt; M1 1 -&gt; M2 2
-  -&gt; M3 3 -&gt; M4</description>
-  <simpleType>
-    <uint16_t />
-    <array>4</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_PCS_M_CNTL</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- TODO: RTC 145692
+  <attribute>
+    <id>SBE_UPDATE_DISABLE</id>
+    <description>Control execution of updateProcessorSbeSeeproms()
+    if 0, enable SBE update of processor SEEPROM if 1, disable SBE
+    update of processor SEEPROM Consumer: sbe_update.C Default:
+    0</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_SBE_UPDATE_DISABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <!-- Deprecated -->
+  <!--SBE ONLY-->
+  <!--Deprecated-->
+  <!--Deprecated-->
+  <!--Deprecated-->
+  <!-- Deprecated -->
+  <!-- Deprecated -->
+  <!--Deprecated-->
+  <!--Deprecated-->
+  <!--Deprecated-->
+  <attribute>
+    <id>BOOT_FREQ_MULT</id>
+    <description>EQ boot frequency multiplier</description>
+    <simpleType>
+      <uint16_t>
+        <default>150</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_BOOT_FREQ_MULT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!--Deprecated-->
+  <!--Deprecated-->
+  <!--SBE ONLY-->
+  <!--Deprecated-->
+  <!--Deprecated-->
+  <!--SBE ONLY-->
+  <!-- Deprecated -->
+  <attribute>
+    <id>I2C_BUS_DIV_NEST</id>
+    <description>I2C Bus speed based on nest freq, ref
+    clock</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_I2C_BUS_DIV_NEST</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- Deprecated -->
+  <!--SBE ONLY-->
+  <!-- Deprecated -->
+  <attribute>
+    <id>MB_BIT_RATE_DIVISOR_REFCLK</id>
+    <description>MB_BIT_RATE_DIVISOR_REFCLK</description>
+    <simpleType>
+      <uint8_t>
+        <default>133</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MB_BIT_RATE_DIVISOR_REFCLK</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!--SBE ONLY-->
+  <!--SBE ONLY-->
+  <!--SBE ONLY-->
+  <!--SBE ONLY-->
+  <!--SBE ONLY-->
+  <!--SBE ONLY-->
+  <!-- Deprecated -->
+  <!-- Deprecated -->
+  <!-- Deprecated -->
+  <!-- Deprecated -->
+  <!-- name changed in ekb, need to have both to push interim commits through -->
+  <attribute>
+    <id>PROC_FABRIC_SYSTEM_ID</id>
+    <description>Logical fabric system ID associated with this
+    chip. Would only need to be a non-zero to support CCSM
+    (coherent cluster shared memory) system topologies Provided by
+    the MRW.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FABRIC_SYSTEM_ID</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>CLOCK_PLL_MUX</id>
+    <description>setup clock mux settings</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <writeable />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_CLOCK_PLL_MUX</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>CLOCK_PLL_MUX0</id>
+    <description>Clock Mux#0 settings</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_CLOCK_PLL_MUX0</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!--SBE ONLY-->
+  <!--SBE ONLY-->
+  <attribute>
+    <id>CHIPLET_ID</id>
+    <description>The address offset which each Chiplet types
+    pervasive address space used to represent the a chiplet. 0x00
+    to 0x0F =&gt; For P9 all non-core and non-cache chiplets 0x10
+    to 0x1F =&gt; All Cache Chiplets 0x20 to 0x37 =&gt; All Core
+    Chiplets 0x38 to 0x3F =&gt; Multicast Operation</description>
+    <simpleType>
+      <uint8_t>
+        <default>0xFF</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>SYSTEM_IPL_PHASE</id>
+    <description>Define context for current phase of system IPL.
+    Provided by the platform. HB_IPL = 0x1,HB_RUNTIME =
+    0x2,CACHE_CONTAINED = 0x4</description>
+    <simpleType>
+      <uint8_t>
+        <default>0x01</default>
+      </uint8_t>
+    </simpleType>
+    <hwpfToHbAttrMap>
+      <id>ATTR_SYSTEM_IPL_PHASE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>PARENT_PERVASIVE</id>
+    <description>Physical entity path of the target's associated
+    pervasive target</description>
+    <nativeType>
+      <name>EntityPath</name>
+    </nativeType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <virtual />
+  </attribute>
+  <!-- ********************************************************************** -->
+  <enumerationType>
+    <id>PROC_FABRIC_A_BUS_WIDTH</id>
+    <description>Enumeration indicating the
+    PROC_FABRIC_A_BUS_WIDTH</description>
+    <!--  Note: Values must match numbers from nest_attributes.xml -->
+    <enumerator>
+      <name>2_BYTE</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>4_BYTE</name>
+      <value>2</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>PROC_FABRIC_A_BUS_WIDTH</id>
+    <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
+    <description>Processor SMP A bus width. Provided by the MRW.
+    2_BYTE = 0x01, 4_BYTE = 0x02</description>
+    <simpleType>
+      <uint8_t>
+        <default>4_BYTE</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FABRIC_A_BUS_WIDTH</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>PROC_FABRIC_X_BUS_WIDTH</id>
+    <description>Enumeration indicating the
+    PROC_FABRIC_X_BUS_WIDTH</description>
+    <!--  Note: Values must match numbers from nest_attributes.xml -->
+    <enumerator>
+      <name>2_BYTE</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>4_BYTE</name>
+      <value>2</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>PROC_FABRIC_X_BUS_WIDTH</id>
+    <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
+    <description>Processor SMP X bus width. Provided by the MRW.
+    2_BYTE = 0x01, 4_BYTE = 0x02</description>
+    <simpleType>
+      <uint8_t>
+        <default>4_BYTE</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FABRIC_X_BUS_WIDTH</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_FABRIC_CCSM_MODE</id>
+    <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
+    <description>Processor SMP topology configuration. 0 = default
+    = 1 or 2 hop topology (PHYP image spans system) Provided by the
+    MRW. OFF = 0x0 (default)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FABRIC_CCSM_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>OPTICS_CONFIG_MODE</id>
+    <description>Enumeration indicating the
+    OPTICS_CONFIG_MODE</description>
+    <enumerator>
+      <name>SMP</name>
+      <value>0x0</value>
+    </enumerator>
+    <enumerator>
+      <name>CAPILINK</name>
+      <value>0x1</value>
+    </enumerator>
+    <enumerator>
+      <name>NVLINK</name>
+      <value>0x2</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>OPTICS_CONFIG_MODE</id>
+    <description>Per-link optics configuration 0 = SMP (default) 1
+    = CAPI 2.0 2 = NV 2.0 Provided by the MRW.</description>
+    <simpleType>
+      <uint8_t>
+        <default>SMP</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_OPTICS_CONFIG_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>OBUS_BRICK_LANE_MASK</id>
+    <description>Lane mask for which 8 lanes belong to this brick
+    This is a right justified 24-bit value. Only 8 of the 24 bits
+    will be set representing the lanes belonging to the associated
+    brick. Provided by the MRW.</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_OBUS_BRICK_LANE_MASK</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>PROC_FABRIC_SMP_OPTICS_MODE</id>
+    <description>Enumeration indicating the
+    PROC_FABRIC_SMP_OPTICS_MODE</description>
+    <!--  Note: Values must match numbers from nest_attributes.xml -->
+    <enumerator>
+      <name>OPTICS_IS_X_BUS</name>
+      <value>0x0</value>
+    </enumerator>
+    <enumerator>
+      <name>OPTICS_IS_A_BUS</name>
+      <value>0x1</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>PROC_FABRIC_SMP_OPTICS_MODE</id>
+    <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
+    <description>Processor SMP optics mode. 0 = Optics_is_X_bus
+    (default) 1 = Optics_is_A_bus Provided by the MRW.
+    OPTICS_IS_X_BUS = 0x0, OPTICS_IS_A_BUS = 0x1</description>
+    <simpleType>
+      <uint8_t>
+        <default>OPTICS_IS_X_BUS</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FABRIC_SMP_OPTICS_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>PROC_FABRIC_CAPI_MODE</id>
+    <description>Enumeration indicating the
+    PROC_FABRIC_CAPI_MODE</description>
+    <!--  Note: Values must match numbers from nest_attributes.xml -->
+    <enumerator>
+      <name>OFF</name>
+      <value>0x0</value>
+    </enumerator>
+    <enumerator>
+      <name>ON</name>
+      <value>0x1</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>PROC_FABRIC_CAPI_MODE</id>
+    <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
+    <description>Processor CAPI attachment protocol mode. 0 = no:
+    SMPA CAPI attachment (default) 1 = yes: SMPA CAPI attachment
+    Provided by the MRW.</description>
+    <simpleType>
+      <uint8_t>
+        <default>OFF</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FABRIC_CAPI_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_ENABLE</id>
+    <!-- TARGET_TYPE_PHB -->
+    <description>PCIE MMIO BAR enable creator: platform consumer:
+    p9_pcie_config firmware notes: Array index: BAR number (0:2)
+    index 0~1 for MMIO BAR0/1 index 2 for PHB register space
+    DISABLE = 0x0, ENABLE = 0x1</description>
+    <simpleType>
+      <uint8_t />
+      <array>3</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_BAR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_BASE_ADDR</id>
+    <!-- TARGET_TYPE_PHB -->
+    <description>PCIE MMIO BAR base address value creator: platform
+    consumer: p9_setup_bars firmware notes: 64-bit address
+    representing BAR RA Array index: BAR number (0:2) NOTE: BAR0/1
+    registers cover RA 8:47 NOTE: BAR2 registers covers RA 8:49
+    index 0~1 for BAR0/1 index 2 for PHB index 3 for
+    interrupt</description>
+    <simpleType>
+      <uint64_t />
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_BAR_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_BAR_SIZE</id>
+    <!-- TARGET_TYPE_PHB -->
+    <description>PCIE MMIO BAR size values creator: platform
+    consumer: p9_pcie_config firmware notes: Array index: BAR
+    number (0:2) NOTE: supported MMIO BAR0/1 sizes are from
+    64KB-32PB NOTE: only supported PHB register size is 16KB 32_PB
+    = 0x8000000000000000, 16_PB = 0xC000000000000000, 8_PB =
+    0xE000000000000000, 4_PB = 0xF000000000000000, 2_PB =
+    0xF800000000000000, 1_PB = 0xFC00000000000000, 512_TB =
+    0xFE00000000000000, 256_TB = 0xFF00000000000000, 128_TB =
+    0xFF80000000000000, 64_TB = 0xFFC0000000000000, 32_TB =
+    0xFFE0000000000000, 16_TB = 0xFFF0000000000000, 8_TB =
+    0xFFF8000000000000, 4_TB = 0xFFFC000000000000, 2_TB =
+    0xFFFE000000000000, 1_TB = 0xFFFF000000000000, 512_GB =
+    0xFFFF800000000000, 256_GB = 0xFFFFC00000000000, 128_GB =
+    0xFFFFE00000000000, 64_GB = 0xFFFFF00000000000, 32_GB =
+    0xFFFFF80000000000, 16_GB = 0xFFFFFC0000000000, 8_GB =
+    0xFFFFFE0000000000, 4_GB = 0xFFFFFF0000000000, 2_GB =
+    0xFFFFFF8000000000, 1_GB = 0xFFFFFFC000000000, 512_MB =
+    0xFFFFFFE000000000, 256_MB = 0xFFFFFFF000000000, 128_MB =
+    0xFFFFFFF800000000, 64_MB = 0xFFFFFFFC00000000, 32_MB =
+    0xFFFFFFFE00000000, 16_MB = 0xFFFFFFFF00000000, 8_MB =
+    0xFFFFFFFF80000000, 4_MB = 0xFFFFFFFFC0000000, 2_MB =
+    0xFFFFFFFFE0000000, 1_MB = 0xFFFFFFFFF0000000, 512_KB =
+    0xFFFFFFFFF8000000, 256_KB = 0xFFFFFFFFFC000000, 128_KB =
+    0xFFFFFFFFFE000000, 64_KB = 0xFFFFFFFFFF000000, 16_KB =
+    0xFFFFFFFFFFFFFFFF</description>
+    <simpleType>
+      <uint64_t />
+      <array>3</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_BAR_SIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_HOTPLUG_I2C_DEVICE_ADDRESS</id>
+    <!-- TARGET_TYPE_PROC_CHIP -->
+    <description>I2C device address for PCIE hotplug controller
+    creator: platform consumer: p9_pcie_hotplug</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_HOTPLUG_I2C_DEVICE_ADDRESS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_HOTPLUG_ENABLE_ACTIONS</id>
+    <!-- TARGET_TYPE_PROC_CHIP -->
+    <description>Sequence of PCIE hotplug controller register
+    writes required to enable slot power creator: platform
+    consumer: p9_pcie_hotplug firmware notes: Primary array index:
+    Sequence number Secondary array index: Address (0) / Data
+    (1)</description>
+    <simpleType>
+      <uint8_t />
+      <array>8,2</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_HOTPLUG_ENABLE_ACTIONS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_HOTPLUG_NUM_ENABLE_ACTIONS</id>
+    <!-- TARGET_TYPE_PROC_CHIP -->
+    <description>Number of valid entries in primary index of
+    ATTR_PROC_PCIE_HOTPLUG_ENABLE_ACTIONS creator: platform
+    consumer: p9_pcie_hotplug ZERO = 0x0, ONE = 0x1, TWO = 0x2,
+    THREE = 0x3, FOUR = 0x4, FIVE = 0x5, SIX = 0x6, SEVEN = 0x7,
+    EIGHT = 0x8</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_HOTPLUG_NUM_ENABLE_ACTIONS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_HOTPLUG_DISABLE_ACTIONS</id>
+    <!-- TARGET_TYPE_PROC_CHIP -->
+    <description>Sequence of PCIE hotplug controller register
+    writes required to disable slot power creator: platform
+    consumer: p9_pcie_hotplug firmware notes: Primary array index:
+    Sequence number Secondary array index: Address (0) / Data
+    (1)</description>
+    <simpleType>
+      <uint8_t />
+      <array>8,2</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_HOTPLUG_DISABLE_ACTIONS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_HOTPLUG_NUM_DISABLE_ACTIONS</id>
+    <!-- TARGET_TYPE_PROC_CHIP -->
+    <description>Number of valid entries in primary index of
+    ATTR_PROC_PCIE_HOTPLUG_DISABLE_ACTIONS creator: platform
+    consumer: p9_pcie_hotplug ZERO = 0x0, ONE = 0x1, TWO = 0x2,
+    THREE = 0x3, FOUR = 0x4, FIVE = 0x5, SIX = 0x6, SEVEN = 0x7,
+    EIGHT = 0x8</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_HOTPLUG_NUM_DISABLE_ACTIONS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>PCS rx cdr gains creator: platform consumer:
+    p9_pcie_scominit firmware notes: The value of rx cdr gains for
+    PCS. Array index: Configuration number index 0~3 for
+    CONFIG0~3</description>
+    <simpleType>
+      <uint8_t />
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_CDR_GAIN</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_PK_INIT</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>PCS rx vga peak init value creator: platform
+    consumer: p9_pcie_scominit firmware notes: The value of rx vga
+    peak init for PCS. Array index: Configuration number index 0~3
+    for CONFIG0~3 lane 0~15 for each PCIE Lane</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+      <array>4,16</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_PK_INIT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_INIT_GAIN</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>PCS rx vga gain init value creator: platform
+    consumer: p9_pcie_scominit firmware notes: The value of rx vga
+    gain init for PCS. Array index: Configuration number index 0~3
+    for CONFIG0~3 lane 0~15 for each PCIE Lane</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+      <array>4,16</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_INIT_GAIN</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_SIGDET_LVL</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>PCS rx sigdet lvl value creator: platform
+    consumer: p9_pcie_scominit firmware notes: The value of rx
+    sigdet lvl for PCS. Array index: Configuration number index 0~3
+    for CONFIG0~3</description>
+    <simpleType>
+      <uint8_t>
+        <default>0x0B</default>
+      </uint8_t>
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_SIGDET_LVL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_RST_FW</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS RX ROT rstfw latch creator: platform
+    consumer: p9_pcie_scominit firmware notes: 0 normal, flywheel
+    is enabled (default) 1 assert reset to the phase rotator
+    flywheel (disable the flywheel)</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_ROT_RST_FW</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>PCS rx loff control creator: platform consumer:
+    p9_pcie_scominit firmware notes: The value of rx loff control
+    for PCS. Array index: Configuration number index 0~3 for
+    CONFIG0~3</description>
+    <simpleType>
+      <uint16_t />
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>PCS rx vga control register3 creator: platform
+    consumer: p9_pcie_scominit firmware notes: The value of rx vga
+    control register3. Array index: Configuration number index 0~3
+    for CONFIG0~3</description>
+    <simpleType>
+      <uint16_t />
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS RX ROT CNTL CDR lookahead creator:
+    platform consumer: p9_pcie_scominit firmware notes: 0 for
+    disable, 1 for enable</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS RX ROT CNTL CDR ssc creator: platform
+    consumer: p9_pcie_scominit firmware notes: 0 for disable, 1 for
+    enable</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS pclck control plla creator: platform
+    consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS pclck control pllb creator: platform
+    consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS tx dclck rotator override creator:
+    platform consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint16_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_TX_DCLCK_ROT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS tx fifo config offset creator:
+    platform consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS tx pcie receiver detect control
+    register 1 creator: platform consumer:
+    p9_pcie_scominit</description>
+    <simpleType>
+      <uint16_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS tx pcie receiver detect control
+    register 2 creator: platform consumer:
+    p9_pcie_scominit</description>
+    <simpleType>
+      <uint16_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS tx power sequence enable creator:
+    platform consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS rx phase rotator control creator:
+    platform consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint16_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS rx vga control register 1 creator:
+    platform consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint16_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS rx vga control register 2 creator:
+    platform consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint16_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS rx sigdet control creator: platform
+    consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint16_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS system control creator: platform
+    consumer: p9_pcie_scominit</description>
+    <simpleType>
+      <uint16_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_SYSTEM_CNTL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_PCS_M_CNTL</id>
+    <!-- TARGET_TYPE_PEC -->
+    <description>Value of PCS m1-m4 control creator: platform
+    consumer: p9_pcie_scominit Array index: 0 -&gt; M1 1 -&gt; M2 2
+    -&gt; M3 3 -&gt; M4</description>
+    <simpleType>
+      <uint16_t />
+      <array>4</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_PCS_M_CNTL</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- TODO: RTC 145692
      Temporary attributes used for p9_mss_eff_grouping test cases
      These attributes need to be removed and test cases need to use
      (TBD) attributes that specify the DIMM sizes used to calculate the
      result of getDimmSize() function called in p9_mss_eff_grouping -->
-<attribute>
-  <id>PROC_PCIE_IOP_SWAP</id>
-  <description>PCIE IOP swap configuration creator: platform
-  consumer: p9_pcie_scominit firmware notes: Encoded PCIE IOP swap
-  configuration</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_IOP_SWAP</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IO_XBUS_TX_MARGIN_RATIO</id>
-  <!-- <targetType>TARGET_TYPE_XBUS</targetType> -->
-  <description>Value to select amount of margin to be
-  applied.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_IO_XBUS_TX_MARGIN_RATIO</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IO_XBUS_TX_FFE_PRECURSOR</id>
-  <!-- <targetType>TARGET_TYPE_XBUS</targetType> -->
-  <description>Value to select amount of tx ffe precusor to
-  apply.</description>
-  <simpleType>
-    <uint8_t>
-      <default>6</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_IO_XBUS_TX_FFE_PRECURSOR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
-  <description>Machine Readable Workbook safe mode throttle value
-  for numerator cfg_nm_n_per_port Set to below optimum value/ rate.
-  On a per port (MCA) basis Consumer: thermal_init</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>
-    ATTR_MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
-  <description>Machine Readable Workbook safe mode throttle value
-  for numerator cfg_nm_n_per_slot</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>
-    ATTR_MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_MEM_M_DRAM_CLOCKS</id>
-  <description>Machine Readable Workbook for the number of M DRAM
-  clocks. One approach to curbing DRAM power usage is by throttling
-  traffic through a programmable N commands over M
-  window.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x00000200</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_MEM_M_DRAM_CLOCKS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_AVDD_OFFSET_DISABLE</id>
-  <description>Used for to determine whether to apply an offset to
-  AVDD. Supplied by MRW.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_AVDD_OFFSET_DISABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_VDD_OFFSET_DISABLE</id>
-  <description>Used for to determine whether to apply an offset to
-  VDD. Supplied by MRW</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_VDD_OFFSET_DISABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_VCS_OFFSET_DISABLE</id>
-  <description>Used for to determine whether to apply an offset to
-  VCS. Supplied by MRW.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_VCS_OFFSET_DISABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_VPP_OFFSET_DISABLE</id>
-  <description>Used for to determine whether to apply an offset to
-  VPP. Supplied by MRW.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_VPP_OFFSET_DISABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_VDDR_OFFSET_DISABLE</id>
-  <description>Used for to determine whether to apply an offset to
-  VDDR. Supplied by MRW.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_VDDR_OFFSET_DISABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_FINE_REFRESH_MODE</id>
-  <description>Fine refresh mode. Should be defaulted to normal
-  mode. This is for DDR4 MRS3.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_FINE_REFRESH_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_TEMP_REFRESH_RANGE</id>
-  <description>Temp ref range. Should be defaulted to extended
-  range. This is for DDR4 MRS4. Should be defaulted to extended
-  range. NORMAL for running at 85 degrees C or less, EXTENDED for
-  95 or less degrees C Used for calculating periodic refresh
-  intervals JEDEC DDR4 spec 1716.78C from 07-2016 page 46
-  4.8.1</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_TEMP_REFRESH_RANGE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!--Deprecated-->
-<!--Deprecated-->
-<attribute>
-  <id>MSS_MRW_PERIODIC_MEMCAL_MODE_OPTIONS</id>
-  <description>Describes the settings for periodic calibration for
-  all ports: Reading left to right</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_PERIODIC_MEMCAL_MODE_OPTIONS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_PERIODIC_ZQCAL_MODE_OPTIONS</id>
-  <description>Describes the settings for periodic ZQ calibration
-  for all ports: Reading left to right. For each bit: OFF = 0, ON =
-  1. Setting to 0 indicates to disable periodic zqcal. Byte 0: 0:
-  ZQCAL All others reserved for future use</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_PERIODIC_ZQCAL_MODE_OPTIONS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_DRAMINIT_RESET_DISABLE</id>
-  <description>A disable switch for resetting the phy delay values
-  at the beginning of calling mss_draminit_training.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MRW_DRAMINIT_RESET_DISABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>SECURITY_ENABLE</id>
-  <description>Holds the state of Security Access Bit
-  (SAB)</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <writeable />
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_SECURITY_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_PREFETCH_ENABLE</id>
-  <description>0 = OFF 1 = ON Value of on or off. Determines if
-  prefetching enabled or not. See chapter 7 of the Centaur
-  Workbook.</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_PREFETCH_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_CLEANER_ENABLE</id>
-  <description>Value of on or off. Determines if the cleaner of the
-  L4 cache (write modified entries to memory on idle cycles)
-  enabled or not. See chapter 7 of the Centaur
-  Workbook.</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_CLEANER_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!--SBE ONLY-->
-<!--SBE ONLY-->
-<!--SBE ONLY-->
-<attribute>
-  <id>SUPPORTS_DYNAMIC_MEM_VOLT</id>
-  <description>Do we support dynamically updating memory voltages?
-  0 = no, 1 = yes</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>LPC_BASE_ADDR</id>
-  <description>Defines LPC base address on each processor
-  level.</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_LPC_BASE_ADDR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_FSP_BAR_ENABLE</id>
-  <description>FSP BAR enable DISABLE = 0x0, ENABLE =
-  0x1</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FSP_BAR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PSI_BRIDGE_BAR_ENABLE</id>
-  <description>PSI Bridge BAR enable DISABLE = 0x0, ENABLE =
-  0x1</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PSI_BRIDGE_BAR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>VDM_ENABLE</id>
-  <description>Controls the enablement of Voltage Droop Monitors
-  (VDM) in the system. OFF = 0x00, ON = 0x01 Producer: Machine
-  Readable Workbook Consumers: p9_pstate_parameter_block to set
-  flag for CME QuadManager Hcode reaction p9_hcd_cache procedures
-  to power on VDMs before CME booting</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <readable />
-  <persistency>non-volatile</persistency>
-  <hwpfToHbAttrMap>
-    <id>ATTR_VDM_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>VDM_ENABLE</id>
-  <description>Enumeration for Voltage Drop Monitor
-  enable</description>
-  <enumerator>
-    <name>OFF</name>
-    <value>0x00</value>
-  </enumerator>
-  <enumerator>
-    <name>ON</name>
-    <value>0x01</value>
-  </enumerator>
-</enumerationType>
-<!-- p9_setup_bars - Begin -->
-<attribute>
-  <id>PROC_PCIE_MMIO_BAR0_BASE_ADDR_OFFSET</id>
-  <description>PCIE MMIO0 BAR base address offset Attribute holds
-  offset (relative to chip MMIO origin) to program into chip
-  address range field of BAR -- RA bits 8:47 (excludes
-  system/memory select/group/chip fields) Array index: PHB number
-  (0:5)</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-    <array>6</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_MMIO_BAR0_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_MMIO_BAR1_BASE_ADDR_OFFSET</id>
-  <description>PCIE MMIO1 BAR base address offset Attribute holds
-  offset (relative to chip MMIO origin) to program into chip
-  address range field of BAR -- RA bits 8:47 (excludes
-  system/memory select/group/chip fields) Array index: PHB number
-  (0:5)</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-    <array>6</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_MMIO_BAR1_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_REGISTER_BAR_BASE_ADDR_OFFSET</id>
-  <description>PCIE PHB register space BAR base address offset chip
-  address range field of BAR -- RA bits 8:49 (excludes
-  system/memory select/group/chip fields) Array index: PHB number
-  (0:5)</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-    <array>6</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PCIE_REGISTER_BAR_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_XSCOM_BAR_BASE_ADDR_OFFSET</id>
-  <description>XSCOM BAR base address offset Defines 16GB range
-  (size implied) mapped for XSCOM usage Attribute holds offset
-  (relative to chip MMIO origin) to program into chip address range
-  field of BAR -- RA bits 22:29 (excludes system/memory
-  select/group/chip fields)</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_XSCOM_BAR_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_LPC_BAR_BASE_ADDR_OFFSET</id>
-  <description>LPC BAR base address offset Defines 4GB range (size
-  implied) mapped for LPC usage Attribute holds offset (relative to
-  chip MMIO origin) to program into chip address range field of BAR
-  -- RA bits 22:31 (excludes system/memory select/group/chip
-  fields)</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_LPC_BAR_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_FSP_BAR_SIZE</id>
-  <description>FSP BAR size value creator: platform consumer:
-  p9_setup_bars firmware notes: none</description>
-  <simpleType>
-    <uint64_t>
-      <default>0xFFFFFC00FFFFFFFF</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FSP_BAR_SIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_FSP_BAR_BASE_ADDR_OFFSET</id>
-  <description>FSP BAR Defines range mapped for FSP MMIO Attribute
-  holds offset (relative to chip MMIO origin) to program into chip
-  address range field of BAR -- RA bits 22:43</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000030100000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FSP_BAR_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_FSP_MMIO_MASK_SIZE</id>
-  <description>FSP MMIO mask size value AND mask applied to RA
-  32:35 when transmitting address to FSP NOTE: RA 8:31 are always
-  replaced with zero 4_GB = 0x00F0000000000000, 2_GB =
-  0x0070000000000000, 1_GB = 0x0030000000000000, 512_MB =
-  0x0010000000000000, 256_MB = 0x0000000000000000</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0010000000000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_FSP_MMIO_MASK_SIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PSI_BRIDGE_BAR_BASE_ADDR_OFFSET</id>
-  <description>PSI Bridge BAR base address offset Defines 1MB range
-  (size implied) mapped for PSI host-bridge Attribute holds offset
-  (relative to chip MMIO origin) to program into chip address range
-  field of BAR -- RA bits 22:43 (excludes system/memory
-  select/group/chip fields)</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000030203000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_PSI_BRIDGE_BAR_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_NPU_PHY0_BAR_ENABLE</id>
-  <description>NPU PHY0 (stack0) BAR enable DISABLE = 0x0, ENABLE =
-  0x1</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NPU_PHY0_BAR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_NPU_PHY0_BAR_BASE_ADDR_OFFSET</id>
-  <description>NPU PHY0 (stack0) BAR Defines 2MB range (size
-  implied) mapped to PHY0 registers Attribute holds offset
-  (relative to chip MMIO origin) to program into chip address range
-  field of BAR -- RA bits 22:42 (excludes system/memory
-  select/group/chip fields)</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000030201200000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NPU_PHY0_BAR_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_NPU_PHY1_BAR_ENABLE</id>
-  <description>NPU PHY1 (stack1) BAR enable DISABLE = 0x0, ENABLE =
-  0x1</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NPU_PHY1_BAR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_NPU_PHY1_BAR_BASE_ADDR_OFFSET</id>
-  <description>NPU PHY1 (stack1) BAR Defines 2MB range (size
-  implied) mapped to PHY1 registers Attribute holds offset
-  (relative to chip MMIO origin) to program into chip address range
-  field of BAR -- RA bits 22:42 (excludes system/memory
-  select/group/chip fields)</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000030201400000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NPU_PHY1_BAR_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_NPU_MMIO_BAR_ENABLE</id>
-  <description>NPU MMIO (stack2) BAR enable DISABLE = 0x0, ENABLE =
-  0x1</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NPU_MMIO_BAR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_NPU_MMIO_BAR_BASE_ADDR_OFFSET</id>
-  <description>NPU MMIO (stack2) BAR Defines 16MB range mapped to
-  all NPU registers Attribute holds offset (relative to chip MMIO
-  origin) to program into chip address range field of BAR -- RA
-  bits 22:39 (excludes system/memory select/group/chip
-  fields)</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0000030200000000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NPU_MMIO_BAR_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_NX_RNG_BAR_ENABLE</id>
-  <description>NX RNG BAR enable DISABLE = 0x0, ENABLE =
-  0x1</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NX_RNG_BAR_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_NX_RNG_BAR_BASE_ADDR_OFFSET</id>
-  <description>NX RNG BAR Defines 8KB range (size implied) mapped
-  for NX RNG function Attribute holds offset (relative to chip MMIO
-  origin) to program into chip address range field of BAR -- RA
-  bits 22:51 (excludes system/memory select/group/chip
-  fields)</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x00000302031D0000</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_NX_RNG_BAR_BASE_ADDR_OFFSET</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- p9_setup_bars - End -->
-<!--The following two NX_RING_FAILED attributes are essentially overrides
+  <attribute>
+    <id>PROC_PCIE_IOP_SWAP</id>
+    <description>PCIE IOP swap configuration creator: platform
+    consumer: p9_pcie_scominit firmware notes: Encoded PCIE IOP
+    swap configuration</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_IOP_SWAP</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_TX_MARGIN_RATIO</id>
+    <!-- <targetType>TARGET_TYPE_XBUS</targetType> -->
+    <description>Value to select amount of margin to be
+    applied.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IO_XBUS_TX_MARGIN_RATIO</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IO_XBUS_TX_FFE_PRECURSOR</id>
+    <!-- <targetType>TARGET_TYPE_XBUS</targetType> -->
+    <description>Value to select amount of tx ffe precusor to
+    apply.</description>
+    <simpleType>
+      <uint8_t>
+        <default>6</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IO_XBUS_TX_FFE_PRECURSOR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+    <description>Machine Readable Workbook safe mode throttle value
+    for numerator cfg_nm_n_per_port Set to below optimum value/
+    rate. On a per port (MCA) basis Consumer:
+    thermal_init</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>
+      ATTR_MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+    <description>Machine Readable Workbook safe mode throttle value
+    for numerator cfg_nm_n_per_slot</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>
+      ATTR_MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_MEM_M_DRAM_CLOCKS</id>
+    <description>Machine Readable Workbook for the number of M DRAM
+    clocks. One approach to curbing DRAM power usage is by
+    throttling traffic through a programmable N commands over M
+    window.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x00000200</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_MEM_M_DRAM_CLOCKS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_AVDD_OFFSET_DISABLE</id>
+    <description>Used for to determine whether to apply an offset
+    to AVDD. Supplied by MRW.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_AVDD_OFFSET_DISABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_VDD_OFFSET_DISABLE</id>
+    <description>Used for to determine whether to apply an offset
+    to VDD. Supplied by MRW</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_VDD_OFFSET_DISABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_VCS_OFFSET_DISABLE</id>
+    <description>Used for to determine whether to apply an offset
+    to VCS. Supplied by MRW.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_VCS_OFFSET_DISABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_VPP_OFFSET_DISABLE</id>
+    <description>Used for to determine whether to apply an offset
+    to VPP. Supplied by MRW.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_VPP_OFFSET_DISABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_VDDR_OFFSET_DISABLE</id>
+    <description>Used for to determine whether to apply an offset
+    to VDDR. Supplied by MRW.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_VDDR_OFFSET_DISABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_FINE_REFRESH_MODE</id>
+    <description>Fine refresh mode. Should be defaulted to normal
+    mode. This is for DDR4 MRS3.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_FINE_REFRESH_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_TEMP_REFRESH_RANGE</id>
+    <description>Temp ref range. Should be defaulted to extended
+    range. This is for DDR4 MRS4. Should be defaulted to extended
+    range. NORMAL for running at 85 degrees C or less, EXTENDED for
+    95 or less degrees C Used for calculating periodic refresh
+    intervals JEDEC DDR4 spec 1716.78C from 07-2016 page 46
+    4.8.1</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_TEMP_REFRESH_RANGE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!--Deprecated-->
+  <!--Deprecated-->
+  <attribute>
+    <id>MSS_MRW_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+    <description>Describes the settings for periodic calibration
+    for all ports: Reading left to right</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_PERIODIC_MEMCAL_MODE_OPTIONS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_PERIODIC_ZQCAL_MODE_OPTIONS</id>
+    <description>Describes the settings for periodic ZQ calibration
+    for all ports: Reading left to right. For each bit: OFF = 0, ON
+    = 1. Setting to 0 indicates to disable periodic zqcal. Byte 0:
+    0: ZQCAL All others reserved for future use</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_PERIODIC_ZQCAL_MODE_OPTIONS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_DRAMINIT_RESET_DISABLE</id>
+    <description>A disable switch for resetting the phy delay
+    values at the beginning of calling
+    mss_draminit_training.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MRW_DRAMINIT_RESET_DISABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>SECURITY_ENABLE</id>
+    <description>Holds the state of Security Access Bit
+    (SAB)</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <writeable />
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_SECURITY_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_PREFETCH_ENABLE</id>
+    <description>0 = OFF 1 = ON Value of on or off. Determines if
+    prefetching enabled or not. See chapter 7 of the Centaur
+    Workbook.</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_PREFETCH_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_CLEANER_ENABLE</id>
+    <description>Value of on or off. Determines if the cleaner of
+    the L4 cache (write modified entries to memory on idle cycles)
+    enabled or not. See chapter 7 of the Centaur
+    Workbook.</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_CLEANER_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!--SBE ONLY-->
+  <!--SBE ONLY-->
+  <!--SBE ONLY-->
+  <attribute>
+    <id>SUPPORTS_DYNAMIC_MEM_VOLT</id>
+    <description>Do we support dynamically updating memory
+    voltages? 0 = no, 1 = yes</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>LPC_BASE_ADDR</id>
+    <description>Defines LPC base address on each processor
+    level.</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_LPC_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_FSP_BAR_ENABLE</id>
+    <description>FSP BAR enable DISABLE = 0x0, ENABLE =
+    0x1</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FSP_BAR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PSI_BRIDGE_BAR_ENABLE</id>
+    <description>PSI Bridge BAR enable DISABLE = 0x0, ENABLE =
+    0x1</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PSI_BRIDGE_BAR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>VDM_ENABLE</id>
+    <description>Controls the enablement of Voltage Droop Monitors
+    (VDM) in the system. OFF = 0x00, ON = 0x01 Producer: Machine
+    Readable Workbook Consumers: p9_pstate_parameter_block to set
+    flag for CME QuadManager Hcode reaction p9_hcd_cache procedures
+    to power on VDMs before CME booting</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <readable />
+    <persistency>non-volatile</persistency>
+    <hwpfToHbAttrMap>
+      <id>ATTR_VDM_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>VDM_ENABLE</id>
+    <description>Enumeration for Voltage Drop Monitor
+    enable</description>
+    <enumerator>
+      <name>OFF</name>
+      <value>0x00</value>
+    </enumerator>
+    <enumerator>
+      <name>ON</name>
+      <value>0x01</value>
+    </enumerator>
+  </enumerationType>
+  <!-- p9_setup_bars - Begin -->
+  <attribute>
+    <id>PROC_PCIE_MMIO_BAR0_BASE_ADDR_OFFSET</id>
+    <description>PCIE MMIO0 BAR base address offset Attribute holds
+    offset (relative to chip MMIO origin) to program into chip
+    address range field of BAR -- RA bits 8:47 (excludes
+    system/memory select/group/chip fields) Array index: PHB number
+    (0:5)</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+      <array>6</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_MMIO_BAR0_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_MMIO_BAR1_BASE_ADDR_OFFSET</id>
+    <description>PCIE MMIO1 BAR base address offset Attribute holds
+    offset (relative to chip MMIO origin) to program into chip
+    address range field of BAR -- RA bits 8:47 (excludes
+    system/memory select/group/chip fields) Array index: PHB number
+    (0:5)</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+      <array>6</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_MMIO_BAR1_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_REGISTER_BAR_BASE_ADDR_OFFSET</id>
+    <description>PCIE PHB register space BAR base address offset
+    chip address range field of BAR -- RA bits 8:49 (excludes
+    system/memory select/group/chip fields) Array index: PHB number
+    (0:5)</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+      <array>6</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PCIE_REGISTER_BAR_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_XSCOM_BAR_BASE_ADDR_OFFSET</id>
+    <description>XSCOM BAR base address offset Defines 16GB range
+    (size implied) mapped for XSCOM usage Attribute holds offset
+    (relative to chip MMIO origin) to program into chip address
+    range field of BAR -- RA bits 22:29 (excludes system/memory
+    select/group/chip fields)</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_XSCOM_BAR_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_LPC_BAR_BASE_ADDR_OFFSET</id>
+    <description>LPC BAR base address offset Defines 4GB range
+    (size implied) mapped for LPC usage Attribute holds offset
+    (relative to chip MMIO origin) to program into chip address
+    range field of BAR -- RA bits 22:31 (excludes system/memory
+    select/group/chip fields)</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_LPC_BAR_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_FSP_BAR_SIZE</id>
+    <description>FSP BAR size value creator: platform consumer:
+    p9_setup_bars firmware notes: none</description>
+    <simpleType>
+      <uint64_t>
+        <default>0xFFFFFC00FFFFFFFF</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FSP_BAR_SIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_FSP_BAR_BASE_ADDR_OFFSET</id>
+    <description>FSP BAR Defines range mapped for FSP MMIO
+    Attribute holds offset (relative to chip MMIO origin) to
+    program into chip address range field of BAR -- RA bits
+    22:43</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000030100000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FSP_BAR_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_FSP_MMIO_MASK_SIZE</id>
+    <description>FSP MMIO mask size value AND mask applied to RA
+    32:35 when transmitting address to FSP NOTE: RA 8:31 are always
+    replaced with zero 4_GB = 0x00F0000000000000, 2_GB =
+    0x0070000000000000, 1_GB = 0x0030000000000000, 512_MB =
+    0x0010000000000000, 256_MB = 0x0000000000000000</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0010000000000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_FSP_MMIO_MASK_SIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PSI_BRIDGE_BAR_BASE_ADDR_OFFSET</id>
+    <description>PSI Bridge BAR base address offset Defines 1MB
+    range (size implied) mapped for PSI host-bridge Attribute holds
+    offset (relative to chip MMIO origin) to program into chip
+    address range field of BAR -- RA bits 22:43 (excludes
+    system/memory select/group/chip fields)</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000030203000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_PSI_BRIDGE_BAR_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_NPU_PHY0_BAR_ENABLE</id>
+    <description>NPU PHY0 (stack0) BAR enable DISABLE = 0x0, ENABLE
+    = 0x1</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NPU_PHY0_BAR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_NPU_PHY0_BAR_BASE_ADDR_OFFSET</id>
+    <description>NPU PHY0 (stack0) BAR Defines 2MB range (size
+    implied) mapped to PHY0 registers Attribute holds offset
+    (relative to chip MMIO origin) to program into chip address
+    range field of BAR -- RA bits 22:42 (excludes system/memory
+    select/group/chip fields)</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000030201200000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NPU_PHY0_BAR_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_NPU_PHY1_BAR_ENABLE</id>
+    <description>NPU PHY1 (stack1) BAR enable DISABLE = 0x0, ENABLE
+    = 0x1</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NPU_PHY1_BAR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_NPU_PHY1_BAR_BASE_ADDR_OFFSET</id>
+    <description>NPU PHY1 (stack1) BAR Defines 2MB range (size
+    implied) mapped to PHY1 registers Attribute holds offset
+    (relative to chip MMIO origin) to program into chip address
+    range field of BAR -- RA bits 22:42 (excludes system/memory
+    select/group/chip fields)</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000030201400000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NPU_PHY1_BAR_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_NPU_MMIO_BAR_ENABLE</id>
+    <description>NPU MMIO (stack2) BAR enable DISABLE = 0x0, ENABLE
+    = 0x1</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NPU_MMIO_BAR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_NPU_MMIO_BAR_BASE_ADDR_OFFSET</id>
+    <description>NPU MMIO (stack2) BAR Defines 16MB range mapped to
+    all NPU registers Attribute holds offset (relative to chip MMIO
+    origin) to program into chip address range field of BAR -- RA
+    bits 22:39 (excludes system/memory select/group/chip
+    fields)</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0000030200000000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NPU_MMIO_BAR_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_NX_RNG_BAR_ENABLE</id>
+    <description>NX RNG BAR enable DISABLE = 0x0, ENABLE =
+    0x1</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NX_RNG_BAR_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_NX_RNG_BAR_BASE_ADDR_OFFSET</id>
+    <description>NX RNG BAR Defines 8KB range (size implied) mapped
+    for NX RNG function Attribute holds offset (relative to chip
+    MMIO origin) to program into chip address range field of BAR --
+    RA bits 22:51 (excludes system/memory select/group/chip
+    fields)</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x00000302031D0000</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_NX_RNG_BAR_BASE_ADDR_OFFSET</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- p9_setup_bars - End -->
+  <!--The following two NX_RING_FAILED attributes are essentially overrides
     so we will init them to zero -->
-<attribute>
-  <id>PROC_R_LOADLINE_VDD_UOHM</id>
-  <description>Impedance (binary microOhms) of the load line from a
-  processor VDD VRM to the Processor Module pins. This value is
-  applied to each processor instance. Producer: Machine Readable
-  Workbook (per the power subsystem design) Consumers:
-  p9_pstate_parameter_block</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_R_LOADLINE_VDD_UOHM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_R_DISTLOSS_VDD_UOHM</id>
-  <description>Impedance (binary in microOhms) of the VDD
-  distribution loss sense point to the circuit. This value is
-  applied to each processor instance. Producer: Machine Readable
-  Workbook (per the power subsystem design) Consumers:
-  p9_pstate_parameter_block</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_R_DISTLOSS_VDD_UOHM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_VRM_VOFFSET_VDD_UV</id>
-  <description>Offset voltage (binary in microvolts) to apply to
-  the VDD VRM distribution to the processor module. This value is
-  applied to each processor instance. Note: no loadline may be
-  present in the system; thus, a value of 0 is legal. Producer:
-  Machine Readable Workbook (per the power subsystem design)
-  Consumers: p9_pstate_parameter_block</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_VRM_VOFFSET_VDD_UV</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_R_LOADLINE_VDN_UOHM</id>
-  <description>Impedance (binary microOhms) of the load line from a
-  processor VDN VRM to the Processor Module pins. This value is
-  applied to each processor instance. Note: no loadline may be
-  present in the system; thus, a value of 0 is legal. Producer:
-  Machine Readable Workbook (per the power subsystem design)
-  Consumers: p9_pstate_parameter_block</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_R_LOADLINE_VDN_UOHM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_R_DISTLOSS_VDN_UOHM</id>
-  <description>Impedance (binary in microOhms) of the VDN
-  distribution loss sense point to the circuit. This value is
-  applied to each processor instance. Producer: Machine Readable
-  Workbook (per the power subsystem design) Consumers:
-  p9_pstate_parameter_block</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_R_DISTLOSS_VDN_UOHM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_VRM_VOFFSET_VDN_UV</id>
-  <description>Offset voltage (binary in microvolts) to apply to
-  the VDN VRM distribution to the processor module. This value is
-  applied to each processor instance. Producer: Machine Readable
-  Workbook (per the power subsystem design) Consumers:
-  p9_pstate_parameter_block</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_VRM_VOFFSET_VDN_UV</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_R_LOADLINE_VCS_UOHM</id>
-  <description>Impedance (binary microOhms) of the load line from a
-  processor VCS VRM to the Processor Module pins. This value is
-  applied to each processor instance. Note: no loadline may be
-  present in the system; thus, a value of 0 is legal. Producer:
-  Machine Readable Workbook (per the power subsystem design)
-  Consumers: p9_pstate_parameter_block</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_R_LOADLINE_VCS_UOHM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_R_DISTLOSS_VCS_UOHM</id>
-  <description>Impedance (binary in microOhms) of the VCS
-  distribution loss sense point to the circuit. This value is
-  applied to each processor instance. Producer: Machine Readable
-  Workbook (via the power subsystem design per system) Consumer:
-  p9_pstate_parameter_block</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_R_DISTLOSS_VCS_UOHM</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_VRM_VOFFSET_VCS_UV</id>
-  <description>Offset voltage (binary in microvolts) to apply to
-  the VCS VRM distribution to the processor module. This value is
-  applied to each processor instance. Producer: Machine Readable
-  Workbook (via the power subsystem design per system) Consumer:
-  FSP</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PROC_VRM_VOFFSET_VCS_UV</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IVRM_DEADZONE_MV</id>
-  <description>Indicates the size of the deadzone where the iVRM
-  cannot regulate (binary in millivolts) Producer:
-  MRWB.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_IVRM_DEADZONE_MV</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>TDP_RDP_CURRENT_FACTOR</id>
-  <description>TODO RTC 157943 -- Placeholder description
-  Consumers: p9_pstate_parameter_block</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_TDP_RDP_CURRENT_FACTOR</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_SAFE_FREQUENCY_MHZ</id>
-  <description>Frequency (in MHz) to move to if the Power
-  Management function fails. This is the same for all cores in the
-  system. Provided by the MRW.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_SAFE_FREQUENCY_MHZ</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR4</id>
-  <description>Machine Readable Workbook VMEM regulator power limit
-  per DIMM assuming a full configuration. Units in cW Consumed in
-  mss_eff_config_thermal</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x000006A4</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>
-    ATTR_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR4</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR3</id>
-  <description>Machine Readable Workbook VMEM regulator power limit
-  per CDIMM assuming a full configuration. Units in cW Used for
-  Cumulus Consumed in mss_eff_config_thermal</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>
-    ATTR_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR3</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>SYSTEM_FAMILY</id>
-  <description>This field is of the form "vendor,name" where the
-  name indicates the family of the systems. The textual portion of
-  the string has a maximum length of 63 characters to accommodate a
-  terminating NULL. Both vendor and name fields are lower case US
-  ASCII. No special characters other than ",", "-", and "+" as
-  described below should be used in the string.</description>
-  <simpleType>
-    <string>
-      <default>ibm,p9</default>
-      <sizeInclNull>64</sizeInclNull>
-    </string>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>SYSTEM_TYPE</id>
-  <description>This field is of the form ?vendor,type? where the
-  type indicates a type of system within the System Family. The
-  textual portion of the string has a maximum length of 63
-  characters to accommodate a terminating NULL. Both vendor and
-  name fields are lower case US ASCII. No special characters other
-  than ",", "-", and "+" as described below should be used in the
-  string. If identification of specific models within a system type
-  is desired, "-model" should be appended to the end of the name.
-  The "-model" portion is optional and could be used to identify
-  the packaging, specific model numbers, etc. NOTE: No Hostboot
-  code should ever key off of this value.</description>
-  <simpleType>
-    <string>
-      <default>ibm,miscopenpower</default>
-      <sizeInclNull>64</sizeInclNull>
-    </string>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>SUPPORTED_STOP_STATES</id>
-  <description>STOP levels supported at runtime (sent to Host via
-  HDAT): Bit 0: STOP0 Supported - Quiesce thread only Bit 1: STOP1
-  Supported - P8 Nap Bit 2: STOP2 Supported - P8 Fast Sleep Bit 3:
-  STOP3 Supported - P8 Fast Sleep using iVRMs Bit 4: STOP4
-  supported - P8 Deep Sleep Bit 5: STOP5 Supported - WOF-friendly
-  "Instant on" Bit 6,7: Reserved Bit 8: STOP8 supported - Half Quad
-  Sleep Bit 9: STOP9 supported - P8 Fast Winkle Bit 10: Reserved
-  Bit 11: STOP11 supported - P8 Deep Winkle Bit 12-15 : Reserved
-  Bits 16..31 - Reserved</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x80000000</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>SBE_IMAGE_MINIMUM_VALID_ECS</id>
-  <description>The minimum number of valid ECs that is required to
-  be used when customizing an SBE image. The customization will
-  fail if it cannot create an image with at least this many
-  ECs.</description>
-  <simpleType>
-    <uint8_t>
-      <default>2</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_SBE_IMAGE_MINIMUM_VALID_ECS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>REL_POS</id>
-  <description>Logical position of this unit/dimm relative to its
-  immediate parent</description>
-  <simpleType>
-    <uint8_t>
-      <default>0xFF</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_REL_POS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-  <description>PCIE Lane Equalization values for each PHB Creator:
-  MRW Purpose: Holds settings which are loaded into the HW to
-  optimize the PCIE lane signal eye between the chips + PCIE Gen3
-  endpoints Data Format: 16 entries of 16 bytes of EQ data per PHB.
-  Each PHB has an EQ value for each of its 16 lanes. Each value is
-  a uint16 formatted as follows: Bit 0:3 - up_rx_hint (bit 0
-  reserved) Bit 4:7 - up_tx_preset Bit 8:11 - dn_rx_hint (bit 0
-  reserved) Bit 12:15 - dn_tx_preset</description>
-  <simpleType>
-    <uint16_t>
-      <default>0x7777,0x7777,0x7777,0x7777,
-      0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777,
-      0x7777,0x7777,0x7777,0x7777</default>
-    </uint16_t>
-    <array>16</array>
-    <!-- Lane -->
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-  <description>PCIE Lane Equalization values for each PHB Creator:
-  MRW Purpose: Holds settings which are loaded into the HW to
-  optimize the PCIE lane signal eye between the chips + PCIE Gen4
-  endpoints Data Format: 16 entries of 16 bytes of EQ data per PHB.
-  Each PHB has an EQ value for each of its 16 lanes. Each value is
-  a uint16 formatted as follows: Bit 0:3 - up_rx_hint (bit 0
-  reserved) Bit 4:7 - up_tx_preset Bit 8:11 - dn_rx_hint (bit 0
-  reserved) Bit 12:15 - dn_tx_preset</description>
-  <simpleType>
-    <uint16_t>
-      <default>0x7777,0x7777,0x7777,0x7777,
-      0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777,
-      0x7777,0x7777,0x7777,0x7777</default>
-    </uint16_t>
-    <array>16</array>
-    <!-- Lane -->
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>SBE_SYS_CONFIG</id>
-  <description>System Configuration information - 1 indicates a
-  chip present</description>
-  <simpleType>
-    <uint64_t>
-      <default>0x0</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_SBE_SYS_CONFIG</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_PWR_INTERCEPT</id>
-  <description>Machine Readable Workbook Power Curve Intercept for
-  DIMM Used to get the VDDR and VDDR+VPP power curve for each DIMM
-  Decoded and used to set ATTR_MSS_TOTAL_PWR_INTERCEPT Key Value
-  pair KEY (0-19): In order DIMM_SIZE = bits 0-3, DIMM_GEN = 4-5,
-  DIMM_TYPE = 6-7, DIMM_WIDTH = 8-9, DIMM_DENSITY = 10-12,
-  DIMM_STACK_TYPE = 13-14, DRAM_MFGID = 15-16, DIMMS_PER_PORT =
-  17-18, Bits 19-32: Not used VALUE (bits 32-63) in cW: VMEM power
-  curve = 32-47 VMEM+VPP power curve = 48-63 Consumers:
-  eff_config_thermal</description>
-  <simpleType>
-    <uint64_t>
-      <default>
-      0xffffe00002CC03AE,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0</default>
-    </uint64_t>
-    <array>100</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_PWR_INTERCEPT</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_PWR_SLOPE</id>
-  <description>Machine Readable Workbook Power Curve Slope for DIMM
-  Used to get the VDDR and VDDR+VPP power curve for each DIMM
-  Decoded and used to set ATTR_MSS_TOTAL_PWR_INTERCEPT Key Value
-  pair KEY (0-19): In order DIMM_SIZE = bits 0-3, DIMM_GEN = 4-5,
-  DIMM_TYPE = 6-7, DIMM_WIDTH = 8-9, DIMM_DENSITY = 10-12,
-  DIMM_STACK_TYPE = 13-14, DRAM_MFGID = 15-16, DIMMS_PER_PORT =
-  17-18, Bits 19-32: Not used VALUE (bits 32-63) in cW: VMEM power
-  curve = 32-47 VMEM+VPP power curve = 48-63 Consumers:
-  eff_config_thermal</description>
-  <simpleType>
-    <uint64_t>
-      <default>
-      0xffffe00003FD0546,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-      0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0</default>
-    </uint64_t>
-    <array>100</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_PWR_SLOPE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>MSS_MRW_REFRESH_RATE_REQUEST</id>
-  <description>Machine Readable Workbook Refresh Rate Desired
-  refresh interval used in refresh register 0,
-  MBAREF0Q_CFG_REFRESH_INTERVAL 7.8 us (SINGLE) 3.9 us (DOUBLE)
-  7.02 us (SINGLE_10_PERCENT_FASTER) 3.51 us
-  (DOUBLE_10_PERCENT_FASTER)</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_REFRESH_RATE_REQUEST</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PM_SAFE_VOLTAGE_MV</id>
-  <description>Voltage (in mV) to move to if the Power Management
-  function fails. Provided by the MRW.</description>
-  <simpleType>
-    <uint32_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PM_SAFE_VOLTAGE_MV</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IVRM_STRENGTH_LOOKUP</id>
-  <description>Producer: MRWB.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-    <array>64</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_IVRM_STRENGTH_LOOKUP</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IVRM_VIN_MULTIPLIER</id>
-  <description>Producer: MRWB.</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-    <array>64</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_IVRM_VIN_MULTIPLIER</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IVRM_VIN_MAX_MV</id>
-  <description>Producer: MRWB.</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_IVRM_VIN_MAX_MV</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IVRM_STEP_DELAY_NS</id>
-  <description>Producer: MRWB.</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_IVRM_STEP_DELAY_NS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>IVRM_STABILIZATION_DELAY_NS</id>
-  <description>Producer: MRWB.</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_IVRM_STABILIZATION_DELAY_NS</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>SYSTEM_RESCLK_ENABLE</id>
-  <description>Controls the enablement of resonant clocking in the
-  system. Producer: Machine Readable Workbook Consumers:
-  p9_pstate_parameter_block to set flag for CME QuadManager Hcode
-  reaction</description>
-  <simpleType>
-    <uint8_t></uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_SYSTEM_RESCLK_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>ORDINAL_ID</id>
-  <description>Ordinal ID of a target</description>
-  <simpleType>
-    <uint32_t>
-      <default>0xFFFFFFFF</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-</attribute>
-<attribute>
-  <id>POUND_W_STATIC_DATA_ENABLE</id>
-  <description>Enables pstate parameter block code to use the
-  static #W data Consumer: p9_pstate_parameter_block.C -&gt;
-  Platform default: OFF=0</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_POUND_W_STATIC_DATA_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>PGPE_HCODE_FUNCTION_ENABLE</id>
-  <description>Enables the PGPE Hcode to physically perform
-  frequency and voltage operations based on constructed parameters
-  (eg #V VPD, system parameters, biases, WPF VFRTs. etc). If OFF,
-  the PGPE provides an immedicate good response to all Pstate/WOF
-  IPC operations from the OCC for firmware integration testing
-  purposes. Consumer: p9_hcode_image_build.c -&gt; PGPE Header
-  field Platform default: OFF</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_PGPE_HCODE_FUNCTION_ENABLE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<attribute>
-  <id>XIVE_HW_RESET</id>
-  <description>Used to tell INTRP code whether to use the XIVE HW
-  Reset or a software based reset. 0 = Software based reset 1 =
-  XIVE HW reset</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<attribute>
-  <id>MAX_SBE_SEEPROM_SIZE</id>
-  <description>Defines the maximum Seeprom storage size for the
-  fully-customized SBE image permitted by the platform. For
-  platforms (FSP/HB FW) which require the image to be constrained
-  into a physical storage device (SEEPROM), this should reflect the
-  maximum size of that memory (e.g., 256KB). For platforms (Cronus)
-  which may use a customized image in a virtual envrionment with no
-  physical storage constraints, this size may be larger than the
-  physical SEEPROM size.</description>
-  <simpleType>
-    <uint32_t>
-      <default>0x40000</default>
-    </uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MAX_SBE_SEEPROM_SIZE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<!-- @fixme RTC:166754 Remove old attribute -->
-<!-- @fixme RTC:166754 Remove old attribute -->
-<attribute>
-  <id>DISABLE_I2C_ENGINE2_PORT0_DIAG_MODE</id>
-  <description>Used to tell I2C code whether to run I2C Engine 2
-  Port 0 in diag mode or not 0 = Use Diag Mode 1 = Disable Diag
-  Mode</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-</attribute>
-<enumerationType>
-  <id>MSS_MRW_TEMP_REFRESH_MODE</id>
-  <description>Enumeration for Temperature refresh
-  mode</description>
-  <enumerator>
-    <name>DISABLE</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>ENABLE</name>
-    <value>1</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>MSS_MRW_TEMP_REFRESH_MODE</id>
-  <description>Used in MR4 A3 Temperature refresh mode Should be
-  defaulted to disable</description>
-  <simpleType>
-    <uint8_t>
-      <default>DISABLE</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_MSS_MRW_TEMP_REFRESH_MODE</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-</attribute>
-<enumerationType>
-  <id>HDAT_I2C_DEVICE_TYPE</id>
-  <description>Pulled from the MRW, this describes the device type
-  to the HDAT. This is for I2C devices only.</description>
-  <enumerator>
-    <name>955X</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>SEEPROM</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>NUVOTON_TPM</name>
-    <value>3</value>
-  </enumerator>
-  <enumerator>
-    <name>MEX_FPGA</name>
-    <value>4</value>
-  </enumerator>
-  <enumerator>
-    <name>UCX90XX</name>
-    <value>5</value>
-  </enumerator>
-  <enumerator>
-    <name>NVLINK</name>
-    <value>6</value>
-  </enumerator>
-  <enumerator>
-    <name>UNKNOWN</name>
-    <value>FF</value>
-  </enumerator>
-</enumerationType>
-<enumerationType>
-  <id>HDAT_I2C_DEVICE_PURPOSE</id>
-  <description>Pulled from the MRW, this describes the device
-  purpose to the HDAT. This is for I2C devices only.</description>
-  <enumerator>
-    <name>CABLE_CARD_PRES</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>CABLE_CARD_POWER_SENSE</name>
-    <value>2</value>
-  </enumerator>
-  <enumerator>
-    <name>CABLE_CARD_POWER_CONTROL</name>
-    <value>3</value>
-  </enumerator>
-  <enumerator>
-    <name>TPM</name>
-    <value>4</value>
-  </enumerator>
-  <enumerator>
-    <name>MODULE_VPD</name>
-    <value>5</value>
-  </enumerator>
-  <enumerator>
-    <name>DIMM_SPD</name>
-    <value>6</value>
-  </enumerator>
-  <enumerator>
-    <name>PROC_MODULE_VPD</name>
-    <value>7</value>
-  </enumerator>
-  <enumerator>
-    <name>SBE_SEEPROM</name>
-    <value>8</value>
-  </enumerator>
-  <enumerator>
-    <name>PLANAR_VPD</name>
-    <value>9</value>
-  </enumerator>
-  <enumerator>
-    <name>PCI_HOTPLUG</name>
-    <value>A</value>
-  </enumerator>
-  <enumerator>
-    <name>NVLINK</name>
-    <value>B</value>
-  </enumerator>
-  <enumerator>
-    <name>UNKNOWN</name>
-    <value>FF</value>
-  </enumerator>
-</enumerationType>
-<enumerationType>
-  <id>IPMI_SENSOR_ARRAY</id>
-  <description>Enumeration defining the offsets into the
-  IPMI_SENSORS array.</description>
-  <enumerator>
-    <name>NAME_OFFSET</name>
-    <value>0x00</value>
-  </enumerator>
-  <enumerator>
-    <name>NUMBER_OFFSET</name>
-    <value>0x01</value>
-  </enumerator>
-</enumerationType>
-<enumerationType>
-  <id>SENSOR_NAME</id>
-  <description>Enumeration indicating the IPMI sensor name, which
-  will be used by hostboot when determining the sensor number to
-  return. he sensor name consists of one byte of sensor type plus
-  one byte of sub-type, to differentiate similar sensors under the
-  same target. Our implementaion uses the IPMI defined entity ID as
-  the sub-type.</description>
-  <enumerator>
-    <name>PROC_TEMP</name>
-    <value>0x0103</value>
-  </enumerator>
-  <enumerator>
-    <name>DIMM_TEMP</name>
-    <value>0x0120</value>
-  </enumerator>
-  <enumerator>
-    <name>CORE_TEMP</name>
-    <value>0x01D0</value>
-  </enumerator>
-  <enumerator>
-    <name>STATE</name>
-    <value>0x0500</value>
-  </enumerator>
-  <enumerator>
-    <name>MEMBUF_TEMP</name>
-    <value>0x01D1</value>
-  </enumerator>
-  <enumerator>
-    <name>PROC_STATE</name>
-    <value>0x0703</value>
-  </enumerator>
-  <enumerator>
-    <name>CORE_STATE</name>
-    <value>0x07D0</value>
-  </enumerator>
-  <enumerator>
-    <name>DIMM_STATE</name>
-    <value>0x0C20</value>
-  </enumerator>
-  <enumerator>
-    <name>MEMBUF_STATE</name>
-    <value>0x0CD1</value>
-  </enumerator>
-  <enumerator>
-    <name>FW_BOOT_PROGRESS</name>
-    <value>0x0F22</value>
-  </enumerator>
-  <enumerator>
-    <name>SYSTEM_EVENT</name>
-    <value>0x1201</value>
-  </enumerator>
-  <enumerator>
-    <name>OS_BOOT</name>
-    <value>0x1F23</value>
-  </enumerator>
-  <enumerator>
-    <name>HOST_STATUS</name>
-    <value>0x2223</value>
-  </enumerator>
-  <enumerator>
-    <name>OCC_ACTIVE</name>
-    <value>0x07D2</value>
-  </enumerator>
-  <enumerator>
-    <name>CORE_FREQ</name>
-    <value>0xC1D0</value>
-  </enumerator>
-  <enumerator>
-    <name>APSS_CHANNEL</name>
-    <value>0xC2D7</value>
-  </enumerator>
-  <enumerator>
-    <name>PCI_ACTIVE</name>
-    <value>0xC423</value>
-  </enumerator>
-  <enumerator>
-    <name>REBOOT_COUNT</name>
-    <value>0xC322</value>
-  </enumerator>
-  <enumerator>
-    <name>FAULT</name>
-    <value>0xC700</value>
-  </enumerator>
-  <enumerator>
-    <name>BACKPLANE_FAULT</name>
-    <value>0xC707</value>
-  </enumerator>
-  <enumerator>
-    <name>REF_CLOCK_FAULT</name>
-    <value>0xC7D4</value>
-  </enumerator>
-  <enumerator>
-    <name>PCI_CLOCK_FAULT</name>
-    <value>0xC7D5</value>
-  </enumerator>
-  <enumerator>
-    <name>TOD_CLOCK_FAULT</name>
-    <value>0xC7D6</value>
-  </enumerator>
-  <enumerator>
-    <name>APSS_FAULT</name>
-    <value>0xC7D7</value>
-  </enumerator>
-  <enumerator>
-    <name>DERATING_FACTOR</name>
-    <value>0xC815</value>
-  </enumerator>
-  <enumerator>
-    <name>REDUNDANT_PS_POLICY</name>
-    <value>0xCA22</value>
-  </enumerator>
-  <enumerator>
-    <name>TPM_REQUIRED</name>
-    <value>0xFFFF</value>
-  </enumerator>
-</enumerationType>
-<enumerationType>
-  <id>ENTITY_ID</id>
-  <description>Enumeration indicating the IPMI entity ID, these
-  values are defined in the IPMI specification. These values will
-  be used in place of target type when events are sent to the
-  BMC.</description>
-  <enumerator>
-    <name>NA</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>OTHER</name>
-    <value>0x01</value>
-  </enumerator>
-  <enumerator>
-    <name>PROCESSOR</name>
-    <value>0x03</value>
-  </enumerator>
-  <enumerator>
-    <name>SYSTEM_BOARD</name>
-    <value>0x07</value>
-  </enumerator>
-  <enumerator>
-    <name>POWER_MGMT</name>
-    <value>0x15</value>
-  </enumerator>
-  <enumerator>
-    <name>CHASSIS</name>
-    <value>0x17</value>
-  </enumerator>
-  <enumerator>
-    <name>MEMORY_DEVICE</name>
-    <value>0x20</value>
-  </enumerator>
-  <enumerator>
-    <name>BIOS</name>
-    <value>0x22</value>
-  </enumerator>
-  <enumerator>
-    <name>OS</name>
-    <value>0x23</value>
-  </enumerator>
-  <enumerator>
-    <name>CORE</name>
-    <value>0xD0</value>
-  </enumerator>
-  <enumerator>
-    <name>MEMBUF</name>
-    <value>0xD1</value>
-  </enumerator>
-  <enumerator>
-    <name>OCC</name>
-    <value>0xD2</value>
-  </enumerator>
-  <enumerator>
-    <name>REF_CLOCK</name>
-    <value>0xD4</value>
-  </enumerator>
-  <enumerator>
-    <name>PCI_CLOCK</name>
-    <value>0xD5</value>
-  </enumerator>
-  <enumerator>
-    <name>TOD_CLOCK</name>
-    <value>0xD6</value>
-  </enumerator>
-  <enumerator>
-    <name>APSS</name>
-    <value>0xD7</value>
-  </enumerator>
-</enumerationType>
-<enumerationType>
-  <id>SENSOR_TYPE</id>
-  <description>Enumeration indicating the IPMI sensor type, these
-  values are defined in the IPMI specification. These values will
-  be used when sending sensor reading events to the
-  BMC.</description>
-  <enumerator>
-    <name>NA</name>
-    <value>0</value>
-  </enumerator>
-  <enumerator>
-    <name>TEMPERATURE</name>
-    <value>0x01</value>
-  </enumerator>
-  <enumerator>
-    <name>PROCESSOR</name>
-    <value>0x07</value>
-  </enumerator>
-  <enumerator>
-    <name>MEMORY</name>
-    <value>0x0c</value>
-  </enumerator>
-  <enumerator>
-    <name>SYS_FW_PROGRESS</name>
-    <value>0x0F</value>
-  </enumerator>
-  <enumerator>
-    <name>SYS_EVENT</name>
-    <value>0x12</value>
-  </enumerator>
-  <enumerator>
-    <name>OS_BOOT</name>
-    <value>0x1F</value>
-  </enumerator>
-  <enumerator>
-    <name>APCI_POWER_STATE</name>
-    <value>0x22</value>
-  </enumerator>
-  <enumerator>
-    <name>FREQ</name>
-    <value>0xC1</value>
-  </enumerator>
-  <enumerator>
-    <name>POWER</name>
-    <value>0xC2</value>
-  </enumerator>
-  <enumerator>
-    <name>BOOT_COUNT</name>
-    <value>0xC3</value>
-  </enumerator>
-  <enumerator>
-    <name>PCI_LINK_PRES</name>
-    <value>0xC4</value>
-  </enumerator>
-  <enumerator>
-    <name>PWR_LIMIT_ACTIVE</name>
-    <value>0xC4</value>
-  </enumerator>
-  <enumerator>
-    <name>FAULT</name>
-    <value>0xC7</value>
-  </enumerator>
-</enumerationType>
-<attribute>
-  <id>ADC_CHANNEL_FUNC_IDS</id>
-  <description>ADC Channel function id. 16 channels.</description>
-  <simpleType>
-    <uint8_t />
-    <array>16</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>ADC_CHANNEL_SENSOR_NUMBERS</id>
-  <description>ADC Channel IPMI sensor numbers. 16
-  channels.</description>
-  <simpleType>
-    <uint32_t />
-    <array>16</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>ADC_CHANNEL_GNDS</id>
-  <description>ADC Channel ground. 16 channels.</description>
-  <simpleType>
-    <uint8_t />
-    <array>16</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>ADC_CHANNEL_GAINS</id>
-  <description>ADC channel gain * 1000. 16 channels.</description>
-  <simpleType>
-    <uint32_t />
-    <array>16</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>ADC_CHANNEL_OFFSETS</id>
-  <description>ADC channel offset * 1000. 16 channels</description>
-  <simpleType>
-    <uint32_t />
-    <array>16</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>APSS_GPIO_PORT_MODES</id>
-  <description>APSS GPIO PORT MODES</description>
-  <simpleType>
-    <uint8_t />
-    <array>2</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>APSS_GPIO_PORT_PINS</id>
-  <description>APSS GPIO PORT PINS Port0 pin 0-7 Port1 pin
-  8-15</description>
-  <simpleType>
-    <uint8_t />
-    <array>16</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>GPIO_INFO</id>
-  <description>Information needed to address GPIO
-  device</description>
-  <complexType>
-    <description>Structure to define the addessing for an I2C slave
-    device.</description>
-    <field>
-      <name>i2cMasterPath</name>
-      <description>Entity path to the chip that contains the I2C
-      master</description>
-      <type>EntityPath</type>
-      <default>physical:sys-0</default>
-    </field>
-    <field>
-      <name>port</name>
-      <description>Port from the I2C Master device. This is a 6-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0</default>
-    </field>
-    <field>
-      <name>devAddr</name>
-      <description>Device address on the I2C bus. This is a 7-bit
-      value, but then shifted 1 bit left.</description>
-      <type>uint8_t</type>
-      <default>0</default>
-    </field>
-    <field>
-      <name>engine</name>
-      <description>I2C master engine. This is a 2-bit
-      value.</description>
-      <type>uint8_t</type>
-      <default>0</default>
-    </field>
-    <field>
-      <name>vddrPin</name>
-      <description>Logical GPIO pin number used to enabled/disable
-      VDDR</description>
-      <type>uint8_t</type>
-      <default>0</default>
-    </field>
-  </complexType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>HDAT_I2C_ENGINE</id>
-  <description>This attribute holds the values of the I2C Engine
-  from the i2c device connections as defined in the MRW. It is
-  parsed into a struct in i2c.C</description>
-  <simpleType>
-    <uint8_t />
-    <array>32</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>HDAT_I2C_MASTER_PORT</id>
-  <description>This attribute holds the values of the I2C Master
-  Port from the i2c device connections as defined in the MRW. It is
-  parsed into a struct in i2c.C</description>
-  <simpleType>
-    <uint8_t />
-    <array>32</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>HDAT_I2C_DEVICE_TYPE</id>
-  <description>This attribute holds the values of the I2C device
-  type from the i2c device connections as defined in the MRW. It is
-  parsed into a struct in i2c.C</description>
-  <simpleType>
-    <uint8_t />
-    <array>32</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>HDAT_I2C_ADDR</id>
-  <description>This attribute holds the values of the I2C address
-  from the i2c device connections as defined in the MRW. It is
-  parsed into a struct in i2c.C</description>
-  <simpleType>
-    <uint8_t />
-    <array>32</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>HDAT_I2C_SLAVE_PORT</id>
-  <description>This attribute holds the values of the I2C slave
-  port from the i2c device connections as defined in the MRW. It is
-  parsed into a struct in i2c.C</description>
-  <simpleType>
-    <uint8_t />
-    <array>32</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>HDAT_I2C_BUS_FREQ</id>
-  <description>This attribute holds the values of the I2C bus
-  frequency in Hz from the i2c device connections as defined in the
-  MRW. It is parsed into a struct in i2c.C</description>
-  <simpleType>
-    <uint8_t />
-    <array>32</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>HDAT_I2C_DEVICE_PURPOSE</id>
-  <description>This attribute holds the values of the I2C device
-  purpose from the i2c device connections as defined in the MRW. It
-  is parsed into a struct in i2c.C</description>
-  <simpleType>
-    <uint8_t />
-    <array>32</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>HDAT_I2C_ELEMENTS</id>
-  <description>This attribute holds the number of elements that
-  were found under this particular target, and how many devices are
-  stored in the arrays.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>ISDIMM_MBVPD_INDEX</id>
-  <description>Multiple centaurs can sometimes have their VPD
-  located in one physical SEEPROM. This is the index into the
-  memory buffer VPD for this centaur.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hwpfToHbAttrMap>
-    <id>ATTR_ISDIMM_MBVPD_INDEX</id>
-    <macro>DIRECT</macro>
-  </hwpfToHbAttrMap>
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>IPMI_INSTANCE</id>
-  <description>Holds the IPMI instance number for this
-  entity.</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>IPMI_SENSORS</id>
-  <description>Attribute to hold 16 pairs of sensor name, sensor
-  number pairs. A sensor name consists of one byte of general
-  sensor type and one byte of sub-type</description>
-  <simpleType>
-    <uint16_t />
-    <array>16,2</array>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_DIMM_THROTTLE_TEMP_DEG_C</id>
-  <description>DIMM temperature threshold where throttling will
-  occur in degrees C</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_DIMM_ERROR_TEMP_DEG_C</id>
-  <description>DIMM temperature where an error will be generated in
-  degrees C</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_MEMCTRL_THROTTLE_TEMP_DEG_C</id>
-  <description>Memory controller temperature threshold where
-  throttling will occur in degrees C</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_PROC_WEIGHT</id>
-  <description>Weight factor (in 1/10ths) for each core DTS to
-  calculate a core temperature.</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_QUAD_WEIGHT</id>
-  <description>Weight factor (in 1/10ths) for each quad (cache) DTS
-  to calculate a core temperature.</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_PROC_DVFS_TEMP_DEG_C</id>
-  <description>Processor temperature where DVFS will occur in
-  degrees C</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_MEMCTRL_ERROR_TEMP_DEG_C</id>
-  <description>Memory controller temperature where an error will
-  occur in degrees C</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_N_BULK_POWER_LIMIT_WATTS</id>
-  <description>N mode bulk power supply limit in
-  Watts</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_N_MAX_MEM_POWER_WATTS</id>
-  <description>Maximum power allocated to DIMMs in
-  Watts</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_MEMCTRL_READ_TIMEOUT_SEC</id>
-  <description>Memory controller read timeout in
-  seconds</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_DIMM_READ_TIMEOUT_SEC</id>
-  <description>DIMM read timeout in seconds</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_PROC_ERROR_TEMP_DEG_C</id>
-  <description>Processor temperature error threshold in degrees
-  C</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_MIN_MEM_UTILIZATION_THROTTLING</id>
-  <description>Minimum memory utilization for memory
-  throttling</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_PROC_READ_TIMEOUT_SEC</id>
-  <description>Processor read timeout in seconds</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_REGULATOR_EFFICIENCY_FACTOR</id>
-  <description>Regulator efficiency factor</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_MIN_POWER_CAP_WATTS</id>
-  <description>Minimum hard power cap in Watts</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_SOFT_MIN_PCAP_WATTS</id>
-  <description>Minimum soft power cap in Watts</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_N_PLUS_ONE_BULK_POWER_LIMIT_WATTS</id>
-  <description>N+1 bulk power limit in Watts for systems running
-  with redundant power supplies (default)</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_N_PLUS_ONE_HPC_BULK_POWER_LIMIT_WATTS</id>
-  <description>N+1 bulk power limit in Watts for High Performance
-  Computing systems running with a non-redundant power supply
-  policy</description>
-  <simpleType>
-    <uint64_t>
-      <default>0</default>
-    </uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_N_PLUS_ONE_MAX_MEM_POWER_WATTS</id>
-  <description>N+1 max memory power in Watts</description>
-  <simpleType>
-    <uint64_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_TURBO_MODE_SUPPORTED</id>
-  <description>If this system supports Turbo frequency mode. 0x00 =
-  no 0x01 = yes</description>
-  <simpleType>
-    <uint8_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPAL_MODEL</id>
-  <description>Specifies the compatible model name for Opal to key
-  off of. This is sourced from the MRW and should be of the format
-  'vendor,model', e.g. 'tyan,palmetto'.</description>
-  <simpleType>
-    <string>
-      <default>ibm,miscopenpower</default>
-      <sizeInclNull>32</sizeInclNull>
-    </string>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>openpower</serverwizShow>
-</attribute>
-<enumerationType>
-  <id>CHIP_VER</id>
-  <description>Enumeration indicating the chip
-  version</description>
-  <enumerator>
-    <name>DD10</name>
-    <value>0x10</value>
-  </enumerator>
-  <enumerator>
-    <name>DD11</name>
-    <value>0x11</value>
-  </enumerator>
-  <enumerator>
-    <name>DD20</name>
-    <value>0x20</value>
-  </enumerator>
-  <enumerator>
-    <name>DD21</name>
-    <value>0x21</value>
-  </enumerator>
-  <default>DD10</default>
-</enumerationType>
-<enumerationType>
-  <id>HW_VER</id>
-  <description>Enumeration indicating the chip HW
-  version</description>
-  <enumerator>
-    <name>FSP_HW_VER</name>
-    <value>0x2</value>
-  </enumerator>
-  <enumerator>
-    <name>BMC_HW_VER</name>
-    <value>0x3</value>
-  </enumerator>
-  <default>BMC_HW_VER</default>
-</enumerationType>
-<enumerationType>
-  <id>SW_VER</id>
-  <description>Enumeration indicating the SW version</description>
-  <enumerator>
-    <name>FSP_SW_VER</name>
-    <value>0x1</value>
-  </enumerator>
-  <enumerator>
-    <name>BMC_SW_VER</name>
-    <value>0x2</value>
-  </enumerator>
-  <default>BMC_SW_VER</default>
-</enumerationType>
-<enumerationType>
-  <id>ROLE</id>
-  <description>Enumeration indicating the master's FSI
-  type</description>
-  <enumerator>
-    <name>PRIMARY</name>
-    <value>1</value>
-  </enumerator>
-  <enumerator>
-    <name>BACKUP</name>
-    <value>0</value>
-  </enumerator>
-  <default>PRIMARY</default>
-</enumerationType>
-<attribute>
-  <id>PROC_HW_TOPOLOGY</id>
-  <description>Hardware topology for HDAT creator:MRW consumer:HDAT
-  firmware notes: Hardware Topology 2 Bytes Byte 1: bit 0-3: Node
-  Id bit 4-7: Socket id inside the node bit 8-11: Proc id inside
-  socket bit 12-15:Hub Id inside proc</description>
-  <simpleType>
-    <uint16_t></uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>CHIP_VER</id>
-  <description>Attribute indicating the target's chip
-  version</description>
-  <simpleType>
-    <enumeration>
-      <id>CHIP_VER</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>HW_VER</id>
-  <description>Attribute indicating the target's hw
-  version</description>
-  <simpleType>
-    <enumeration>
-      <id>HW_VER</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>SW_VER</id>
-  <description>Attribute indicating the target's software
-  version</description>
-  <simpleType>
-    <enumeration>
-      <id>SW_VER</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>ROLE</id>
-  <description>Attribute indicating the target's role</description>
-  <simpleType>
-    <enumeration>
-      <id>ROLE</id>
-    </enumeration>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <hasStringConversion />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>PHYP_SYSTEM_TYPE</id>
-  <description>PHYP system type value for habanero and barreleye
-  (0x3015 and 0x3016 respectively). The value is updated in the
-  system xml.</description>
-  <simpleType>
-    <uint32_t></uint32_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>ASCII_VPD_LX_KEYWORD</id>
-  <description>LX keyword VPD data for HDAT module</description>
-  <simpleType>
-    <uint64_t></uint64_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <writeable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_PM_MODE</id>
-  <description>Power management mode the system should use. Valid
-  values: 1 = Nominal (default), 5 = Static Power Save (percentage
-  below nominal whose value is defined in
-  OPEN_POWER_PM_MODE_FREQ_PERCENT), 6 = Dynamic Power Save - Favor
-  Energy (DPS-FE), 10 = Dynamic Power Save - Favor Performance
-  (DPS-FP), 11 = Fixed Frequency Override - (percentage above
-  nominal whose value is defined in
-  OPEN_POWER_PM_MODE_FREQ_PERCENT)</description>
-  <simpleType>
-    <uint8_t>
-      <default>1</default>
-      <!-- Nominal -->
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>OPEN_POWER_PM_MODE_FREQ_PERCENT</id>
-  <description>Percentage from nominal that the processors should
-  run at when OPEN_POWER_PM_MODE is set to Static Power Save or
-  Fixed Frequency Override (ignored on all other modes). Unit is in
-  tenths of a percent (150 = 15.0%). Static Power Save (5):
-  percentage to decrease frequency, Fixed Frequency Override (11):
-  percentage to increase frequency</description>
-  <simpleType>
-    <uint16_t />
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>IPS_ENABLE</id>
-  <description>Indicates if Idle Power Save is enabled. This is
-  independent of the OPEN_POWER_PM_MODE (DPS and IPS can be enabled
-  at the same time). Valid Values: 0 = Disabled (default), 1 =
-  Enabled. See IPS_ENTER / IPS_EXIT attributes for IPS
-  configuration.</description>
-  <simpleType>
-    <uint8_t>
-      <default>0</default>
-      <!-- disabled -->
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>IPS_ENTER_TIME_SECONDS</id>
-  <description>When IPS is enabled, this defines the delay time in
-  seconds (between 10 and 600) to enter Idle Power
-  Save.</description>
-  <simpleType>
-    <uint16_t>
-      <default>240</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>IPS_ENTER_UTILIZATION_PERCENT</id>
-  <description>When IPS is enabled, this defines the utilization
-  threshold as a percent (between 0 and 100) to enter Idle Power
-  Save. This value should be less than
-  IPS_EXIT_UTILIZATION_PERCENT.</description>
-  <simpleType>
-    <uint8_t>
-      <default>8</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>IPS_EXIT_TIME_SECONDS</id>
-  <description>When IPS is enabled, this defines the delay time in
-  seconds (between 10 and 600) to exit Idle Power
-  Save.</description>
-  <simpleType>
-    <uint16_t>
-      <default>10</default>
-    </uint16_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute>
-<attribute>
-  <id>IPS_EXIT_UTILIZATION_PERCENT</id>
-  <description>When IPS is enabled, this defines the utilization
-  threshold as a percent (between 0 and 100) to exit Idle Power
-  Save. This value should be greater than
-  IPS_ENTER_UTILIZATION_PERCENT.</description>
-  <simpleType>
-    <uint8_t>
-      <default>12</default>
-    </uint8_t>
-  </simpleType>
-  <persistency>non-volatile</persistency>
-  <readable />
-  <serverwizShow>oppowervm</serverwizShow>
-</attribute></attributes>
+  <attribute>
+    <id>PROC_R_LOADLINE_VDD_UOHM</id>
+    <description>Impedance (binary microOhms) of the load line from
+    a processor VDD VRM to the Processor Module pins. This value is
+    applied to each processor instance. Producer: Machine Readable
+    Workbook (per the power subsystem design) Consumers:
+    p9_pstate_parameter_block</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_R_LOADLINE_VDD_UOHM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_R_DISTLOSS_VDD_UOHM</id>
+    <description>Impedance (binary in microOhms) of the VDD
+    distribution loss sense point to the circuit. This value is
+    applied to each processor instance. Producer: Machine Readable
+    Workbook (per the power subsystem design) Consumers:
+    p9_pstate_parameter_block</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_R_DISTLOSS_VDD_UOHM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_VRM_VOFFSET_VDD_UV</id>
+    <description>Offset voltage (binary in microvolts) to apply to
+    the VDD VRM distribution to the processor module. This value is
+    applied to each processor instance. Note: no loadline may be
+    present in the system; thus, a value of 0 is legal. Producer:
+    Machine Readable Workbook (per the power subsystem design)
+    Consumers: p9_pstate_parameter_block</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_VRM_VOFFSET_VDD_UV</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_R_LOADLINE_VDN_UOHM</id>
+    <description>Impedance (binary microOhms) of the load line from
+    a processor VDN VRM to the Processor Module pins. This value is
+    applied to each processor instance. Note: no loadline may be
+    present in the system; thus, a value of 0 is legal. Producer:
+    Machine Readable Workbook (per the power subsystem design)
+    Consumers: p9_pstate_parameter_block</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_R_LOADLINE_VDN_UOHM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_R_DISTLOSS_VDN_UOHM</id>
+    <description>Impedance (binary in microOhms) of the VDN
+    distribution loss sense point to the circuit. This value is
+    applied to each processor instance. Producer: Machine Readable
+    Workbook (per the power subsystem design) Consumers:
+    p9_pstate_parameter_block</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_R_DISTLOSS_VDN_UOHM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_VRM_VOFFSET_VDN_UV</id>
+    <description>Offset voltage (binary in microvolts) to apply to
+    the VDN VRM distribution to the processor module. This value is
+    applied to each processor instance. Producer: Machine Readable
+    Workbook (per the power subsystem design) Consumers:
+    p9_pstate_parameter_block</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_VRM_VOFFSET_VDN_UV</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_R_LOADLINE_VCS_UOHM</id>
+    <description>Impedance (binary microOhms) of the load line from
+    a processor VCS VRM to the Processor Module pins. This value is
+    applied to each processor instance. Note: no loadline may be
+    present in the system; thus, a value of 0 is legal. Producer:
+    Machine Readable Workbook (per the power subsystem design)
+    Consumers: p9_pstate_parameter_block</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_R_LOADLINE_VCS_UOHM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_R_DISTLOSS_VCS_UOHM</id>
+    <description>Impedance (binary in microOhms) of the VCS
+    distribution loss sense point to the circuit. This value is
+    applied to each processor instance. Producer: Machine Readable
+    Workbook (via the power subsystem design per system) Consumer:
+    p9_pstate_parameter_block</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_R_DISTLOSS_VCS_UOHM</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_VRM_VOFFSET_VCS_UV</id>
+    <description>Offset voltage (binary in microvolts) to apply to
+    the VCS VRM distribution to the processor module. This value is
+    applied to each processor instance. Producer: Machine Readable
+    Workbook (via the power subsystem design per system) Consumer:
+    FSP</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PROC_VRM_VOFFSET_VCS_UV</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IVRM_DEADZONE_MV</id>
+    <description>Indicates the size of the deadzone where the iVRM
+    cannot regulate (binary in millivolts) Producer:
+    MRWB.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IVRM_DEADZONE_MV</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>TDP_RDP_CURRENT_FACTOR</id>
+    <description>TODO RTC 157943 -- Placeholder description
+    Consumers: p9_pstate_parameter_block</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_TDP_RDP_CURRENT_FACTOR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_SAFE_FREQUENCY_MHZ</id>
+    <description>Frequency (in MHz) to move to if the Power
+    Management function fails. This is the same for all cores in
+    the system. Provided by the MRW.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_SAFE_FREQUENCY_MHZ</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR4</id>
+    <description>Machine Readable Workbook VMEM regulator power
+    limit per DIMM assuming a full configuration. Units in cW
+    Consumed in mss_eff_config_thermal</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x000006A4</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>
+      ATTR_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR4</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR3</id>
+    <description>Machine Readable Workbook VMEM regulator power
+    limit per CDIMM assuming a full configuration. Units in cW Used
+    for Cumulus Consumed in mss_eff_config_thermal</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>
+      ATTR_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR3</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>SYSTEM_FAMILY</id>
+    <description>This field is of the form "vendor,name" where the
+    name indicates the family of the systems. The textual portion
+    of the string has a maximum length of 63 characters to
+    accommodate a terminating NULL. Both vendor and name fields are
+    lower case US ASCII. No special characters other than ",", "-",
+    and "+" as described below should be used in the
+    string.</description>
+    <simpleType>
+      <string>
+        <default>ibm,p9</default>
+        <sizeInclNull>64</sizeInclNull>
+      </string>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>SYSTEM_TYPE</id>
+    <description>This field is of the form ?vendor,type? where the
+    type indicates a type of system within the System Family. The
+    textual portion of the string has a maximum length of 63
+    characters to accommodate a terminating NULL. Both vendor and
+    name fields are lower case US ASCII. No special characters
+    other than ",", "-", and "+" as described below should be used
+    in the string. If identification of specific models within a
+    system type is desired, "-model" should be appended to the end
+    of the name. The "-model" portion is optional and could be used
+    to identify the packaging, specific model numbers, etc. NOTE:
+    No Hostboot code should ever key off of this
+    value.</description>
+    <simpleType>
+      <string>
+        <default>ibm,miscopenpower</default>
+        <sizeInclNull>64</sizeInclNull>
+      </string>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>SUPPORTED_STOP_STATES</id>
+    <description>STOP levels supported at runtime (sent to Host via
+    HDAT): Bit 0: STOP0 Supported - Quiesce thread only Bit 1:
+    STOP1 Supported - P8 Nap Bit 2: STOP2 Supported - P8 Fast Sleep
+    Bit 3: STOP3 Supported - P8 Fast Sleep using iVRMs Bit 4: STOP4
+    supported - P8 Deep Sleep Bit 5: STOP5 Supported - WOF-friendly
+    "Instant on" Bit 6,7: Reserved Bit 8: STOP8 supported - Half
+    Quad Sleep Bit 9: STOP9 supported - P8 Fast Winkle Bit 10:
+    Reserved Bit 11: STOP11 supported - P8 Deep Winkle Bit 12-15 :
+    Reserved Bits 16..31 - Reserved</description>
+    <simpleType>
+      <uint32_t>
+        <default>0xEC900000</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>SBE_IMAGE_MINIMUM_VALID_ECS</id>
+    <description>The minimum number of valid ECs that is required
+    to be used when customizing an SBE image. The customization
+    will fail if it cannot create an image with at least this many
+    ECs.</description>
+    <simpleType>
+      <uint8_t>
+        <default>2</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_SBE_IMAGE_MINIMUM_VALID_ECS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>REL_POS</id>
+    <description>Logical position of this unit/dimm relative to its
+    immediate parent</description>
+    <simpleType>
+      <uint8_t>
+        <default>0xFF</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_REL_POS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
+    <description>PCIE Lane Equalization values for each PHB
+    Creator: MRW Purpose: Holds settings which are loaded into the
+    HW to optimize the PCIE lane signal eye between the chips +
+    PCIE Gen3 endpoints Data Format: 16 entries of 16 bytes of EQ
+    data per PHB. Each PHB has an EQ value for each of its 16
+    lanes. Each value is a uint16 formatted as follows: Bit 0:3 -
+    up_rx_hint (bit 0 reserved) Bit 4:7 - up_tx_preset Bit 8:11 -
+    dn_rx_hint (bit 0 reserved) Bit 12:15 -
+    dn_tx_preset</description>
+    <simpleType>
+      <uint16_t>
+        <default>0x7777,0x7777,0x7777,0x7777,
+        0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777,
+        0x7777,0x7777,0x7777,0x7777</default>
+      </uint16_t>
+      <array>16</array>
+      <!-- Lane -->
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
+    <description>PCIE Lane Equalization values for each PHB
+    Creator: MRW Purpose: Holds settings which are loaded into the
+    HW to optimize the PCIE lane signal eye between the chips +
+    PCIE Gen4 endpoints Data Format: 16 entries of 16 bytes of EQ
+    data per PHB. Each PHB has an EQ value for each of its 16
+    lanes. Each value is a uint16 formatted as follows: Bit 0:3 -
+    up_rx_hint (bit 0 reserved) Bit 4:7 - up_tx_preset Bit 8:11 -
+    dn_rx_hint (bit 0 reserved) Bit 12:15 -
+    dn_tx_preset</description>
+    <simpleType>
+      <uint16_t>
+        <default>0x7777,0x7777,0x7777,0x7777,
+        0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777,
+        0x7777,0x7777,0x7777,0x7777</default>
+      </uint16_t>
+      <array>16</array>
+      <!-- Lane -->
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>SBE_SYS_CONFIG</id>
+    <description>System Configuration information - 1 indicates a
+    chip present</description>
+    <simpleType>
+      <uint64_t>
+        <default>0x0</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_SBE_SYS_CONFIG</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_PWR_INTERCEPT</id>
+    <description>Machine Readable Workbook Power Curve Intercept
+    for DIMM Used to get the VDDR and VDDR+VPP power curve for each
+    DIMM Decoded and used to set ATTR_MSS_TOTAL_PWR_INTERCEPT Key
+    Value pair KEY (0-19): In order DIMM_SIZE = bits 0-3, DIMM_GEN
+    = 4-5, DIMM_TYPE = 6-7, DIMM_WIDTH = 8-9, DIMM_DENSITY = 10-12,
+    DIMM_STACK_TYPE = 13-14, DRAM_MFGID = 15-16, DIMMS_PER_PORT =
+    17-18, Bits 19-32: Not used VALUE (bits 32-63) in cW: VMEM
+    power curve = 32-47 VMEM+VPP power curve = 48-63 Consumers:
+    eff_config_thermal</description>
+    <simpleType>
+      <uint64_t>
+        <default>
+        0xffffe00002CC03AE,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0</default>
+      </uint64_t>
+      <array>100</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_PWR_INTERCEPT</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_PWR_SLOPE</id>
+    <description>Machine Readable Workbook Power Curve Slope for
+    DIMM Used to get the VDDR and VDDR+VPP power curve for each
+    DIMM Decoded and used to set ATTR_MSS_TOTAL_PWR_INTERCEPT Key
+    Value pair KEY (0-19): In order DIMM_SIZE = bits 0-3, DIMM_GEN
+    = 4-5, DIMM_TYPE = 6-7, DIMM_WIDTH = 8-9, DIMM_DENSITY = 10-12,
+    DIMM_STACK_TYPE = 13-14, DRAM_MFGID = 15-16, DIMMS_PER_PORT =
+    17-18, Bits 19-32: Not used VALUE (bits 32-63) in cW: VMEM
+    power curve = 32-47 VMEM+VPP power curve = 48-63 Consumers:
+    eff_config_thermal</description>
+    <simpleType>
+      <uint64_t>
+        <default>
+        0xffffe00003FD0546,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0</default>
+      </uint64_t>
+      <array>100</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_PWR_SLOPE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>MSS_MRW_REFRESH_RATE_REQUEST</id>
+    <description>Machine Readable Workbook Refresh Rate Desired
+    refresh interval used in refresh register 0,
+    MBAREF0Q_CFG_REFRESH_INTERVAL 7.8 us (SINGLE) 3.9 us (DOUBLE)
+    7.02 us (SINGLE_10_PERCENT_FASTER) 3.51 us
+    (DOUBLE_10_PERCENT_FASTER)</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_REFRESH_RATE_REQUEST</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PM_SAFE_VOLTAGE_MV</id>
+    <description>Voltage (in mV) to move to if the Power Management
+    function fails. Provided by the MRW.</description>
+    <simpleType>
+      <uint32_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PM_SAFE_VOLTAGE_MV</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IVRM_STRENGTH_LOOKUP</id>
+    <description>Producer: MRWB.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+      <array>64</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IVRM_STRENGTH_LOOKUP</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IVRM_VIN_MULTIPLIER</id>
+    <description>Producer: MRWB.</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+      <array>64</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IVRM_VIN_MULTIPLIER</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IVRM_VIN_MAX_MV</id>
+    <description>Producer: MRWB.</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IVRM_VIN_MAX_MV</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IVRM_STEP_DELAY_NS</id>
+    <description>Producer: MRWB.</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IVRM_STEP_DELAY_NS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>IVRM_STABILIZATION_DELAY_NS</id>
+    <description>Producer: MRWB.</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IVRM_STABILIZATION_DELAY_NS</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>SYSTEM_RESCLK_ENABLE</id>
+    <description>Controls the enablement of resonant clocking in
+    the system. Producer: Machine Readable Workbook Consumers:
+    p9_pstate_parameter_block to set flag for CME QuadManager Hcode
+    reaction</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_SYSTEM_RESCLK_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>ORDINAL_ID</id>
+    <description>Ordinal ID of a target</description>
+    <simpleType>
+      <uint32_t>
+        <default>0xFFFFFFFF</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+  </attribute>
+  <attribute>
+    <id>POUND_W_STATIC_DATA_ENABLE</id>
+    <description>Enables pstate parameter block code to use the
+    static #W data Consumer: p9_pstate_parameter_block.C -&gt;
+    Platform default: OFF=0</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_POUND_W_STATIC_DATA_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>PGPE_HCODE_FUNCTION_ENABLE</id>
+    <description>Enables the PGPE Hcode to physically perform
+    frequency and voltage operations based on constructed
+    parameters (eg #V VPD, system parameters, biases, WPF VFRTs.
+    etc). If OFF, the PGPE provides an immedicate good response to
+    all Pstate/WOF IPC operations from the OCC for firmware
+    integration testing purposes. Consumer: p9_hcode_image_build.c
+    -&gt; PGPE Header field Platform default: OFF</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_PGPE_HCODE_FUNCTION_ENABLE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
+    <id>XIVE_HW_RESET</id>
+    <description>Used to tell INTRP code whether to use the XIVE HW
+    Reset or a software based reset. 0 = Software based reset 1 =
+    XIVE HW reset</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MAX_SBE_SEEPROM_SIZE</id>
+    <description>Defines the maximum Seeprom storage size for the
+    fully-customized SBE image permitted by the platform. For
+    platforms (FSP/HB FW) which require the image to be constrained
+    into a physical storage device (SEEPROM), this should reflect
+    the maximum size of that memory (e.g., 256KB). For platforms
+    (Cronus) which may use a customized image in a virtual
+    envrionment with no physical storage constraints, this size may
+    be larger than the physical SEEPROM size.</description>
+    <simpleType>
+      <uint32_t>
+        <default>0x40000</default>
+      </uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MAX_SBE_SEEPROM_SIZE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <!-- @fixme RTC:166754 Remove old attribute -->
+  <!-- @fixme RTC:166754 Remove old attribute -->
+  <attribute>
+    <id>DISABLE_I2C_ENGINE2_PORT0_DIAG_MODE</id>
+    <description>Used to tell I2C code whether to run I2C Engine 2
+    Port 0 in diag mode or not 0 = Use Diag Mode 1 = Disable Diag
+    Mode</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <enumerationType>
+    <id>MSS_MRW_TEMP_REFRESH_MODE</id>
+    <description>Enumeration for Temperature refresh
+    mode</description>
+    <enumerator>
+      <name>DISABLE</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>ENABLE</name>
+      <value>1</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>MSS_MRW_TEMP_REFRESH_MODE</id>
+    <description>Used in MR4 A3 Temperature refresh mode Should be
+    defaulted to disable</description>
+    <simpleType>
+      <uint8_t>
+        <default>DISABLE</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_MSS_MRW_TEMP_REFRESH_MODE</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <enumerationType>
+    <id>HDAT_I2C_DEVICE_TYPE</id>
+    <description>Pulled from the MRW, this describes the device
+    type to the HDAT. This is for I2C devices only.</description>
+    <enumerator>
+      <name>955X</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>SEEPROM</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>NUVOTON_TPM</name>
+      <value>3</value>
+    </enumerator>
+    <enumerator>
+      <name>MEX_FPGA</name>
+      <value>4</value>
+    </enumerator>
+    <enumerator>
+      <name>UCX90XX</name>
+      <value>5</value>
+    </enumerator>
+    <enumerator>
+      <name>NVLINK</name>
+      <value>6</value>
+    </enumerator>
+    <enumerator>
+      <name>UNKNOWN</name>
+      <value>FF</value>
+    </enumerator>
+  </enumerationType>
+  <enumerationType>
+    <id>HDAT_I2C_DEVICE_PURPOSE</id>
+    <description>Pulled from the MRW, this describes the device
+    purpose to the HDAT. This is for I2C devices
+    only.</description>
+    <enumerator>
+      <name>CABLE_CARD_PRES</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>CABLE_CARD_POWER_SENSE</name>
+      <value>2</value>
+    </enumerator>
+    <enumerator>
+      <name>CABLE_CARD_POWER_CONTROL</name>
+      <value>3</value>
+    </enumerator>
+    <enumerator>
+      <name>TPM</name>
+      <value>4</value>
+    </enumerator>
+    <enumerator>
+      <name>MODULE_VPD</name>
+      <value>5</value>
+    </enumerator>
+    <enumerator>
+      <name>DIMM_SPD</name>
+      <value>6</value>
+    </enumerator>
+    <enumerator>
+      <name>PROC_MODULE_VPD</name>
+      <value>7</value>
+    </enumerator>
+    <enumerator>
+      <name>SBE_SEEPROM</name>
+      <value>8</value>
+    </enumerator>
+    <enumerator>
+      <name>PLANAR_VPD</name>
+      <value>9</value>
+    </enumerator>
+    <enumerator>
+      <name>PCI_HOTPLUG</name>
+      <value>A</value>
+    </enumerator>
+    <enumerator>
+      <name>NVLINK</name>
+      <value>B</value>
+    </enumerator>
+    <enumerator>
+      <name>WINDOW_OPEN</name>
+      <value>0xD</value>
+    </enumerator>
+    <enumerator>
+      <name>PHYSICAL_PRESENCE</name>
+      <value>0xE</value>
+    </enumerator>
+    <enumerator>
+      <name>UNKNOWN</name>
+      <value>FF</value>
+    </enumerator>
+  </enumerationType>
+  <enumerationType>
+    <id>IPMI_SENSOR_ARRAY</id>
+    <description>Enumeration defining the offsets into the
+    IPMI_SENSORS array.</description>
+    <enumerator>
+      <name>NAME_OFFSET</name>
+      <value>0x00</value>
+    </enumerator>
+    <enumerator>
+      <name>NUMBER_OFFSET</name>
+      <value>0x01</value>
+    </enumerator>
+  </enumerationType>
+  <enumerationType>
+    <id>SENSOR_NAME</id>
+    <description>Enumeration indicating the IPMI sensor name, which
+    will be used by hostboot when determining the sensor number to
+    return. he sensor name consists of one byte of sensor type plus
+    one byte of sub-type, to differentiate similar sensors under
+    the same target. Our implementaion uses the IPMI defined entity
+    ID as the sub-type.</description>
+    <enumerator>
+      <name>PROC_TEMP</name>
+      <value>0x0103</value>
+    </enumerator>
+    <enumerator>
+      <name>DIMM_TEMP</name>
+      <value>0x0120</value>
+    </enumerator>
+    <enumerator>
+      <name>CORE_TEMP</name>
+      <value>0x01D0</value>
+    </enumerator>
+    <enumerator>
+      <name>STATE</name>
+      <value>0x0500</value>
+    </enumerator>
+    <enumerator>
+      <name>MEMBUF_TEMP</name>
+      <value>0x01D1</value>
+    </enumerator>
+    <enumerator>
+      <name>PROC_STATE</name>
+      <value>0x0703</value>
+    </enumerator>
+    <enumerator>
+      <name>CORE_STATE</name>
+      <value>0x07D0</value>
+    </enumerator>
+    <enumerator>
+      <name>DIMM_STATE</name>
+      <value>0x0C20</value>
+    </enumerator>
+    <enumerator>
+      <name>MEMBUF_STATE</name>
+      <value>0x0CD1</value>
+    </enumerator>
+    <enumerator>
+      <name>FW_BOOT_PROGRESS</name>
+      <value>0x0F22</value>
+    </enumerator>
+    <enumerator>
+      <name>SYSTEM_EVENT</name>
+      <value>0x1201</value>
+    </enumerator>
+    <enumerator>
+      <name>OS_BOOT</name>
+      <value>0x1F23</value>
+    </enumerator>
+    <enumerator>
+      <name>HOST_STATUS</name>
+      <value>0x2223</value>
+    </enumerator>
+    <enumerator>
+      <name>OCC_ACTIVE</name>
+      <value>0x07D2</value>
+    </enumerator>
+    <enumerator>
+      <name>CORE_FREQ</name>
+      <value>0xC1D0</value>
+    </enumerator>
+    <enumerator>
+      <name>APSS_CHANNEL</name>
+      <value>0xC2D7</value>
+    </enumerator>
+    <enumerator>
+      <name>PCI_ACTIVE</name>
+      <value>0xC423</value>
+    </enumerator>
+    <enumerator>
+      <name>REBOOT_COUNT</name>
+      <value>0xC322</value>
+    </enumerator>
+    <enumerator>
+      <name>FAULT</name>
+      <value>0xC700</value>
+    </enumerator>
+    <enumerator>
+      <name>BACKPLANE_FAULT</name>
+      <value>0xC707</value>
+    </enumerator>
+    <enumerator>
+      <name>REF_CLOCK_FAULT</name>
+      <value>0xC7D4</value>
+    </enumerator>
+    <enumerator>
+      <name>PCI_CLOCK_FAULT</name>
+      <value>0xC7D5</value>
+    </enumerator>
+    <enumerator>
+      <name>TOD_CLOCK_FAULT</name>
+      <value>0xC7D6</value>
+    </enumerator>
+    <enumerator>
+      <name>APSS_FAULT</name>
+      <value>0xC7D7</value>
+    </enumerator>
+    <enumerator>
+      <name>DERATING_FACTOR</name>
+      <value>0xC815</value>
+    </enumerator>
+    <enumerator>
+      <name>REDUNDANT_PS_POLICY</name>
+      <value>0xCA22</value>
+    </enumerator>
+    <enumerator>
+      <name>TPM_REQUIRED</name>
+      <value>0xFFFF</value>
+    </enumerator>
+  </enumerationType>
+  <enumerationType>
+    <id>ENTITY_ID</id>
+    <description>Enumeration indicating the IPMI entity ID, these
+    values are defined in the IPMI specification. These values will
+    be used in place of target type when events are sent to the
+    BMC.</description>
+    <enumerator>
+      <name>NA</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>OTHER</name>
+      <value>0x01</value>
+    </enumerator>
+    <enumerator>
+      <name>PROCESSOR</name>
+      <value>0x03</value>
+    </enumerator>
+    <enumerator>
+      <name>SYSTEM_BOARD</name>
+      <value>0x07</value>
+    </enumerator>
+    <enumerator>
+      <name>POWER_MGMT</name>
+      <value>0x15</value>
+    </enumerator>
+    <enumerator>
+      <name>CHASSIS</name>
+      <value>0x17</value>
+    </enumerator>
+    <enumerator>
+      <name>MEMORY_DEVICE</name>
+      <value>0x20</value>
+    </enumerator>
+    <enumerator>
+      <name>BIOS</name>
+      <value>0x22</value>
+    </enumerator>
+    <enumerator>
+      <name>OS</name>
+      <value>0x23</value>
+    </enumerator>
+    <enumerator>
+      <name>CORE</name>
+      <value>0xD0</value>
+    </enumerator>
+    <enumerator>
+      <name>MEMBUF</name>
+      <value>0xD1</value>
+    </enumerator>
+    <enumerator>
+      <name>OCC</name>
+      <value>0xD2</value>
+    </enumerator>
+    <enumerator>
+      <name>REF_CLOCK</name>
+      <value>0xD4</value>
+    </enumerator>
+    <enumerator>
+      <name>PCI_CLOCK</name>
+      <value>0xD5</value>
+    </enumerator>
+    <enumerator>
+      <name>TOD_CLOCK</name>
+      <value>0xD6</value>
+    </enumerator>
+    <enumerator>
+      <name>APSS</name>
+      <value>0xD7</value>
+    </enumerator>
+  </enumerationType>
+  <enumerationType>
+    <id>SENSOR_TYPE</id>
+    <description>Enumeration indicating the IPMI sensor type, these
+    values are defined in the IPMI specification. These values will
+    be used when sending sensor reading events to the
+    BMC.</description>
+    <enumerator>
+      <name>NA</name>
+      <value>0</value>
+    </enumerator>
+    <enumerator>
+      <name>TEMPERATURE</name>
+      <value>0x01</value>
+    </enumerator>
+    <enumerator>
+      <name>PROCESSOR</name>
+      <value>0x07</value>
+    </enumerator>
+    <enumerator>
+      <name>MEMORY</name>
+      <value>0x0c</value>
+    </enumerator>
+    <enumerator>
+      <name>SYS_FW_PROGRESS</name>
+      <value>0x0F</value>
+    </enumerator>
+    <enumerator>
+      <name>SYS_EVENT</name>
+      <value>0x12</value>
+    </enumerator>
+    <enumerator>
+      <name>OS_BOOT</name>
+      <value>0x1F</value>
+    </enumerator>
+    <enumerator>
+      <name>APCI_POWER_STATE</name>
+      <value>0x22</value>
+    </enumerator>
+    <enumerator>
+      <name>FREQ</name>
+      <value>0xC1</value>
+    </enumerator>
+    <enumerator>
+      <name>POWER</name>
+      <value>0xC2</value>
+    </enumerator>
+    <enumerator>
+      <name>BOOT_COUNT</name>
+      <value>0xC3</value>
+    </enumerator>
+    <enumerator>
+      <name>PCI_LINK_PRES</name>
+      <value>0xC4</value>
+    </enumerator>
+    <enumerator>
+      <name>PWR_LIMIT_ACTIVE</name>
+      <value>0xC4</value>
+    </enumerator>
+    <enumerator>
+      <name>FAULT</name>
+      <value>0xC7</value>
+    </enumerator>
+  </enumerationType>
+  <attribute>
+    <id>ADC_CHANNEL_FUNC_IDS</id>
+    <description>ADC Channel function id. 16
+    channels.</description>
+    <simpleType>
+      <uint8_t />
+      <array>16</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>ADC_CHANNEL_SENSOR_NUMBERS</id>
+    <description>ADC Channel IPMI sensor numbers. 16
+    channels.</description>
+    <simpleType>
+      <uint32_t />
+      <array>16</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>ADC_CHANNEL_GNDS</id>
+    <description>ADC Channel ground. 16 channels.</description>
+    <simpleType>
+      <uint8_t />
+      <array>16</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>ADC_CHANNEL_GAINS</id>
+    <description>ADC channel gain * 1000. 16
+    channels.</description>
+    <simpleType>
+      <uint32_t />
+      <array>16</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>ADC_CHANNEL_OFFSETS</id>
+    <description>ADC channel offset * 1000. 16
+    channels</description>
+    <simpleType>
+      <uint32_t />
+      <array>16</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>APSS_GPIO_PORT_MODES</id>
+    <description>APSS GPIO PORT MODES</description>
+    <simpleType>
+      <uint8_t />
+      <array>2</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>APSS_GPIO_PORT_PINS</id>
+    <description>APSS GPIO PORT PINS Port0 pin 0-7 Port1 pin
+    8-15</description>
+    <simpleType>
+      <uint8_t />
+      <array>16</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>GPIO_INFO</id>
+    <description>Information needed to address GPIO
+    device</description>
+    <complexType>
+      <description>Structure to define the addessing for an I2C
+      slave device.</description>
+      <field>
+        <name>i2cMasterPath</name>
+        <description>Entity path to the chip that contains the I2C
+        master</description>
+        <type>EntityPath</type>
+        <default>physical:sys-0</default>
+      </field>
+      <field>
+        <name>port</name>
+        <description>Port from the I2C Master device. This is a
+        6-bit value.</description>
+        <type>uint8_t</type>
+        <default>0</default>
+      </field>
+      <field>
+        <name>devAddr</name>
+        <description>Device address on the I2C bus. This is a 7-bit
+        value, but then shifted 1 bit left.</description>
+        <type>uint8_t</type>
+        <default>0</default>
+      </field>
+      <field>
+        <name>engine</name>
+        <description>I2C master engine. This is a 2-bit
+        value.</description>
+        <type>uint8_t</type>
+        <default>0</default>
+      </field>
+      <field>
+        <name>vddrPin</name>
+        <description>Logical GPIO pin number used to
+        enabled/disable VDDR</description>
+        <type>uint8_t</type>
+        <default>0</default>
+      </field>
+    </complexType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>HDAT_I2C_ENGINE</id>
+    <description>This attribute holds the values of the I2C Engine
+    from the i2c device connections as defined in the MRW. It is
+    parsed into a struct in i2c.C</description>
+    <simpleType>
+      <uint8_t />
+      <array>32</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>HDAT_I2C_MASTER_PORT</id>
+    <description>This attribute holds the values of the I2C Master
+    Port from the i2c device connections as defined in the MRW. It
+    is parsed into a struct in i2c.C</description>
+    <simpleType>
+      <uint8_t />
+      <array>32</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>HDAT_I2C_DEVICE_TYPE</id>
+    <description>This attribute holds the values of the I2C device
+    type from the i2c device connections as defined in the MRW. It
+    is parsed into a struct in i2c.C</description>
+    <simpleType>
+      <uint8_t />
+      <array>32</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>HDAT_I2C_ADDR</id>
+    <description>This attribute holds the values of the I2C address
+    from the i2c device connections as defined in the MRW. It is
+    parsed into a struct in i2c.C</description>
+    <simpleType>
+      <uint8_t />
+      <array>32</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>HDAT_I2C_SLAVE_PORT</id>
+    <description>This attribute holds the values of the I2C slave
+    port from the i2c device connections as defined in the MRW. It
+    is parsed into a struct in i2c.C</description>
+    <simpleType>
+      <uint8_t />
+      <array>32</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>HDAT_I2C_BUS_FREQ</id>
+    <description>This attribute holds the values of the I2C bus
+    frequency in Hz from the i2c device connections as defined in
+    the MRW. It is parsed into a struct in i2c.C</description>
+    <simpleType>
+      <uint8_t />
+      <array>32</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>HDAT_I2C_DEVICE_PURPOSE</id>
+    <description>This attribute holds the values of the I2C device
+    purpose from the i2c device connections as defined in the MRW.
+    It is parsed into a struct in i2c.C</description>
+    <simpleType>
+      <uint8_t />
+      <array>32</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>HDAT_I2C_ELEMENTS</id>
+    <description>This attribute holds the number of elements that
+    were found under this particular target, and how many devices
+    are stored in the arrays.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>ISDIMM_MBVPD_INDEX</id>
+    <description>Multiple centaurs can sometimes have their VPD
+    located in one physical SEEPROM. This is the index into the
+    memory buffer VPD for this centaur.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_ISDIMM_MBVPD_INDEX</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>IPMI_INSTANCE</id>
+    <description>Holds the IPMI instance number for this
+    entity.</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>IPMI_SENSORS</id>
+    <description>Attribute to hold 16 pairs of sensor name, sensor
+    number pairs. A sensor name consists of one byte of general
+    sensor type and one byte of sub-type</description>
+    <simpleType>
+      <uint16_t />
+      <array>16,2</array>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_DIMM_THROTTLE_TEMP_DEG_C</id>
+    <description>DIMM temperature threshold where throttling will
+    occur in degrees C</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_DIMM_ERROR_TEMP_DEG_C</id>
+    <description>DIMM temperature where an error will be generated
+    in degrees C</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_MEMCTRL_THROTTLE_TEMP_DEG_C</id>
+    <description>Memory controller temperature threshold where
+    throttling will occur in degrees C</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_PROC_WEIGHT</id>
+    <description>Weight factor (in 1/10ths) for each core DTS to
+    calculate a core temperature.</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_QUAD_WEIGHT</id>
+    <description>Weight factor (in 1/10ths) for each quad (cache)
+    DTS to calculate a core temperature.</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_PROC_DVFS_TEMP_DEG_C</id>
+    <description>Processor temperature where DVFS will occur in
+    degrees C</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_MEMCTRL_ERROR_TEMP_DEG_C</id>
+    <description>Memory controller temperature where an error will
+    occur in degrees C</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_N_BULK_POWER_LIMIT_WATTS</id>
+    <description>N mode bulk power supply limit in
+    Watts</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_N_MAX_MEM_POWER_WATTS</id>
+    <description>Maximum power allocated to DIMMs in
+    Watts</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_MEMCTRL_READ_TIMEOUT_SEC</id>
+    <description>Memory controller read timeout in
+    seconds</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_DIMM_READ_TIMEOUT_SEC</id>
+    <description>DIMM read timeout in seconds</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_PROC_ERROR_TEMP_DEG_C</id>
+    <description>Processor temperature error threshold in degrees
+    C</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_MIN_MEM_UTILIZATION_THROTTLING</id>
+    <description>Minimum memory utilization for memory
+    throttling</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_PROC_READ_TIMEOUT_SEC</id>
+    <description>Processor read timeout in seconds</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_REGULATOR_EFFICIENCY_FACTOR</id>
+    <description>Regulator efficiency factor</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_MIN_POWER_CAP_WATTS</id>
+    <description>Minimum hard power cap in Watts</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_SOFT_MIN_PCAP_WATTS</id>
+    <description>Minimum soft power cap in Watts</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_N_PLUS_ONE_BULK_POWER_LIMIT_WATTS</id>
+    <description>N+1 bulk power limit in Watts for systems running
+    with redundant power supplies (default)</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_N_PLUS_ONE_HPC_BULK_POWER_LIMIT_WATTS</id>
+    <description>N+1 bulk power limit in Watts for High Performance
+    Computing systems running with a non-redundant power supply
+    policy</description>
+    <simpleType>
+      <uint64_t>
+        <default>0</default>
+      </uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_N_PLUS_ONE_MAX_MEM_POWER_WATTS</id>
+    <description>N+1 max memory power in Watts</description>
+    <simpleType>
+      <uint64_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_TURBO_MODE_SUPPORTED</id>
+    <description>If this system supports Turbo frequency mode. 0x00
+    = no 0x01 = yes</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPAL_MODEL</id>
+    <description>Specifies the compatible model name for Opal to
+    key off of. This is sourced from the MRW and should be of the
+    format 'vendor,model', e.g. 'tyan,palmetto'.</description>
+    <simpleType>
+      <string>
+        <default>ibm,miscopenpower</default>
+        <sizeInclNull>32</sizeInclNull>
+      </string>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>openpower</serverwizShow>
+  </attribute>
+  <enumerationType>
+    <id>CHIP_VER</id>
+    <description>Enumeration indicating the chip
+    version</description>
+    <enumerator>
+      <name>DD10</name>
+      <value>0x10</value>
+    </enumerator>
+    <enumerator>
+      <name>DD11</name>
+      <value>0x11</value>
+    </enumerator>
+    <enumerator>
+      <name>DD20</name>
+      <value>0x20</value>
+    </enumerator>
+    <enumerator>
+      <name>DD21</name>
+      <value>0x21</value>
+    </enumerator>
+    <default>DD10</default>
+  </enumerationType>
+  <enumerationType>
+    <id>HW_VER</id>
+    <description>Enumeration indicating the chip HW
+    version</description>
+    <enumerator>
+      <name>FSP_HW_VER</name>
+      <value>0x2</value>
+    </enumerator>
+    <enumerator>
+      <name>BMC_HW_VER</name>
+      <value>0x3</value>
+    </enumerator>
+    <default>BMC_HW_VER</default>
+  </enumerationType>
+  <enumerationType>
+    <id>SW_VER</id>
+    <description>Enumeration indicating the SW
+    version</description>
+    <enumerator>
+      <name>FSP_SW_VER</name>
+      <value>0x1</value>
+    </enumerator>
+    <enumerator>
+      <name>BMC_SW_VER</name>
+      <value>0x2</value>
+    </enumerator>
+    <default>BMC_SW_VER</default>
+  </enumerationType>
+  <enumerationType>
+    <id>ROLE</id>
+    <description>Enumeration indicating the master's FSI
+    type</description>
+    <enumerator>
+      <name>PRIMARY</name>
+      <value>1</value>
+    </enumerator>
+    <enumerator>
+      <name>BACKUP</name>
+      <value>0</value>
+    </enumerator>
+    <default>PRIMARY</default>
+  </enumerationType>
+  <attribute>
+    <id>PROC_HW_TOPOLOGY</id>
+    <description>Hardware topology for HDAT creator:MRW
+    consumer:HDAT firmware notes: Hardware Topology 2 Bytes Byte 1:
+    bit 0-3: Node Id bit 4-7: Socket id inside the node bit 8-11:
+    Proc id inside socket bit 12-15:Hub Id inside
+    proc</description>
+    <simpleType>
+      <uint16_t></uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>CHIP_VER</id>
+    <description>Attribute indicating the target's chip
+    version</description>
+    <simpleType>
+      <enumeration>
+        <id>CHIP_VER</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>HW_VER</id>
+    <description>Attribute indicating the target's hw
+    version</description>
+    <simpleType>
+      <enumeration>
+        <id>HW_VER</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>SW_VER</id>
+    <description>Attribute indicating the target's software
+    version</description>
+    <simpleType>
+      <enumeration>
+        <id>SW_VER</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>ROLE</id>
+    <description>Attribute indicating the target's
+    role</description>
+    <simpleType>
+      <enumeration>
+        <id>ROLE</id>
+      </enumeration>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hasStringConversion />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>PHYP_SYSTEM_TYPE</id>
+    <description>PHYP system type value for habanero and barreleye
+    (0x3015 and 0x3016 respectively). The value is updated in the
+    system xml.</description>
+    <simpleType>
+      <uint32_t></uint32_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>ASCII_VPD_LX_KEYWORD</id>
+    <description>LX keyword VPD data for HDAT module</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <writeable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_PM_MODE</id>
+    <description>Power management mode the system should use. Valid
+    values: 1 = Nominal (default), 5 = Static Power Save
+    (percentage below nominal whose value is defined in
+    OPEN_POWER_PM_MODE_FREQ_PERCENT), 6 = Dynamic Power Save -
+    Favor Energy (DPS-FE), 10 = Dynamic Power Save - Favor
+    Performance (DPS-FP), 11 = Fixed Frequency Override -
+    (percentage above nominal whose value is defined in
+    OPEN_POWER_PM_MODE_FREQ_PERCENT)</description>
+    <simpleType>
+      <uint8_t>
+        <default>1</default>
+        <!-- Nominal -->
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>OPEN_POWER_PM_MODE_FREQ_PERCENT</id>
+    <description>Percentage from nominal that the processors should
+    run at when OPEN_POWER_PM_MODE is set to Static Power Save or
+    Fixed Frequency Override (ignored on all other modes). Unit is
+    in tenths of a percent (150 = 15.0%). Static Power Save (5):
+    percentage to decrease frequency, Fixed Frequency Override
+    (11): percentage to increase frequency</description>
+    <simpleType>
+      <uint16_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>IPS_ENABLE</id>
+    <description>Indicates if Idle Power Save is enabled. This is
+    independent of the OPEN_POWER_PM_MODE (DPS and IPS can be
+    enabled at the same time). Valid Values: 0 = Disabled
+    (default), 1 = Enabled. See IPS_ENTER / IPS_EXIT attributes for
+    IPS configuration.</description>
+    <simpleType>
+      <uint8_t>
+        <default>0</default>
+        <!-- disabled -->
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>IPS_ENTER_TIME_SECONDS</id>
+    <description>When IPS is enabled, this defines the delay time
+    in seconds (between 10 and 600) to enter Idle Power
+    Save.</description>
+    <simpleType>
+      <uint16_t>
+        <default>240</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>IPS_ENTER_UTILIZATION_PERCENT</id>
+    <description>When IPS is enabled, this defines the utilization
+    threshold as a percent (between 0 and 100) to enter Idle Power
+    Save. This value should be less than
+    IPS_EXIT_UTILIZATION_PERCENT.</description>
+    <simpleType>
+      <uint8_t>
+        <default>8</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>IPS_EXIT_TIME_SECONDS</id>
+    <description>When IPS is enabled, this defines the delay time
+    in seconds (between 10 and 600) to exit Idle Power
+    Save.</description>
+    <simpleType>
+      <uint16_t>
+        <default>10</default>
+      </uint16_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+  <attribute>
+    <id>IPS_EXIT_UTILIZATION_PERCENT</id>
+    <description>When IPS is enabled, this defines the utilization
+    threshold as a percent (between 0 and 100) to exit Idle Power
+    Save. This value should be greater than
+    IPS_ENTER_UTILIZATION_PERCENT.</description>
+    <simpleType>
+      <uint8_t>
+        <default>12</default>
+      </uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <serverwizShow>oppowervm</serverwizShow>
+  </attribute>
+</attributes>

--- a/target_types_hb.xml
+++ b/target_types_hb.xml
@@ -704,9 +704,6 @@
       <id>FREQ_PCIE_MHZ</id>
     </attribute>
     <attribute>
-      <id>FREQ_X_MHZ</id>
-    </attribute>
-    <attribute>
       <id>MSS_MBA_ADDR_INTERLEAVE_BIT</id>
     </attribute>
     <attribute>
@@ -984,6 +981,9 @@
       <id>PAYLOAD_IN_MIRROR_MEM</id>
     </attribute>
     <!-- AVP override for fused cores or normal cores -->
+    <attribute>
+      <id>FUSED_CORE_MODE</id>
+    </attribute>
     <attribute>
       <id>MIRROR_BASE_ADDRESS</id>
     </attribute>
@@ -1445,27 +1445,6 @@
       <id>IMT_BAR_SIZE</id>
     </attribute>
     <attribute>
-      <id>PHB_MMIO_ADDRS_64</id>
-    </attribute>
-    <attribute>
-      <id>PHB_MMIO_ADDRS_32</id>
-    </attribute>
-    <attribute>
-      <id>PHB_XIVE_ESB_ADDRS</id>
-    </attribute>
-    <attribute>
-      <id>PHB_REG_ADDRS</id>
-    </attribute>
-    <attribute>
-      <id>XIVE_ROUTING_ESB_ADDR</id>
-    </attribute>
-    <attribute>
-      <id>XIVE_ROUTING_END_ADDR</id>
-    </attribute>
-    <attribute>
-      <id>XIVE_PRESENTATION_NVT_ADDR</id>
-    </attribute>
-    <attribute>
       <id>VAS_HYPERVISOR_WINDOW_CONTEXT_ADDR</id>
     </attribute>
     <attribute>
@@ -1488,9 +1467,6 @@
     </attribute>
     <attribute>
       <id>XIVE_CONTROLLER_BAR_ADDR</id>
-    </attribute>
-    <attribute>
-      <id>XIVE_PRESENTATION_BAR_ADDR</id>
     </attribute>
     <attribute>
       <id>PSI_HB_ESB_ADDR</id>
@@ -2262,31 +2238,88 @@
       <default>CUMULUS</default>
     </attribute>
   </targetType>
-  <!-- NV
-     Nimbus : 1 per chip
-     Cumulus: 1 per chip -->
+  <!-- OBUS Brick
+     Nimbus : 3 per OBUS
+     Cumulus: 3 per OBUS -->
   <targetType>
-    <id>unit-nv-power9</id>
-    <parent>unit</parent>
+    <id>unit-obus-brick-power9</id>
+    <parent>unit-obus-power9</parent>
     <attribute>
       <id>TYPE</id>
-      <default>NV</default>
-    </attribute>
-    <attribute>
-      <id>DECONFIG_GARDABLE</id>
-      <default>1</default>
+      <default>OBUS_BRICK</default>
     </attribute>
     <attribute>
       <id>CDM_DOMAIN</id>
       <default>FABRIC</default>
     </attribute>
     <attribute>
+      <id>DECONFIG_GARDABLE</id>
+      <default>0</default>
+    </attribute>
+    <attribute>
+      <id>HUID</id>
+    </attribute>
+    <attribute>
+      <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+      <default>0</default>
+      <!-- GARD -->
+    </attribute>
+    <attribute>
+      <id>OBUS_BRICK_LANE_MASK</id>
+    </attribute>
+    <attribute>
+      <id>OPTICS_CONFIG_MODE</id>
+    </attribute>
+    <attribute>
       <id>PARENT_PERVASIVE</id>
+    </attribute>
+  </targetType>
+  <targetType>
+    <id>unit-obus-brick-nimbus</id>
+    <parent>unit-obus-brick-power9</parent>
+    <attribute>
+      <id>MODEL</id>
+      <default>NIMBUS</default>
+    </attribute>
+  </targetType>
+  <targetType>
+    <id>unit-obus-brick-cumulus</id>
+    <parent>unit-obus-brick-power9</parent>
+    <attribute>
+      <id>MODEL</id>
+      <default>CUMULUS</default>
+    </attribute>
+  </targetType>
+  <!-- @TODO RTC:173529 - Remove NV once it is not used anywhere -->
+  <targetType>
+    <id>unit-nv-power9</id>
+    <parent>unit-obus-power9</parent>
+    <attribute>
+      <id>TYPE</id>
+      <default>NV</default>
+    </attribute>
+    <attribute>
+      <id>CDM_DOMAIN</id>
+      <default>FABRIC</default>
+    </attribute>
+    <attribute>
+      <id>DECONFIG_GARDABLE</id>
+      <default>1</default>
+    </attribute>
+    <attribute>
+      <id>HUID</id>
     </attribute>
     <attribute>
       <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
       <default>0x00000001</default>
       <!-- GARD -->
+    </attribute>
+    <attribute>
+      <id>OPTICS_CONFIG_MODE</id>
+      <default>SMP</default>
+    </attribute>
+    <attribute>
+      <id>PARENT_PERVASIVE</id>
     </attribute>
   </targetType>
   <targetType>
@@ -2300,6 +2333,41 @@
   <targetType>
     <id>unit-nv-cumulus</id>
     <parent>unit-nv-power9</parent>
+    <attribute>
+      <id>MODEL</id>
+      <default>CUMULUS</default>
+    </attribute>
+  </targetType>
+  <!-- One NPU per proc -->
+  <targetType>
+    <id>unit-npu-power9</id>
+    <parent>unit</parent>
+    <attribute>
+      <id>TYPE</id>
+      <default>NPU</default>
+    </attribute>
+    <attribute>
+      <id>DECONFIG_GARDABLE</id>
+      <default>1</default>
+    </attribute>
+    <attribute>
+      <id>HUID</id>
+    </attribute>
+    <attribute>
+      <id>PARENT_PERVASIVE</id>
+    </attribute>
+  </targetType>
+  <targetType>
+    <id>unit-npu-nimbus</id>
+    <parent>unit-npu-power9</parent>
+    <attribute>
+      <id>MODEL</id>
+      <default>NIMBUS</default>
+    </attribute>
+  </targetType>
+  <targetType>
+    <id>unit-npu-cumulus</id>
+    <parent>unit-npu-power9</parent>
     <attribute>
       <id>MODEL</id>
       <default>CUMULUS</default>
@@ -2931,6 +2999,12 @@
   </targetTypeExtension>
   <targetTypeExtension>
     <id>chip-tpm-cectpm</id>
+  </targetTypeExtension>
+  <targetTypeExtension>
+    <id>unit-occ-power9</id>
+    <attribute>
+      <id>IPMI_SENSORS</id>
+    </attribute>
   </targetTypeExtension>
   <targetTypeExtension>
     <id>base</id>


### PR DESCRIPTION
7ab9a90 - Prachi Gupta, 3 weeks ago : deconfing/gard of OBUS_BRICK/NPU targets
6d15381 - Prachi Gupta, 3 weeks ago : define TARGET_TYPE_NPU
3d40df2 - Prachi Gupta, 9 weeks ago : Changing NV target to OBUS_BRICK and mark it a child of OBUS
280883b - Marty Gloff, 5 weeks ago : Complete gerrit38372> Fixed blue waterfall workaround bugs
096ef90 - Jaymes Wilks, 5 weeks ago : Add TPM Presence Info to HDAT
1844c9f - Stephen Glancy, 3 weeks ago : Adds DCD calibration control attributes
529ea1d - Dean Sanner, 6 days ago : Enable STOP5
31f5557 - Prachi Gupta, 10 days ago : set ATTR_FREQ_X_MHZ based on DD-level
09f01f9 - Dan Crowell, 2 weeks ago : Make ATTR_FUSED_CORE_MODE non-volatile
ea02eba - crgeddes, 2 weeks ago : Remove depricated interrupt BAR attributes
19146c6 - Andre Marin, 4 weeks ago : Add PHY sequencer refresh settings after draminit
bd8f72b - Prachi Gupta, 2 weeks ago : adding IPMI_SENSOR to p9 occ target
60b4de3 - nagurram-in, 3 weeks ago : Update the supported Stop states in attribute xml