### PR TITLE
common-mrw-xml update 6-16-2017

### DIFF
--- a/attribute_types_hb.xml
+++ b/attribute_types_hb.xml
@@ -6,8 +6,7 @@
      ================================================================= -->
   <enumerationType>
     <id>CLASS</id>
-    <description>Enumeration indicating the target's
-    class</description>
+    <description>Enumeration indicating the target's class</description>
     <enumerator>
       <name>NA</name>
       <value>0</value>
@@ -60,8 +59,7 @@
      consistent over builds making them easier to recognize.  -->
   <enumerationType>
     <id>TYPE</id>
-    <description>Enumeration indicating the target's
-    type</description>
+    <description>Enumeration indicating the target's type</description>
     <enumerator>
       <name>NA</name>
       <value>0</value>
@@ -345,8 +343,7 @@
   </enumerationType>
   <enumerationType>
     <id>MODEL</id>
-    <description>Enumeration indicating the target's
-    model</description>
+    <description>Enumeration indicating the target's model</description>
     <enumerator>
       <name>NA</name>
       <value>0</value>
@@ -402,8 +399,7 @@
   </enumerationType>
   <enumerationType>
     <id>ENGINE_TYPE</id>
-    <description>Enumeration indicating the target's engine
-    type</description>
+    <description>Enumeration indicating the target's engine type</description>
     <enumerator>
       <name>NA</name>
       <value>0</value>
@@ -420,8 +416,7 @@
   </enumerationType>
   <enumerationType>
     <id>FSI_MASTER_TYPE</id>
-    <description>Enumeration indicating the master's FSI
-    type</description>
+    <description>Enumeration indicating the master's FSI type</description>
     <enumerator>
       <name>MFSI</name>
       <value>0</value>
@@ -438,8 +433,7 @@
   </enumerationType>
   <attribute>
     <id>CLASS</id>
-    <description>Attribute indicating the target's
-    class</description>
+    <description>Attribute indicating the target's class</description>
     <simpleType>
       <enumeration>
         <id>CLASS</id>
@@ -451,8 +445,7 @@
   </attribute>
   <attribute>
     <id>TYPE</id>
-    <description>Attribute indicating the target's
-    type</description>
+    <description>Attribute indicating the target's type</description>
     <simpleType>
       <enumeration>
         <id>TYPE</id>
@@ -464,8 +457,7 @@
   </attribute>
   <attribute>
     <id>MODEL</id>
-    <description>Attribute indicating the target's
-    model</description>
+    <description>Attribute indicating the target's model</description>
     <simpleType>
       <enumeration>
         <id>MODEL</id>
@@ -477,8 +469,7 @@
   </attribute>
   <attribute>
     <id>ENGINE_TYPE</id>
-    <description>Attribute indicating the target's engine
-    type</description>
+    <description>Attribute indicating the target's engine type</description>
     <simpleType>
       <enumeration>
         <id>ENGINE_TYPE</id>
@@ -490,8 +481,7 @@
   </attribute>
   <attribute>
     <id>DUMMY_RW</id>
-    <description>Dummy attribute with read/write
-    permissions</description>
+    <description>Dummy attribute with read/write permissions</description>
     <simpleType>
       <uint8_t>
         <default>5</default>
@@ -508,8 +498,7 @@
   </attribute>
   <attribute>
     <id>DUMMY_WO</id>
-    <description>Dummy attribute with write-only
-    permissions</description>
+    <description>Dummy attribute with write-only permissions</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -520,8 +509,7 @@
   </attribute>
   <attribute>
     <id>DUMMY_RO</id>
-    <description>Dummy attribute with read-only
-    permissions</description>
+    <description>Dummy attribute with read-only permissions</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -532,8 +520,7 @@
   </attribute>
   <attribute>
     <id>PHYS_PATH</id>
-    <description>Physical hierarchical path to the
-    target</description>
+    <description>Physical hierarchical path to the target</description>
     <nativeType>
       <name>EntityPath</name>
     </nativeType>
@@ -542,8 +529,7 @@
   </attribute>
   <attribute>
     <id>AFFINITY_PATH</id>
-    <description>Hierarchical path to the target with respect to
-    logical affinity</description>
+    <description>Hierarchical path to the target with respect to logical affinity</description>
     <nativeType>
       <name>EntityPath</name>
     </nativeType>
@@ -552,8 +538,7 @@
   </attribute>
   <attribute>
     <id>POWER_PATH</id>
-    <description>Hierarchical path to the target with respect to
-    power</description>
+    <description>Hierarchical path to the target with respect to power</description>
     <nativeType>
       <name>EntityPath</name>
     </nativeType>
@@ -562,33 +547,26 @@
   </attribute>
   <attribute>
     <id>PRIMARY_CAPABILITIES</id>
-    <description>Attribute which describes capabilities of a
-    target</description>
+    <description>Attribute which describes capabilities of a target</description>
     <complexType>
-      <description>Structure which defines a target's primary
-      capabilities. A target can only support at most FSI SCOM and
-      one of the other two SCOM types. Applicable for all targets.
-      Structure is read-only.</description>
+      <description>Structure which defines a target's primary capabilities. A target can only support at most FSI SCOM and one of the other two SCOM types. Applicable for all targets. Structure is read-only.</description>
       <field>
         <name>supportsFsiScom</name>
-        <description>0b0: Target does not support FSI SCOM; 0b1:
-        Target supports FSI SCOM</description>
+        <description>0b0: Target does not support FSI SCOM; 0b1: Target supports FSI SCOM</description>
         <type>uint8_t</type>
         <bits>1</bits>
         <default>0</default>
       </field>
       <field>
         <name>supportsXscom</name>
-        <description>0b0: Target does not support XSCOM; 0b1:
-        Target supports FSI XSCOM</description>
+        <description>0b0: Target does not support XSCOM; 0b1: Target supports FSI XSCOM</description>
         <type>uint8_t</type>
         <bits>1</bits>
         <default>0</default>
       </field>
       <field>
         <name>supportsInbandScom</name>
-        <description>0b0: Target does not support inband
-        SCOM</description>
+        <description>0b0: Target does not support inband SCOM</description>
         <type>uint8_t</type>
         <bits>1</bits>
         <default>0</default>
@@ -615,9 +593,7 @@
   </attribute>
   <attribute>
     <id>FSI_MASTER_CHIP</id>
-    <description>Chip which contains the FSI master logic that
-    drives this slave when booting from the default master
-    processor</description>
+    <description>Chip which contains the FSI master logic that drives this slave when booting from the default master processor</description>
     <nativeType>
       <name>EntityPath</name>
       <default>physical:sys-0</default>
@@ -627,9 +603,7 @@
   </attribute>
   <attribute>
     <id>ALTFSI_MASTER_CHIP</id>
-    <description>Chip which contains the FSI master logic that
-    drives this slave when booting from the alternate master
-    processor</description>
+    <description>Chip which contains the FSI master logic that drives this slave when booting from the alternate master processor</description>
     <nativeType>
       <name>EntityPath</name>
       <default>physical:sys-0</default>
@@ -639,8 +613,7 @@
   </attribute>
   <attribute>
     <id>FSI_MASTER_TYPE</id>
-    <description>Type of Master FSI connection to this slave (MFSI
-    or cMFSI)</description>
+    <description>Type of Master FSI connection to this slave (MFSI or cMFSI)</description>
     <simpleType>
       <enumeration>
         <id>FSI_MASTER_TYPE</id>
@@ -653,8 +626,7 @@
   </attribute>
   <attribute>
     <id>FSI_MASTER_PORT</id>
-    <description>Which port is this chip hanging off of when
-    booting from the default master processor</description>
+    <description>Which port is this chip hanging off of when booting from the default master processor</description>
     <simpleType>
       <uint8_t>
         <default>0xFF</default>
@@ -665,8 +637,7 @@
   </attribute>
   <attribute>
     <id>ALTFSI_MASTER_PORT</id>
-    <description>Which port is this chip hanging off of when
-    booting from the alternate master processor</description>
+    <description>Which port is this chip hanging off of when booting from the alternate master processor</description>
     <simpleType>
       <uint8_t>
         <default>0xFF</default>
@@ -703,15 +674,12 @@
   </attribute>
   <attribute>
     <id>FSI_OPTION_FLAGS</id>
-    <description>Reserved for any special flags we might need to
-    access FSI</description>
+    <description>Reserved for any special flags we might need to access FSI</description>
     <complexType>
       <description>FSI flags</description>
       <field>
         <name>flipPort</name>
-        <description>Set on FSI master chips (procs) if that chip
-        uses slaveB to attach to the acting master
-        chip.</description>
+        <description>Set on FSI master chips (procs) if that chip uses slaveB to attach to the acting master chip.</description>
         <type>uint16_t</type>
         <bits>1</bits>
         <default>0</default>
@@ -729,11 +697,7 @@
   </attribute>
   <attribute>
     <id>EXECUTION_PLATFORM</id>
-    <description>Which execution platform the HW Procedure is
-    running on Some HWPs (e.g. special wakeup) use different
-    registers for different platforms to avoid arbitration problems
-    when multiple platforms do the same thing concurrently HOST =
-    0x01, FSP = 0x02, OCC = 0x03</description>
+    <description>Which execution platform the HW Procedure is running on Some HWPs (e.g. special wakeup) use different registers for different platforms to avoid arbitration problems when multiple platforms do the same thing concurrently HOST = 0x01, FSP = 0x02, OCC = 0x03</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -746,8 +710,7 @@
   </attribute>
   <attribute>
     <id>IS_SIMULATION</id>
-    <description>env: 1 = Awan/HWSimulator. 0 =
-    Simics/RealHW.</description>
+    <description>env: 1 = Awan/HWSimulator. 0 = Simics/RealHW.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -763,11 +726,7 @@
   </attribute>
   <attribute>
     <id>HWAS_STATE_CHANGED_FLAG</id>
-    <description>HardWare Availability Service State Changed
-    Attribute. Keeps track of changedSinceChecked state, indicates
-    if the target has changed since last checked by the appropriate
-    service. This is a bit field of flags (see HWAS_CHANGED_BIT
-    enumeration that follows).</description>
+    <description>HardWare Availability Service State Changed Attribute. Keeps track of changedSinceChecked state, indicates if the target has changed since last checked by the appropriate service. This is a bit field of flags (see HWAS_CHANGED_BIT enumeration that follows).</description>
     <simpleType>
       <uint64_t>
         <default>0x0</default>
@@ -779,11 +738,7 @@
   </attribute>
   <attribute>
     <id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-    <description>HardWare Availability Service State Changed Mask.
-    Used when a target changes (ie, via HCDB change) to set the
-    HWAS_STATE_CHANGED_FLAG, so that the appropriate services will
-    all handle the change. This is a bit field of flags (see
-    HWAS_CHANGED_BIT enumeration that follows).</description>
+    <description>HardWare Availability Service State Changed Mask. Used when a target changes (ie, via HCDB change) to set the HWAS_STATE_CHANGED_FLAG, so that the appropriate services will all handle the change. This is a bit field of flags (see HWAS_CHANGED_BIT enumeration that follows).</description>
     <simpleType>
       <uint64_t>
         <default>0x0</default>
@@ -794,9 +749,7 @@
   </attribute>
   <enumerationType>
     <id>HWAS_CHANGED_BIT</id>
-    <description>Enumeration indicating the services that are
-    concerned with target changes (ie, via HCDB change). The values
-    can be combined using a bitwise 'OR'.</description>
+    <description>Enumeration indicating the services that are concerned with target changes (ie, via HCDB change). The values can be combined using a bitwise 'OR'.</description>
     <enumerator>
       <name>GARD</name>
       <value>0x00000001</value>
@@ -823,8 +776,7 @@
   <!-- For POD Testing -->
   <attribute>
     <id>NUMERIC_POD_TYPE_TEST</id>
-    <description>Attribute which tests numeric POD
-    types</description>
+    <description>Attribute which tests numeric POD types</description>
     <complexType>
       <description>Numeric POD type test structure</description>
       <field>
@@ -893,9 +845,7 @@
   </attribute>
   <attribute>
     <id>DECONFIG_GARDABLE</id>
-    <description>If the Target is directly deconfigurable and
-    GARDable; target may still be deconfigured in 'by association'
-    processing.</description>
+    <description>If the Target is directly deconfigurable and GARDable; target may still be deconfigured in 'by association' processing.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -906,8 +856,7 @@
   </attribute>
   <attribute>
     <id>ISTEP_MODE</id>
-    <description>If True, puts HostBoot into SPLess SingleStep
-    mode.</description>
+    <description>If True, puts HostBoot into SPLess SingleStep mode.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -923,77 +872,60 @@
   </attribute>
   <attribute>
     <id>EEPROM_VPD_PRIMARY_INFO</id>
-    <description>Information needed to address the EEPROM
-    slaves</description>
+    <description>Information needed to address the EEPROM slaves</description>
     <complexType>
-      <description>Structure to define the addressing for an I2C
-      slave device.</description>
+      <description>Structure to define the addressing for an I2C slave device.</description>
       <field>
         <name>i2cMasterPath</name>
-        <description>Entity path to the chip that contains the I2C
-        master</description>
+        <description>Entity path to the chip that contains the I2C master</description>
         <type>EntityPath</type>
         <default>physical:sys-0</default>
       </field>
       <field>
         <name>port</name>
-        <description>Port from the I2C Master device. This is a
-        6-bit value.</description>
+        <description>Port from the I2C Master device. This is a 6-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>devAddr</name>
-        <description>Device address on the I2C bus. This is a 7-bit
-        value, but then shifted 1 bit left.</description>
+        <description>Device address on the I2C bus. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>engine</name>
-        <description>I2C master engine. This is a 2-bit
-        value.</description>
+        <description>I2C master engine. This is a 2-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>byteAddrOffset</name>
-        <description>The number of bytes a device requires to set
-        its internal address/offset. DDR4 DIMMs require a special
-        EEPROM page switching mechanic denoted here by a value of 1
-        0 = Zero Byte Addressing 1 = One Byte Addressing with page
-        select 2 = Two Byte Addressing 3 = OneByte Addressing with
-        no page select</description>
+        <description>The number of bytes a device requires to set its internal address/offset. DDR4 DIMMs require a special EEPROM page switching mechanic denoted here by a value of 1 0 = Zero Byte Addressing 1 = One Byte Addressing with page select 2 = Two Byte Addressing 3 = OneByte Addressing with no page select</description>
         <type>uint8_t</type>
         <default>0x02</default>
       </field>
       <field>
         <name>maxMemorySizeKB</name>
-        <description>The number of kilobytes a device can hold.
-        'Zero' value possible for some devices.</description>
+        <description>The number of kilobytes a device can hold. 'Zero' value possible for some devices.</description>
         <type>uint64_t</type>
         <default>0x0</default>
       </field>
       <field>
         <name>chipCount</name>
-        <description>The number of chips making up an eeprom
-        device.</description>
+        <description>The number of chips making up an eeprom device.</description>
         <type>uint8_t</type>
         <default>0x01</default>
       </field>
       <field>
         <name>writePageSize</name>
-        <description>The maximum number of bytes that can be
-        written to a device at one time. 'Zero' value means no
-        maximum value is expected or checked.</description>
+        <description>The maximum number of bytes that can be written to a device at one time. 'Zero' value means no maximum value is expected or checked.</description>
         <type>uint64_t</type>
         <default>0x0</default>
       </field>
       <field>
         <name>writeCycleTime</name>
-        <description>The amount of time in milliseconds a device
-        requires on the completion of a write command to update its
-        internal memory.</description>
+        <description>The amount of time in milliseconds a device requires on the completion of a write command to update its internal memory.</description>
         <type>uint64_t</type>
         <default>0xA</default>
       </field>
@@ -1003,73 +935,60 @@
   </attribute>
   <attribute>
     <id>EEPROM_VPD_BACKUP_INFO</id>
-    <description>Information needed to address the EERPROM
-    slaves</description>
+    <description>Information needed to address the EERPROM slaves</description>
     <complexType>
-      <description>Structure to define the addressing for an I2C
-      slave device.</description>
+      <description>Structure to define the addressing for an I2C slave device.</description>
       <field>
         <name>i2cMasterPath</name>
-        <description>Entity path to the chip that contains the I2C
-        master</description>
+        <description>Entity path to the chip that contains the I2C master</description>
         <type>EntityPath</type>
         <default>physical:sys-0</default>
       </field>
       <field>
         <name>port</name>
-        <description>Port from the I2C Master device. This is a
-        6-bit value.</description>
+        <description>Port from the I2C Master device. This is a 6-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>devAddr</name>
-        <description>Device address on the I2C bus. This is a 7-bit
-        value, but then shifted 1 bit left.</description>
+        <description>Device address on the I2C bus. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>engine</name>
-        <description>I2C master engine. This is a 2-bit
-        value.</description>
+        <description>I2C master engine. This is a 2-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>byteAddrOffset</name>
-        <description>The number of bytes a device requires to set
-        its internal address/offset.</description>
+        <description>The number of bytes a device requires to set its internal address/offset.</description>
         <type>uint8_t</type>
         <default>0x02</default>
       </field>
       <field>
         <name>maxMemorySizeKB</name>
-        <description>The number of kilobytes a device can hold.
-        'Zero' value possible for some devices.</description>
+        <description>The number of kilobytes a device can hold. 'Zero' value possible for some devices.</description>
         <type>uint64_t</type>
         <default>0x0</default>
       </field>
       <field>
         <name>chipCount</name>
-        <description>The number of chips making up an eeprom
-        device.</description>
+        <description>The number of chips making up an eeprom device.</description>
         <type>uint8_t</type>
         <default>0x01</default>
       </field>
       <field>
         <name>writePageSize</name>
-        <description>The maximum number of bytes that can be
-        written to a device at one time. 'Zero' value means no
-        maximum value is expected or checked.</description>
+        <description>The maximum number of bytes that can be written to a device at one time. 'Zero' value means no maximum value is expected or checked.</description>
         <type>uint64_t</type>
         <default>0x0</default>
       </field>
       <field>
         <name>writeCycleTime</name>
-        <description>The amount of time in milliseconds a device
-        requires on the completion of a write command to update its
-        internal memory.</description>
+        <description>The amount of time in milliseconds a device requires on the completion of a write command to update its internal memory.</description>
         <type>uint64_t</type>
         <default>0xA</default>
       </field>
@@ -1079,73 +998,60 @@
   </attribute>
   <attribute>
     <id>EEPROM_SBE_PRIMARY_INFO</id>
-    <description>Information needed to address the EERPROM
-    slaves</description>
+    <description>Information needed to address the EERPROM slaves</description>
     <complexType>
-      <description>Structure to define the addressing for an I2C
-      slave device.</description>
+      <description>Structure to define the addressing for an I2C slave device.</description>
       <field>
         <name>i2cMasterPath</name>
-        <description>Entity path to the chip that contains the I2C
-        master</description>
+        <description>Entity path to the chip that contains the I2C master</description>
         <type>EntityPath</type>
         <default>physical:sys-0</default>
       </field>
       <field>
         <name>port</name>
-        <description>Port from the I2C Master device. This is a
-        6-bit value.</description>
+        <description>Port from the I2C Master device. This is a 6-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>devAddr</name>
-        <description>Device address on the I2C bus. This is a 7-bit
-        value, but then shifted 1 bit left.</description>
+        <description>Device address on the I2C bus. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>engine</name>
-        <description>I2C master engine. This is a 2-bit
-        value.</description>
+        <description>I2C master engine. This is a 2-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>byteAddrOffset</name>
-        <description>The number of bytes a device requires to set
-        its internal address/offset.</description>
+        <description>The number of bytes a device requires to set its internal address/offset.</description>
         <type>uint8_t</type>
         <default>0x02</default>
       </field>
       <field>
         <name>maxMemorySizeKB</name>
-        <description>The number of kilobytes a device can hold.
-        'Zero' value possible for some devices.</description>
+        <description>The number of kilobytes a device can hold. 'Zero' value possible for some devices.</description>
         <type>uint64_t</type>
         <default>0x100</default>
       </field>
       <field>
         <name>chipCount</name>
-        <description>The number of chips making up an eeprom
-        device.</description>
+        <description>The number of chips making up an eeprom device.</description>
         <type>uint8_t</type>
         <default>0x04</default>
       </field>
       <field>
         <name>writePageSize</name>
-        <description>The maximum number of bytes that can be
-        written to a device at one time. 'Zero' value means no
-        maximum value is expected or checked.</description>
+        <description>The maximum number of bytes that can be written to a device at one time. 'Zero' value means no maximum value is expected or checked.</description>
         <type>uint64_t</type>
         <default>0x0</default>
       </field>
       <field>
         <name>writeCycleTime</name>
-        <description>The amount of time in milliseconds a device
-        requires on the completion of a write command to update its
-        internal memory.</description>
+        <description>The amount of time in milliseconds a device requires on the completion of a write command to update its internal memory.</description>
         <type>uint64_t</type>
         <default>0x0</default>
       </field>
@@ -1155,73 +1061,60 @@
   </attribute>
   <attribute>
     <id>EEPROM_SBE_BACKUP_INFO</id>
-    <description>Information needed to address the EERPROM
-    slaves</description>
+    <description>Information needed to address the EERPROM slaves</description>
     <complexType>
-      <description>Structure to define the addressing for an I2C
-      slave device.</description>
+      <description>Structure to define the addressing for an I2C slave device.</description>
       <field>
         <name>i2cMasterPath</name>
-        <description>Entity path to the chip that contains the I2C
-        master</description>
+        <description>Entity path to the chip that contains the I2C master</description>
         <type>EntityPath</type>
         <default>physical:sys-0</default>
       </field>
       <field>
         <name>port</name>
-        <description>Port from the I2C Master device. This is a
-        6-bit value.</description>
+        <description>Port from the I2C Master device. This is a 6-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>devAddr</name>
-        <description>Device address on the I2C bus. This is a 7-bit
-        value, but then shifted 1 bit left.</description>
+        <description>Device address on the I2C bus. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>engine</name>
-        <description>I2C master engine. This is a 2-bit
-        value.</description>
+        <description>I2C master engine. This is a 2-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>byteAddrOffset</name>
-        <description>The number of bytes a device requires to set
-        its internal address/offset.</description>
+        <description>The number of bytes a device requires to set its internal address/offset.</description>
         <type>uint8_t</type>
         <default>0x02</default>
       </field>
       <field>
         <name>maxMemorySizeKB</name>
-        <description>The number of kilobytes a device can hold.
-        'Zero' value possible for some devices.</description>
+        <description>The number of kilobytes a device can hold. 'Zero' value possible for some devices.</description>
         <type>uint64_t</type>
         <default>0x100</default>
       </field>
       <field>
         <name>chipCount</name>
-        <description>The number of chips making up an eeprom
-        device.</description>
+        <description>The number of chips making up an eeprom device.</description>
         <type>uint8_t</type>
         <default>0x04</default>
       </field>
       <field>
         <name>writePageSize</name>
-        <description>The maximum number of bytes that can be
-        written to a device at one time. 'Zero' value means no
-        maximum value is expected or checked.</description>
+        <description>The maximum number of bytes that can be written to a device at one time. 'Zero' value means no maximum value is expected or checked.</description>
         <type>uint64_t</type>
         <default>0x0</default>
       </field>
       <field>
         <name>writeCycleTime</name>
-        <description>The amount of time in milliseconds a device
-        requires on the completion of a write command to update its
-        internal memory.</description>
+        <description>The amount of time in milliseconds a device requires on the completion of a write command to update its internal memory.</description>
         <type>uint64_t</type>
         <default>0x0</default>
       </field>
@@ -1231,36 +1124,30 @@
   </attribute>
   <attribute>
     <id>TEMP_SENSOR_I2C_CONFIG</id>
-    <description>Information needed to address an I2C slave
-    device</description>
+    <description>Information needed to address an I2C slave device</description>
     <complexType>
-      <description>Structure to define the addressing for an I2C
-      slave device.</description>
+      <description>Structure to define the addressing for an I2C slave device.</description>
       <field>
         <name>i2cMasterPath</name>
-        <description>Entity path to the chip that contains the I2C
-        master</description>
+        <description>Entity path to the chip that contains the I2C master</description>
         <type>EntityPath</type>
         <default>physical:sys-0</default>
       </field>
       <field>
         <name>engine</name>
-        <description>I2C master engine. This is a 2-bit
-        value.</description>
+        <description>I2C master engine. This is a 2-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>port</name>
-        <description>Port from the I2C Master device. This is a
-        6-bit value.</description>
+        <description>Port from the I2C Master device. This is a 6-bit value.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
       <field>
         <name>devAddr</name>
-        <description>Device address on the I2C bus. This is a 7-bit
-        value, but then shifted 1 bit left.</description>
+        <description>Device address on the I2C bus. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0x80</default>
       </field>
@@ -1270,83 +1157,66 @@
   </attribute>
   <attribute>
     <id>TPM_INFO</id>
-    <description>Information needed to address the TPM
-    slaves</description>
+    <description>Information needed to address the TPM slaves</description>
     <complexType>
-      <description>Structure to define the addressing for an I2C
-      TPM.</description>
+      <description>Structure to define the addressing for an I2C TPM.</description>
       <field>
         <name>tpmEnabled</name>
-        <description>Boolean indicating whether this TPM is
-        available in the system</description>
+        <description>Boolean indicating whether this TPM is available in the system</description>
         <type>uint8_t</type>
         <default>0x0</default>
       </field>
       <field>
         <name>i2cMasterPath</name>
-        <description>Entity path to the chip that contains the I2C
-        master</description>
+        <description>Entity path to the chip that contains the I2C master</description>
         <type>EntityPath</type>
         <default>physical:sys-0</default>
       </field>
       <field>
         <name>port</name>
-        <description>Port from the I2C Master device. This is a
-        6-bit value.</description>
+        <description>Port from the I2C Master device. This is a 6-bit value.</description>
         <type>uint8_t</type>
         <default>0x01</default>
       </field>
       <field>
         <name>devAddrLocality0</name>
-        <description>Device address on the I2C bus for Locality 0.
-        This is a 7-bit value, but then shifted 1 bit
-        left.</description>
+        <description>Device address on the I2C bus for Locality 0. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0xAE</default>
       </field>
       <field>
         <name>devAddrLocality1</name>
-        <description>Device address on the I2C bus for Locality 1.
-        This is a 7-bit value, but then shifted 1 bit
-        left.</description>
+        <description>Device address on the I2C bus for Locality 1. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0xA8</default>
       </field>
       <field>
         <name>devAddrLocality2</name>
-        <description>Device address on the I2C bus for Locality 2.
-        This is a 7-bit value, but then shifted 1 bit
-        left.</description>
+        <description>Device address on the I2C bus for Locality 2. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0xAA</default>
       </field>
       <field>
         <name>devAddrLocality3</name>
-        <description>Device address on the I2C bus for Locality 3.
-        This is a 7-bit value, but then shifted 1 bit
-        left.</description>
+        <description>Device address on the I2C bus for Locality 3. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0xA4</default>
       </field>
       <field>
         <name>devAddrLocality4</name>
-        <description>Device address on the I2C bus for Locality 4.
-        This is a 7-bit value, but then shifted 1 bit
-        left.</description>
+        <description>Device address on the I2C bus for Locality 4. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0xA6</default>
       </field>
       <field>
         <name>engine</name>
-        <description>I2C master engine. This is a 2-bit
-        value.</description>
+        <description>I2C master engine. This is a 2-bit value.</description>
         <type>uint8_t</type>
         <default>0x00</default>
       </field>
       <field>
         <name>byteAddrOffset</name>
-        <description>The number of bytes a device requires to set
-        its internal address/offset.</description>
+        <description>The number of bytes a device requires to set its internal address/offset.</description>
         <type>uint8_t</type>
         <default>0x01</default>
       </field>
@@ -1356,8 +1226,7 @@
   </attribute>
   <attribute>
     <id>FSI_GP_REG_SCOM_ACCESS</id>
-    <description>attribute indicating if the chip's FSI GP regs
-    have scom access</description>
+    <description>attribute indicating if the chip's FSI GP regs have scom access</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -1370,8 +1239,7 @@
   </attribute>
   <attribute>
     <id>CHIP_UNIT</id>
-    <description>A unit (chiplet) 's offset number within the
-    chip.</description>
+    <description>A unit (chiplet) 's offset number within the chip.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -1427,17 +1295,12 @@
   </attribute>
   <attribute>
     <id>CEN_DQ_TO_DIMM_CONN_DQ</id>
-    <description>Centaur DQ to DIMM connector DQ mapping for a
-    JEDEC DIMM. Uint8 value for each Centaur DQ (0-79). The value
-    is the corresponding DIMM Connector DQ.</description>
+    <description>Centaur DQ to DIMM connector DQ mapping for a JEDEC DIMM. Uint8 value for each Centaur DQ (0-79). The value is the corresponding DIMM Connector DQ.</description>
     <simpleType>
       <uint8_t>
         <!-- Default is 1:1 mapping, DQ0-DQ0, DQ1-DQ1 etc -->
         <!-- Data will eventually come from MRW -->
-        <default>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,
-        20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,
-        40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,
-        60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79</default>
+        <default>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19, 20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39, 40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59, 60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79</default>
       </uint8_t>
       <array>80</array>
     </simpleType>
@@ -1446,8 +1309,7 @@
   </attribute>
   <enumerationType>
     <id>PROC_EPS_TABLE_TYPE</id>
-    <description>Enumeration indicating the
-    PROC_EPS_TABLE_TYPE</description>
+    <description>Enumeration indicating the PROC_EPS_TABLE_TYPE</description>
     <enumerator>
       <name>EPS_TYPE_LE</name>
       <value>1</value>
@@ -1459,9 +1321,7 @@
   </enumerationType>
   <attribute>
     <id>PROC_EPS_TABLE_TYPE</id>
-    <description>System attribute. Processor epsilon table type.
-    Used to calculate the processor nest epsilon register
-    values.</description>
+    <description>System attribute. Processor epsilon table type. Used to calculate the processor nest epsilon register values.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -1475,8 +1335,7 @@
   </attribute>
   <enumerationType>
     <id>PROC_FABRIC_PUMP_MODE</id>
-    <description>Enumeration indicating the
-    PROC_FABRIC_PUMP_MODE</description>
+    <description>Enumeration indicating the PROC_FABRIC_PUMP_MODE</description>
     <enumerator>
       <name>MODE1</name>
       <value>1</value>
@@ -1488,10 +1347,7 @@
   </enumerationType>
   <attribute>
     <id>PROC_FABRIC_PUMP_MODE</id>
-    <description>System attribute. Processor SMP Fabric broadcast
-    scope configuration. MODE1 = default = chip/group/system/remote
-    group/foreign. MODE2 = group/system/remote group/foreign.
-    Provided by the Machine Readable Workbook.</description>
+    <description>System attribute. Processor SMP Fabric broadcast scope configuration. MODE1 = default = chip/group/system/remote group/foreign. MODE2 = group/system/remote group/foreign. Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -1506,14 +1362,7 @@
   </attribute>
   <attribute>
     <id>ALL_MCS_IN_INTERLEAVING_GROUP</id>
-    <description>System attribute. If all MCS chiplets are in an
-    interleaving group (1=true, 0=false). - If true the SMP fabric
-    is setup in normal mode and multiple MCSs are grouped
-    (disallowing systems with memory only under 1 MCS (i.e. systems
-    with a single C-DIMM)) - If false the SMP fabric is setup in
-    checkerboard mode. Provided by the Machine Readable Workbook.
-    This attribute is based on Machine-Type-Model (MTM) and is
-    setup by the service processor.</description>
+    <description>System attribute. If all MCS chiplets are in an interleaving group (1=true, 0=false). - If true the SMP fabric is setup in normal mode and multiple MCSs are grouped (disallowing systems with memory only under 1 MCS (i.e. systems with a single C-DIMM)) - If false the SMP fabric is setup in checkerboard mode. Provided by the Machine Readable Workbook. This attribute is based on Machine-Type-Model (MTM) and is setup by the service processor.</description>
     <simpleType>
       <uint8_t>
         <default>0x00</default>
@@ -1529,9 +1378,7 @@
   </attribute>
   <attribute>
     <id>FABRIC_GROUP_ID</id>
-    <description>Chip attribute. Logical fabric group the chip
-    belongs to. Provided by the Machine Readable Workbook. Can vary
-    across drawers.</description>
+    <description>Chip attribute. Logical fabric group the chip belongs to. Provided by the Machine Readable Workbook. Can vary across drawers.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -1547,10 +1394,7 @@
   </attribute>
   <attribute>
     <id>PROC_EFF_FABRIC_GROUP_ID</id>
-    <description>Effective fabric group ID associated with this
-    chip. Directly drives programming of chip memory map layout.
-    Compared with ATTR_PROC_FABRIC_GROUP_ID to configure FBC XOR
-    masking.</description>
+    <description>Effective fabric group ID associated with this chip. Directly drives programming of chip memory map layout. Compared with ATTR_PROC_FABRIC_GROUP_ID to configure FBC XOR masking.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -1566,9 +1410,7 @@
   </attribute>
   <attribute>
     <id>FABRIC_CHIP_ID</id>
-    <description>Chip attribute. Logical fabric chip id for this
-    chip (position within the fabric). Provided by the Machine
-    Readable Workbook. Can vary across drawers.</description>
+    <description>Chip attribute. Logical fabric chip id for this chip (position within the fabric). Provided by the Machine Readable Workbook. Can vary across drawers.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -1584,10 +1426,7 @@
   </attribute>
   <attribute>
     <id>PROC_EFF_FABRIC_CHIP_ID</id>
-    <description>Effective fabric chip ID associated with this
-    chip. Directly drives programming of chip memory map layout.
-    Compared with ATTR_PROC_FABRIC_CHIP_ID to configure FBC XOR
-    masking.</description>
+    <description>Effective fabric chip ID associated with this chip. Directly drives programming of chip memory map layout. Compared with ATTR_PROC_FABRIC_CHIP_ID to configure FBC XOR masking.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -1603,9 +1442,7 @@
   </attribute>
   <attribute>
     <id>CHIP_HAS_SBE</id>
-    <description>Chip attribute. If true, the chip has an SBE and
-    the associated registers. Provided by the Machine Readable
-    Workbook.</description>
+    <description>Chip attribute. If true, the chip has an SBE and the associated registers. Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -1618,8 +1455,7 @@
   </attribute>
   <attribute>
     <id>FREQ_PROC_REFCLOCK</id>
-    <description>System attribute. The frequency of the processor
-    refclock in MHz. Provided by the MRW.</description>
+    <description>System attribute. The frequency of the processor refclock in MHz. Provided by the MRW.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -1632,8 +1468,7 @@
   </attribute>
   <attribute>
     <id>FREQ_PROC_REFCLOCK_KHZ</id>
-    <description>System attribute. The frequency of the processor
-    refclock in KHz. Provided by the MRW.</description>
+    <description>System attribute. The frequency of the processor refclock in KHz. Provided by the MRW.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -1646,8 +1481,7 @@
   </attribute>
   <attribute>
     <id>FREQ_MEM_REFCLOCK</id>
-    <description>System attribute. The frequency of the memory
-    refclock in MHz. Provided by the MRW.</description>
+    <description>System attribute. The frequency of the memory refclock in MHz. Provided by the MRW.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -1660,17 +1494,11 @@
   </attribute>
   <attribute>
     <id>DPO_MIN_FREQ_PERCENT</id>
-    <description>Defines a negative percentage value that is
-    applied to the ATTR_NOMINAL_FREQ_MHZ determined from MVPD #V.
-    It is used to explicitly raise the value of MIN_FREQ_MHZ above
-    what is specified by MVPD #V data. On FSP systems this is
-    sourced from the power_management def file. Value must be
-    between 0 and 100. A value of zero indicates no
-    override.</description>
+    <description>Defines a negative percentage value that is applied to the ATTR_NOMINAL_FREQ_MHZ determined from MVPD #V. It is used to explicitly raise the value of MIN_FREQ_MHZ above what is specified by MVPD #V data. On FSP systems this is sourced from the power_management def file. Value must be between 0 and -100. A value of zero indicates no override.</description>
     <simpleType>
-      <uint32_t>
+      <int32_t>
         <default>0</default>
-      </uint32_t>
+      </int32_t>
     </simpleType>
     <persistency>non-volatile</persistency>
     <readable />
@@ -1678,9 +1506,7 @@
   </attribute>
   <attribute>
     <id>FREQ_PB_MHZ</id>
-    <description>System attribute. The frequency of a processor's
-    PB chiplet in MHz. This is the same for all PB chiplets in the
-    system. Provided by the MRW.</description>
+    <description>System attribute. The frequency of a processor's PB chiplet in MHz. This is the same for all PB chiplets in the system. Provided by the MRW.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -1694,9 +1520,7 @@
   </attribute>
   <attribute>
     <id>FREQ_A_MHZ</id>
-    <description>System attribute. The frequency of a processor's
-    A-bus chiplet in MHz. This is the same for all A-bus chiplets
-    in the system. Provided by the MRW.</description>
+    <description>System attribute. The frequency of a processor's A-bus chiplet in MHz. This is the same for all A-bus chiplets in the system. Provided by the MRW.</description>
     <simpleType>
       <uint32_t>
         <default>0x1900</default>
@@ -1711,10 +1535,7 @@
   </attribute>
   <attribute>
     <id>HUID</id>
-    <description>Hardware Unit ID SSSSNNNNTTTTTTTTiiiiiiiiiiiiiiii
-    S=System N=Node Number T=Target Type (matches TYPE attribute)
-    i=Instance/Sequence number of target, relative to
-    node</description>
+    <description>Hardware Unit ID SSSSNNNNTTTTTTTTiiiiiiiiiiiiiiii S=System N=Node Number T=Target Type (matches TYPE attribute) i=Instance/Sequence number of target, relative to node</description>
     <simpleType>
       <uint32_t />
       <default>0xFFFFFFFF</default>
@@ -1724,64 +1545,47 @@
   </attribute>
   <attribute>
     <id>SP_FUNCTIONS</id>
-    <description>Attribute which describes what the SP is or is not
-    doing in this system</description>
+    <description>Attribute which describes what the SP is or is not doing in this system</description>
     <complexType>
-      <description>Structure which defines a system's SP functions.
-      Applicable for System target only. Structure is
-      read-only.</description>
+      <description>Structure which defines a system's SP functions. Applicable for System target only. Structure is read-only.</description>
       <field>
         <name>baseServices</name>
-        <description>If this flag is set then mailboxEnabled MUST
-        also be set 0b0: SP does not support for VPD, payload, ATTR
-        sync, VDDR, TOD; 0b1: SP supports VPD, payload, ATTR sync,
-        VDDR, TOD</description>
+        <description>If this flag is set then mailboxEnabled MUST also be set 0b0: SP does not support for VPD, payload, ATTR sync, VDDR, TOD; 0b1: SP supports VPD, payload, ATTR sync, VDDR, TOD</description>
         <type>uint32_t</type>
         <bits>1</bits>
         <default>1</default>
       </field>
       <field>
         <name>fsiSlaveInit</name>
-        <description>0b0: SP does not initialize FSI slave logic,
-        Hostboot must; 0b1: SP does initialize FSI slave logic so
-        Hostboot should not</description>
+        <description>0b0: SP does not initialize FSI slave logic, Hostboot must; 0b1: SP does initialize FSI slave logic so Hostboot should not</description>
         <type>uint32_t</type>
         <bits>1</bits>
         <default>1</default>
       </field>
       <field>
         <name>mailboxEnabled</name>
-        <description>0b0: There is no SP mailbox support; 0b1:
-        There is SP mailbox support</description>
+        <description>0b0: There is no SP mailbox support; 0b1: There is SP mailbox support</description>
         <type>uint32_t</type>
         <bits>1</bits>
         <default>0</default>
       </field>
       <field>
         <name>fsiMasterInit</name>
-        <description>0b0: SP does not initialize FSI master logic,
-        Hostboot must; 0b1: SP does initialize FSI master logic so
-        Hostboot should not</description>
+        <description>0b0: SP does not initialize FSI master logic, Hostboot must; 0b1: SP does initialize FSI master logic so Hostboot should not</description>
         <type>uint32_t</type>
         <bits>1</bits>
         <default>1</default>
       </field>
       <field>
         <name>hardwareChangeDetection</name>
-        <description>0b0: SP does not perform hardware change
-        detection, Hostboot must; 0b1: SP does perform hardware
-        change detection (HCDB) so Hostboot should
-        not</description>
+        <description>0b0: SP does not perform hardware change detection, Hostboot must; 0b1: SP does perform hardware change detection (HCDB) so Hostboot should not</description>
         <type>uint32_t</type>
         <bits>1</bits>
         <default>1</default>
       </field>
       <field>
         <name>powerLineDisturbance</name>
-        <description>0b0: SP does not perform Power Line
-        Disturbance (PLD) detection, Hostboot must; 0b1: SP does
-        perform Power Line Disturbance (PLD) detection so Hostboot
-        should not</description>
+        <description>0b0: SP does not perform Power Line Disturbance (PLD) detection, Hostboot must; 0b1: SP does perform Power Line Disturbance (PLD) detection so Hostboot should not</description>
         <type>uint32_t</type>
         <bits>1</bits>
         <default>1</default>
@@ -1799,36 +1603,26 @@
   </attribute>
   <attribute>
     <id>HB_SETTINGS</id>
-    <description>Attribute which describes how the SP has
-    configured features in Hostboot.</description>
+    <description>Attribute which describes how the SP has configured features in Hostboot.</description>
     <complexType>
-      <description>Structure which defines a system's HB settings.
-      Applicable for System target only.</description>
+      <description>Structure which defines a system's HB settings. Applicable for System target only.</description>
       <field>
         <name>traceContinuous</name>
-        <description>Enable / Disable continuous trace. 0b0:
-        Continuous trace is disabled. 0b1: Continuous trace is
-        enabled.</description>
+        <description>Enable / Disable continuous trace. 0b0: Continuous trace is disabled. 0b1: Continuous trace is enabled.</description>
         <type>uint8_t</type>
         <bits>1</bits>
         <default>0</default>
       </field>
       <field>
         <name>traceScanDebug</name>
-        <description>Override trace debug selection for SCAN
-        component. 0b0: TRACS entries for SCAN have default
-        behavior. 0b1: TRACS entries for SCAN are
-        enabled.</description>
+        <description>Override trace debug selection for SCAN component. 0b0: TRACS entries for SCAN have default behavior. 0b1: TRACS entries for SCAN are enabled.</description>
         <type>uint8_t</type>
         <bits>1</bits>
         <default>0</default>
       </field>
       <field>
         <name>traceFapiDebug</name>
-        <description>Override trace debug selection for DBG
-        component. 0b0: TRACS entries for DBG have default
-        behavior. 0b1: TRACS entries for DBG are
-        enabled.</description>
+        <description>Override trace debug selection for DBG component. 0b0: TRACS entries for DBG have default behavior. 0b1: TRACS entries for DBG are enabled.</description>
         <type>uint8_t</type>
         <bits>1</bits>
         <default>0</default>
@@ -1849,13 +1643,7 @@
   <!-- End attributes (4) to test string support -->
   <attribute>
     <id>FAPI_NAME</id>
-    <description>Common name across FAPI environments chip target
-    -&gt; pu:k0:n0:s0:p00 DIMM target -&gt; dimm:k0:n0:s0:p00 chip
-    unit target -&gt; pu.core:k0:n0:s0:p00:c0 cage/system target
-    -&gt; k0 (chip type).(unit type):k(cage,always zero for
-    us):n(node/drawer) :s(slot,always zero for us):p(chip
-    position):c(core/unit position) pu = generic
-    processor</description>
+    <description>Common name across FAPI environments chip target -&gt; pu:k0:n0:s0:p00 DIMM target -&gt; dimm:k0:n0:s0:p00 chip unit target -&gt; pu.core:k0:n0:s0:p00:c0 cage/system target -&gt; k0 (chip type).(unit type):k(cage,always zero for us):n(node/drawer) :s(slot,always zero for us):p(chip position):c(core/unit position) pu = generic processor</description>
     <simpleType>
       <string>
         <default>unknown</default>
@@ -1878,12 +1666,7 @@
   </attribute>
   <attribute>
     <id>PEER_TARGET</id>
-    <description>Peer target's address of a A/X-bus connection.
-    NULL means address 0 for no peer target. If a target instance
-    overrides the default with the peer target's PHYS_PATH. The
-    target compiler will convert the valid PHYS_PATH string into
-    the runtime virtual address of the peer target
-    instance.</description>
+    <description>Peer target's address of a A/X-bus connection. NULL means address 0 for no peer target. If a target instance overrides the default with the peer target's PHYS_PATH. The target compiler will convert the valid PHYS_PATH string into the runtime virtual address of the peer target instance.</description>
     <simpleType>
       <Target_t>
         <default>NULL</default>
@@ -1894,8 +1677,7 @@
   </attribute>
   <enumerationType>
     <id>PAYLOAD_KIND</id>
-    <description>Enumeration indicating what kind of payload is to
-    be started</description>
+    <description>Enumeration indicating what kind of payload is to be started</description>
     <enumerator>
       <name>UNKNOWN</name>
       <value>0</value>
@@ -1916,8 +1698,7 @@
   </enumerationType>
   <attribute>
     <id>PAYLOAD_KIND</id>
-    <description>Attribute indicating what kind of payload is to be
-    started.</description>
+    <description>Attribute indicating what kind of payload is to be started.</description>
     <simpleType>
       <enumeration>
         <id>PAYLOAD_KIND</id>
@@ -1981,9 +1762,7 @@
   </attribute>
   <attribute>
     <id>PAYLOAD_IN_MIRROR_MEM</id>
-    <description>Indicate that payload should be placed in mirrored
-    memory. Set by the FSP based on the value of the registry key
-    indicating the memory mirroring mode.</description>
+    <description>Indicate that payload should be placed in mirrored memory. Set by the FSP based on the value of the registry key indicating the memory mirroring mode.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -1997,11 +1776,7 @@
   <!-- ===== Processor Chip Attributes ===== -->
   <attribute>
     <id>NPU_MMIO_BAR_BASE_ADDR</id>
-    <description>NPU MMIO BAR base address values creator: platform
-    consumer: proc_setup_bars firmware notes: 64-bit address
-    representing BAR RA NOTE: BAR register covers RA 14:51 first
-    dimension: unit number (0:3) second dimension: BAR number
-    (0:1)</description>
+    <description>NPU MMIO BAR base address values creator: platform consumer: proc_setup_bars firmware notes: 64-bit address representing BAR RA NOTE: BAR register covers RA 14:51 first dimension: unit number (0:3) second dimension: BAR number (0:1)</description>
     <simpleType>
       <uint64_t>
         <default>0</default>
@@ -2017,8 +1792,7 @@
   </attribute>
   <enumerationType>
     <id>NPU_MMIO_BAR_SIZE</id>
-    <description>Enumeration indicating the BAR size used with
-    ATTR_PROC_NPU_MMIO_BAR_SIZE</description>
+    <description>Enumeration indicating the BAR size used with ATTR_PROC_NPU_MMIO_BAR_SIZE</description>
     <enumerator>
       <name>2_MB</name>
       <value>0x0000000000200000</value>
@@ -2046,10 +1820,7 @@
   </enumerationType>
   <attribute>
     <id>NPU_MMIO_BAR_SIZE</id>
-    <description>NPU MMIO BAR size values creator: platform
-    consumer: proc_setup_bars firmware notes: none first dimension:
-    unit number (0:3) second dimension: BAR number
-    (0:1)</description>
+    <description>NPU MMIO BAR size values creator: platform consumer: proc_setup_bars firmware notes: none first dimension: unit number (0:3) second dimension: BAR number (0:1)</description>
     <simpleType>
       <uint64_t>
         <default>0</default>
@@ -2098,8 +1869,7 @@
       <uint64_t>
         <!-- Starts at 1024TB - 7GB -->
         <!-- 0x0003FFFE40000000 + 0x400000*procnum + 0x100000*phbnum -->
-        <default>0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
-        0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF</default>
+        <default>0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF</default>
       </uint64_t>
       <array>4</array>
       <!-- per PHB -->
@@ -2109,8 +1879,7 @@
   </attribute>
   <attribute>
     <id>PCI_BASE_ADDRS_64</id>
-    <description>Base Address of PCI 64 bit Memory
-    Space</description>
+    <description>Base Address of PCI 64 bit Memory Space</description>
     <simpleType>
       <uint64_t></uint64_t>
       <array>4</array>
@@ -2121,8 +1890,7 @@
   </attribute>
   <attribute>
     <id>PCI_BASE_ADDRS_32</id>
-    <description>Base Address of PCI 32 bit Memory
-    Space</description>
+    <description>Base Address of PCI 32 bit Memory Space</description>
     <simpleType>
       <uint64_t></uint64_t>
       <array>4</array>
@@ -2162,8 +1930,7 @@
   </attribute>
   <attribute>
     <id>IMT_BASE_ADDR</id>
-    <description>Base Address of In-Memory Trace Region Set by
-    FSP-based tooling</description>
+    <description>Base Address of In-Memory Trace Region Set by FSP-based tooling</description>
     <simpleType>
       <uint64_t>
         <default>0xFFFFFFFFFFFFFFFF</default>
@@ -2174,8 +1941,7 @@
   </attribute>
   <attribute>
     <id>IMT_BAR_SIZE</id>
-    <description>Size of IMT IO Region Set by FSP-based
-    tooling</description>
+    <description>Size of IMT IO Region Set by FSP-based tooling</description>
     <simpleType>
       <uint64_t>
         <default>0x0000000000000000</default>
@@ -2187,9 +1953,7 @@
   <!-- ===== ===== End Memory Map ===== ===== ===== ===== ===== ===== -->
   <attribute>
     <id>FREQ_PCIE_MHZ</id>
-    <description>The frequency of a processor's PCI-e bus in MHz.
-    This is the same for all PCI-e busses in the system. Provided
-    by the MRW.</description>
+    <description>The frequency of a processor's PCI-e bus in MHz. This is the same for all PCI-e busses in the system. Provided by the MRW.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2202,11 +1966,7 @@
   </attribute>
   <attribute>
     <id>MNFG_FLAGS</id>
-    <description>Provides the manufacturing flags. This is a
-    bitfield. Multiple flags can be set at once. Use MNFG_FLAG_BIT
-    to decode. Expected use-case is for FSP to write this attribute
-    based on the MNFG component flags and for HWSV/Hostboot to read
-    it.</description>
+    <description>Provides the manufacturing flags. This is a bitfield. Multiple flags can be set at once. Use MNFG_FLAG_BIT to decode. Expected use-case is for FSP to write this attribute based on the MNFG component flags and for HWSV/Hostboot to read it.</description>
     <simpleType>
       <uint64_t>
         <default>0x0000000000000000</default>
@@ -2222,12 +1982,7 @@
   </attribute>
   <enumerationType>
     <id>MNFG_FLAG</id>
-    <description>Enumeration indicating the mnfg flags that are set
-    by the user. The values can be combined using a bitwise 'OR'.
-    The values will need to be kept in sync with the FAPI
-    enumerator values. Also the enumeration type is used by the
-    ATTR_MNFG_FLAGS attribute. Should note that the MNFG_FLAG
-    values are of type uint32_t</description>
+    <description>Enumeration indicating the mnfg flags that are set by the user. The values can be combined using a bitwise 'OR'. The values will need to be kept in sync with the FAPI enumerator values. Also the enumeration type is used by the ATTR_MNFG_FLAGS attribute. Should note that the MNFG_FLAG values are of type uint32_t</description>
     <enumerator>
       <!-- Use default mfg error thresholds and reporting values -->
       <name>THRESHOLDS</name>
@@ -2327,11 +2082,7 @@
   <!-- Support for pm_hwp_attributes.xml -->
   <attribute>
     <id>PM_SLEEP_ENTRY</id>
-    <description>PROC_CHIP Attribute Set Assisted if power off
-    serialization is needed and SLEEP_TYPE=Fast; Set to Hardware if
-    the system can handle the unrelated powering off between cores.
-    Hardware setting decreases entry latency Producer: MRWB
-    Consumer: proc_pm_init and proc_pcbs_init</description>
+    <description>PROC_CHIP Attribute Set Assisted if power off serialization is needed and SLEEP_TYPE=Fast; Set to Hardware if the system can handle the unrelated powering off between cores. Hardware setting decreases entry latency Producer: MRWB Consumer: proc_pm_init and proc_pcbs_init</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2344,14 +2095,7 @@
   </attribute>
   <attribute>
     <id>PM_SLEEP_EXIT</id>
-    <description>PROC_CHIP Attribute Set to Assisted if power on
-    serialization is needed and SLEEP_TYPE=Fast; Set to Hardware if
-    the system can handle the unrelated powering off between cores.
-    Hardware setting decreases entry latency Must be set to
-    Assisted if ATTR_PM_SLEEP_TYPE=Deep as this necessary for
-    restore. Setting to Hardware is a test mode for Fast only.
-    Producer: MRWB Consumer: proc_pm_init and
-    proc_pcbs_init.</description>
+    <description>PROC_CHIP Attribute Set to Assisted if power on serialization is needed and SLEEP_TYPE=Fast; Set to Hardware if the system can handle the unrelated powering off between cores. Hardware setting decreases entry latency Must be set to Assisted if ATTR_PM_SLEEP_TYPE=Deep as this necessary for restore. Setting to Hardware is a test mode for Fast only. Producer: MRWB Consumer: proc_pm_init and proc_pcbs_init.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2364,10 +2108,7 @@
   </attribute>
   <attribute>
     <id>PM_SLEEP_TYPE</id>
-    <description>PROC_CHIP Attribute Selects which voltage level to
-    place the Core domain PFETs upon Sleep entry. 0 = Vret (Fast
-    Sleep Mode), 1 = Voff (Deep Sleep Mode) Producer: MRWB
-    Consumer: proc_pm_init and proc_pcbs_init</description>
+    <description>PROC_CHIP Attribute Selects which voltage level to place the Core domain PFETs upon Sleep entry. 0 = Vret (Fast Sleep Mode), 1 = Voff (Deep Sleep Mode) Producer: MRWB Consumer: proc_pm_init and proc_pcbs_init</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2380,9 +2121,7 @@
   </attribute>
   <attribute>
     <id>PM_WINKLE_TYPE</id>
-    <description>PROC_CHIP Attribute Selects which voltage level to
-    place the Core and ECO domain PFETs upon Winkle entry. 0 = Vret
-    (Fast Winkle Mode), 1 = Voff (Deep Winkle Mode)</description>
+    <description>PROC_CHIP Attribute Selects which voltage level to place the Core and ECO domain PFETs upon Winkle entry. 0 = Vret (Fast Winkle Mode), 1 = Voff (Deep Winkle Mode)</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2515,11 +2254,7 @@
   </attribute>
   <attribute>
     <id>NEST_LEAKAGE_PERCENT</id>
-    <description>SYSTEM Attribute Nest leakage percentage used to
-    calculate the Core leakage. Will eventually be read into OCC
-    Pstate Parameter Block so the OCC can see it for it's
-    calculations. Valid Values: 0% thru 100% Producer: Machine
-    Readable Workbook Consumer: OCC Firmware</description>
+    <description>SYSTEM Attribute Nest leakage percentage used to calculate the Core leakage. Will eventually be read into OCC Pstate Parameter Block so the OCC can see it for it's calculations. Valid Values: 0% thru 100% Producer: Machine Readable Workbook Consumer: OCC Firmware</description>
     <simpleType>
       <uint8_t>
         <default>60</default>
@@ -2536,14 +2271,7 @@
   <!-- Support for pm_plat_attributes.xml -->
   <attribute>
     <id>EXTERNAL_VRM_STEPSIZE</id>
-    <description>SYSTEM Attribute Step size (binary in microvolts)
-    to take upon external VRM voltage transitions. The value set
-    here must take into account where internal VRMs are enabled or
-    not as, when they are enabled, the step size must account for
-    the tracking (eg PFET strength recalculation) for the step.
-    Consumer: proc_build_pstate_tables.C, proc_pmc_init.C -config
-    Provided by the Machine Readable Workbook after system
-    characterization.</description>
+    <description>SYSTEM Attribute Step size (binary in microvolts) to take upon external VRM voltage transitions. The value set here must take into account where internal VRMs are enabled or not as, when they are enabled, the step size must account for the tracking (eg PFET strength recalculation) for the step. Consumer: proc_build_pstate_tables.C, proc_pmc_init.C -config Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2556,16 +2284,7 @@
   </attribute>
   <attribute>
     <id>EXTERNAL_VRM_TRANSITION_START_NS</id>
-    <description>Delay (binary in nanoseconds) from the time the
-    VRM receives the write voltage command until the voltage
-    actually moves. This value is used for both increasing and
-    decreasing transitions as part of the overall voltage
-    transition time calculation. Firmware provides a default value
-    of 8000ns (eg 8us)) if this attribute is zero. Note: the
-    smallest possible delay is limited to 1ns. Consumer:
-    p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB)
-    for PGPE Provided by the Machine Readable Workbook after system
-    characterization.</description>
+    <description>Delay (binary in nanoseconds) from the time the VRM receives the write voltage command until the voltage actually moves. This value is used for both increasing and decreasing transitions as part of the overall voltage transition time calculation. Firmware provides a default value of 8000ns (eg 8us)) if this attribute is zero. Note: the smallest possible delay is limited to 1ns. Consumer: p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB) for PGPE Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2578,15 +2297,7 @@
   </attribute>
   <attribute>
     <id>EXTERNAL_VRM_TRANSITION_RATE_INC_UV_PER_US</id>
-    <description>Transition rate (binary in microVolts per
-    microsecond) of the VRM for an increasing voltage transition.
-    This is used as part of the overall voltage transition time
-    calculation Firmware provides a default value of 10000 uV/us
-    (eg 10mV/us) if this attribute is zero. Note: the fastest
-    possible rate is limited to 1uV/us. Consumer:
-    p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB)
-    for PGPE Provided by the Machine Readable Workbook after system
-    characterization.</description>
+    <description>Transition rate (binary in microVolts per microsecond) of the VRM for an increasing voltage transition. This is used as part of the overall voltage transition time calculation Firmware provides a default value of 10000 uV/us (eg 10mV/us) if this attribute is zero. Note: the fastest possible rate is limited to 1uV/us. Consumer: p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB) for PGPE Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2599,15 +2310,7 @@
   </attribute>
   <attribute>
     <id>EXTERNAL_VRM_TRANSITION_RATE_DEC_UV_PER_US</id>
-    <description>Transition rate (binary in microVolts per
-    microsecond) of the VRM for an decreasing voltage transition.
-    This is used as part of the overall voltage transition time
-    calculation Firmware provides a default value of 10000 uV/us
-    (eg 10mV/us) if this attribute is zero. Note: the fastest
-    possible rate is limited to 1uV/us. Consumer:
-    p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB)
-    for PGPE Provided by the Machine Readable Workbook after system
-    characterization.</description>
+    <description>Transition rate (binary in microVolts per microsecond) of the VRM for an decreasing voltage transition. This is used as part of the overall voltage transition time calculation Firmware provides a default value of 10000 uV/us (eg 10mV/us) if this attribute is zero. Note: the fastest possible rate is limited to 1uV/us. Consumer: p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB) for PGPE Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2620,15 +2323,7 @@
   </attribute>
   <attribute>
     <id>EXTERNAL_VRM_TRANSITION_STABILIZATION_TIME_NS</id>
-    <description>Time (binary in nanoseconds) to allow the voltage
-    rail to stabilize before considering the transition to be fully
-    complete. This value is used for both increasing and decreasing
-    transitions as part of the overall voltage transition time
-    calculation. Firmware provides a default value of 5000ns (5us)
-    if this attribute is zero. Note: the smallest delay is limited
-    to 1ns. Consumer: p9_pstate_parameter_block -&gt; Pstate
-    Parameter Block (PSPB) for PGPE Provided by the Machine
-    Readable Workbook after system characterization.</description>
+    <description>Time (binary in nanoseconds) to allow the voltage rail to stabilize before considering the transition to be fully complete. This value is used for both increasing and decreasing transitions as part of the overall voltage transition time calculation. Firmware provides a default value of 5000ns (5us) if this attribute is zero. Note: the smallest delay is limited to 1ns. Consumer: p9_pstate_parameter_block -&gt; Pstate Parameter Block (PSPB) for PGPE Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2641,10 +2336,7 @@
   </attribute>
   <attribute>
     <id>EXTERNAL_VRM_STEPDELAY</id>
-    <description>SYSTEM Attribute Step delay (binary in
-    microseconds) after a voltage change Consumer: proc_pmc_init
-    -config Provided by the Machine Readable Workbook after system
-    characterization.</description>
+    <description>SYSTEM Attribute Step delay (binary in microseconds) after a voltage change Consumer: proc_pmc_init -config Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2657,10 +2349,7 @@
   </attribute>
   <attribute>
     <id>PM_SPIVID_FREQUENCY</id>
-    <description>SYSTEM Attribute SPI Clock Frequency (binary in
-    MHz) Consumer: proc_pm_effective Produces
-    ATTR_PM_SPIVID_CLOCK_DIVIDER Provided by the Machine Readable
-    Workbook.</description>
+    <description>SYSTEM Attribute SPI Clock Frequency (binary in MHz) Consumer: proc_pm_effective Produces ATTR_PM_SPIVID_CLOCK_DIVIDER Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2673,12 +2362,7 @@
   </attribute>
   <attribute>
     <id>PM_SPIVID_PORT_ENABLE</id>
-    <description>PROC_CHIP Attribute Defines the configuration of
-    the SPIVID ports from the target. - NONE means that no VRM is
-    attached. - PORTxNONRED means that the indicated port is used
-    in a non-redundant configuration. - REDUNDANT means that all
-    three are connected and considered redundant. Provided by the
-    Machine Readable Workbook.</description>
+    <description>PROC_CHIP Attribute Defines the configuration of the SPIVID ports from the target. - NONE means that no VRM is attached. - PORTxNONRED means that the indicated port is used in a non-redundant configuration. - REDUNDANT means that all three are connected and considered redundant. Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2691,15 +2375,7 @@
   </attribute>
   <attribute>
     <id>PM_SAFE_FREQUENCY</id>
-    <description>Frequency (binary in KHz) indicating the frequency
-    that the cores will be moved to in the event of the loss of the
-    OCC Heartbeat. This value needs to be the maximum of the DpoMin
-    frequency for proper PowerBus operation and the PowerSave value
-    for the present part. Provided by the Machine Readable Workbook
-    after system characterization. The value is translated to the
-    Pstate space. Producer: Machine Readable Workbook Consumers:
-    p8_build_gpstate_table.C DYNAMIC_ATTRIBUTE:
-    ATTR_PM_SAFE_PSTATE</description>
+    <description>Frequency (binary in KHz) indicating the frequency that the cores will be moved to in the event of the loss of the OCC Heartbeat. This value needs to be the maximum of the DpoMin frequency for proper PowerBus operation and the PowerSave value for the present part. Provided by the Machine Readable Workbook after system characterization. The value is translated to the Pstate space. Producer: Machine Readable Workbook Consumers: p8_build_gpstate_table.C DYNAMIC_ATTRIBUTE: ATTR_PM_SAFE_PSTATE</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2712,28 +2388,20 @@
   </attribute>
   <attribute>
     <id>PM_RESONANT_CLOCK_FULL_CLOCK_SECTOR_BUFFER_FREQUENCY</id>
-    <description>SYSTEM Attribute Frequency (binary in MHz) for the
-    point at which clock sector buffers should be at full strength.
-    This is to support Vmin operation. Setting cannot overlap the
-    Low or High bands. Provided by the Machine Readable Workbook
-    after system characterization.</description>
+    <description>SYSTEM Attribute Frequency (binary in MHz) for the point at which clock sector buffers should be at full strength. This is to support Vmin operation. Setting cannot overlap the Low or High bands. Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
     <persistency>non-volatile</persistency>
     <readable />
     <hwpfToHbAttrMap>
-      <id>
-      ATTR_PM_RESONANT_CLOCK_FULL_CLOCK_SECTOR_BUFFER_FREQUENCY</id>
+      <id>ATTR_PM_RESONANT_CLOCK_FULL_CLOCK_SECTOR_BUFFER_FREQUENCY</id>
       <macro>DIRECT</macro>
     </hwpfToHbAttrMap>
   </attribute>
   <attribute>
     <id>PM_RESONANT_CLOCK_LOW_BAND_LOWER_FREQUENCY</id>
-    <description>SYSTEM Attribute Frequency (binary in MHz)) for
-    the lower end of the Low Frequency Resonant band Provided by
-    the Machine Readable Workbook after system
-    characterization.</description>
+    <description>SYSTEM Attribute Frequency (binary in MHz)) for the lower end of the Low Frequency Resonant band Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2746,10 +2414,7 @@
   </attribute>
   <attribute>
     <id>PM_RESONANT_CLOCK_LOW_BAND_UPPER_FREQUENCY</id>
-    <description>SYSTEM Attribute Frequency (binary in MHz) for the
-    upper end of the Low Frequency Resonant band Provided by the
-    Machine Readable Workbook after system
-    characterization.</description>
+    <description>SYSTEM Attribute Frequency (binary in MHz) for the upper end of the Low Frequency Resonant band Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2762,10 +2427,7 @@
   </attribute>
   <attribute>
     <id>PM_RESONANT_CLOCK_HIGH_BAND_LOWER_FREQUENCY</id>
-    <description>SYSTEM Attribute Frequency (binary in MHz) for the
-    lower end of the High Frequency Resonant band Provided by the
-    Machine Readable Workbook after system
-    characterization.</description>
+    <description>SYSTEM Attribute Frequency (binary in MHz) for the lower end of the High Frequency Resonant band Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2778,10 +2440,7 @@
   </attribute>
   <attribute>
     <id>PM_RESONANT_CLOCK_HIGH_BAND_UPPER_FREQUENCY</id>
-    <description>SYSTEM Attribute Frequency (binary in MHz)) for
-    the upper end of the High Frequency Resonant band Provided by
-    the Machine Readable Workbook after system
-    characterization.</description>
+    <description>SYSTEM Attribute Frequency (binary in MHz)) for the upper end of the High Frequency Resonant band Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2794,11 +2453,7 @@
   </attribute>
   <attribute>
     <id>PM_PBAX_NODEID</id>
-    <description>DEPRECATED!!! Use PBAX_GROUPID instead PROC_CHIP
-    Attribute Receive PBAX Nodeid. Value that indicates this PBA's
-    PBAX Node affinity. This is matched to pbax_nodeid of the PMISC
-    Address phase. Provided by the Machine Readable
-    Workbook.</description>
+    <description>DEPRECATED!!! Use PBAX_GROUPID instead PROC_CHIP Attribute Receive PBAX Nodeid. Value that indicates this PBA's PBAX Node affinity. This is matched to pbax_nodeid of the PMISC Address phase. Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2811,10 +2466,7 @@
   </attribute>
   <attribute>
     <id>PBAX_GROUPID</id>
-    <description>PROC_CHIP Attribute Receive PBAX Nodeid. Value
-    that indicates this PBA's PBAX Node affinity. This is matched
-    to pbax_nodeid of the PMISC Address phase. Provided by the
-    Machine Readable Workbook.</description>
+    <description>PROC_CHIP Attribute Receive PBAX Nodeid. Value that indicates this PBA's PBAX Node affinity. This is matched to pbax_nodeid of the PMISC Address phase. Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -2827,11 +2479,7 @@
   </attribute>
   <attribute>
     <id>PBAX_CHIPID</id>
-    <description>PROC_CHIP Attribute Receive PBAX Chipid. Value
-    that indicates this PBA's PBAX Chipid within the PBAX node. Is
-    matched to pbax_chipid of the Address phase if
-    pbax_type=unicast. Provided by the Machine Readable
-    Workbook.</description>
+    <description>PROC_CHIP Attribute Receive PBAX Chipid. Value that indicates this PBA's PBAX Chipid within the PBAX node. Is matched to pbax_chipid of the Address phase if pbax_type=unicast. Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2844,12 +2492,7 @@
   </attribute>
   <attribute>
     <id>PBAX_BRDCST_ID_VECTOR</id>
-    <description>PROC_CHIP Attribute Receive PBAX Broadcast Group.
-    Vector that is indexed when decoded PMISC pbax_type=broadcast
-    with the decoded PMISC pbax_chipid value. If the bit in this
-    vector at the decoded bit location is a 1, then this receive
-    engine will participate in the broadcast operation. Provided by
-    the Machine Readable Workbook.</description>
+    <description>PROC_CHIP Attribute Receive PBAX Broadcast Group. Vector that is indexed when decoded PMISC pbax_type=broadcast with the decoded PMISC pbax_chipid value. If the bit in this vector at the decoded bit location is a 1, then this receive engine will participate in the broadcast operation. Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2862,14 +2505,7 @@
   </attribute>
   <attribute>
     <id>FREQ_CORE_MAX</id>
-    <description>SYSTEM Attribute Maximum frequency (binary in MHz)
-    that any processor in the system will run. Used to define the
-    top end of the PState range in the frequency space. From this,
-    the ATTR_PROCPM_PSTATE0_FREQUENCY is computed using
-    ATTR_SYSTEM_REFCLK_FREQUENCY to determine the step size.
-    Consumers: proc_build_gpstate_table.C (among others) Data is is
-    provided by MVPD #V and is calculated as the minimum of the
-    turbo frequencies</description>
+    <description>SYSTEM Attribute Maximum frequency (binary in MHz) that any processor in the system will run. Used to define the top end of the PState range in the frequency space. From this, the ATTR_PROCPM_PSTATE0_FREQUENCY is computed using ATTR_SYSTEM_REFCLK_FREQUENCY to determine the step size. Consumers: proc_build_gpstate_table.C (among others) Data is is provided by MVPD #V and is calculated as the minimum of the turbo frequencies</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -2884,9 +2520,7 @@
   <!-- End pm_plat_attributes.xml -->
   <attribute>
     <id>PROC_PCIE_IOP_CONFIG</id>
-    <description>PCIE IOP lane configuration creator: platform
-    consumer: proc_pcie_scominit firmware notes: Encoded PCIE IOP
-    lane configuration</description>
+    <description>PCIE IOP lane configuration creator: platform consumer: proc_pcie_scominit firmware notes: Encoded PCIE IOP lane configuration</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2900,10 +2534,7 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_PHB_ACTIVE</id>
-    <description>PCIE PHB valid mask creator: platform consumer:
-    proc_pcie_scominit firmware notes: Bit mask defining set of
-    active/valid PHBs bit0=PHB0, bit1=PHB1, bit2=PHB2,
-    bit3=PHB3</description>
+    <description>PCIE PHB valid mask creator: platform consumer: proc_pcie_scominit firmware notes: Bit mask defining set of active/valid PHBs bit0=PHB0, bit1=PHB1, bit2=PHB2, bit3=PHB3</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -2917,10 +2548,7 @@
   </attribute>
   <attribute>
     <id>AVDD_ID</id>
-    <description>Memory AVDD voltage domain ID. All memory buffers
-    in the same AVDD voltage domain will share the same ID. IDs are
-    arbitrarily assigned, used for correlation between HB + HWSV,
-    and are generated by genHwsvMrwXml.pl</description>
+    <description>Memory AVDD voltage domain ID. All memory buffers in the same AVDD voltage domain will share the same ID. IDs are arbitrarily assigned, used for correlation between HB + HWSV, and are generated by genHwsvMrwXml.pl</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -2931,10 +2559,7 @@
   </attribute>
   <attribute>
     <id>VDD_ID</id>
-    <description>Memory VDD voltage domain ID. All memory buffers
-    in the same VDD voltage domain will share the same ID. IDs are
-    arbitrarily assigned, used for correlation between HB + HWSV,
-    and are generated by genHwsvMrwXml.pl</description>
+    <description>Memory VDD voltage domain ID. All memory buffers in the same VDD voltage domain will share the same ID. IDs are arbitrarily assigned, used for correlation between HB + HWSV, and are generated by genHwsvMrwXml.pl</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -2945,10 +2570,7 @@
   </attribute>
   <attribute>
     <id>VCS_ID</id>
-    <description>Memory VCS voltage domain ID. All memory buffers
-    in the same VCS voltage domain will share the same ID. IDs are
-    arbitrarily assigned, used for correlation between HB + HWSV,
-    and are generated by genHwsvMrwXml.pl</description>
+    <description>Memory VCS voltage domain ID. All memory buffers in the same VCS voltage domain will share the same ID. IDs are arbitrarily assigned, used for correlation between HB + HWSV, and are generated by genHwsvMrwXml.pl</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -2959,10 +2581,7 @@
   </attribute>
   <attribute>
     <id>VPP_ID</id>
-    <description>Memory VPP voltage domain ID. All memory buffers
-    in the same VPP voltage domain will share the same ID. IDs are
-    arbitrarily assigned, used for correlation between HB + HWSV,
-    and are generated by genHwsvMrwXml.pl</description>
+    <description>Memory VPP voltage domain ID. All memory buffers in the same VPP voltage domain will share the same ID. IDs are arbitrarily assigned, used for correlation between HB + HWSV, and are generated by genHwsvMrwXml.pl</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -2973,11 +2592,7 @@
   </attribute>
   <attribute>
     <id>VDDR_ID</id>
-    <description>Voltage Memory Rail Manager ID. Currently HB only
-    needs to configured the Vddr voltage rail manager during the
-    IPL. The ID is an arbitary value and needed as correlation
-    token between HB and HWSV. It will be generated by the
-    genHwsvMrwXml.pl.</description>
+    <description>Voltage Memory Rail Manager ID. Currently HB only needs to configured the Vddr voltage rail manager during the IPL. The ID is an arbitary value and needed as correlation token between HB and HWSV. It will be generated by the genHwsvMrwXml.pl.</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -2988,9 +2603,7 @@
   </attribute>
   <attribute>
     <id>NEST_VDDR_ID</id>
-    <description>Nest VDDR Voltage Rail ID. The ID is an arbitrary
-    value and is needed as correlation token between HB and HWSV.
-    It will be generated by the genHwsvMrwXml.pl</description>
+    <description>Nest VDDR Voltage Rail ID. The ID is an arbitrary value and is needed as correlation token between HB and HWSV. It will be generated by the genHwsvMrwXml.pl</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -3001,9 +2614,7 @@
   </attribute>
   <attribute>
     <id>NEST_VIO_ID</id>
-    <description>Nest VIO Voltage Rail ID. The ID is an arbitrary
-    value and is needed as correlation token between HB and HWSV.
-    It will be generated by the genHwsvMrwXml.pl</description>
+    <description>Nest VIO Voltage Rail ID. The ID is an arbitrary value and is needed as correlation token between HB and HWSV. It will be generated by the genHwsvMrwXml.pl</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -3014,9 +2625,7 @@
   </attribute>
   <attribute>
     <id>NEST_VDD_ID</id>
-    <description>Nest VDD Voltage Rail ID. The ID is an arbitrary
-    value and is needed as correlation token between HB and HWSV.
-    It will be generated by the genHwsvMrwXml.pl</description>
+    <description>Nest VDD Voltage Rail ID. The ID is an arbitrary value and is needed as correlation token between HB and HWSV. It will be generated by the genHwsvMrwXml.pl</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -3027,9 +2636,7 @@
   </attribute>
   <attribute>
     <id>NEST_VDN_ID</id>
-    <description>Nest VDN Voltage Rail ID. The ID is an arbitrary
-    value and is needed as correlation token between HB and HWSV.
-    It will be generated by the genHwsvMrwXml.pl</description>
+    <description>Nest VDN Voltage Rail ID. The ID is an arbitrary value and is needed as correlation token between HB and HWSV. It will be generated by the genHwsvMrwXml.pl</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -3040,9 +2647,7 @@
   </attribute>
   <attribute>
     <id>NEST_VCS_ID</id>
-    <description>Nest VCS Voltage Rail ID. The ID is an arbitrary
-    value and is needed as correlation token between HB and HWSV.
-    It will be generated by the genHwsvMrwXml.pl</description>
+    <description>Nest VCS Voltage Rail ID. The ID is an arbitrary value and is needed as correlation token between HB and HWSV. It will be generated by the genHwsvMrwXml.pl</description>
     <simpleType>
       <uint16_t>
         <default>0</default>
@@ -3069,9 +2674,7 @@
   </attribute>
   <attribute>
     <id>PROC_ADU_UNTRUSTED_BAR_BASE_ADDR</id>
-    <description>ADU Untrusted BAR base address (secure mode)
-    creator: platform firmware notes: 64-bit address representing
-    BAR RA</description>
+    <description>ADU Untrusted BAR base address (secure mode) creator: platform firmware notes: 64-bit address representing BAR RA</description>
     <simpleType>
       <uint64_t>
         <default>0x0000000000000000</default>
@@ -3086,8 +2689,7 @@
   </attribute>
   <attribute>
     <id>PROC_ADU_UNTRUSTED_BAR_SIZE</id>
-    <description>ADU Untrusted BAR size (secure mode) creator:
-    platform firmware notes: mask applied to RA 14:43</description>
+    <description>ADU Untrusted BAR size (secure mode) creator: platform firmware notes: mask applied to RA 14:43</description>
     <simpleType>
       <uint64_t>
         <default>0x0000000000000000</default>
@@ -3102,10 +2704,7 @@
   </attribute>
   <attribute>
     <id>SBE_IMAGE_MINIMUM_VALID_EXS</id>
-    <description>The minimum number of valid EXs that is required
-    to be used when customizing a SBE image. The customization will
-    fail if it cannot create an image with at least this many
-    EXs.</description>
+    <description>The minimum number of valid EXs that is required to be used when customizing a SBE image. The customization will fail if it cannot create an image with at least this many EXs.</description>
     <simpleType>
       <uint32_t>
         <default>3</default>
@@ -3120,9 +2719,7 @@
   </attribute>
   <attribute>
     <id>PROC_PSI_UNTRUSTED_BAR0_BASE_ADDR</id>
-    <description>PSI Untrusted BAR0 base address (secure mode)
-    creator: platform firmware notes: 64-bit address representing
-    BAR RA</description>
+    <description>PSI Untrusted BAR0 base address (secure mode) creator: platform firmware notes: 64-bit address representing BAR RA</description>
     <simpleType>
       <uint64_t>
         <default>0x0000000000000000</default>
@@ -3137,8 +2734,7 @@
   </attribute>
   <attribute>
     <id>PROC_PSI_UNTRUSTED_BAR0_SIZE</id>
-    <description>PSI Untrusted BAR0 size (secure mode) creator:
-    platform firmware notes: mask applied to RA 14:43</description>
+    <description>PSI Untrusted BAR0 size (secure mode) creator: platform firmware notes: mask applied to RA 14:43</description>
     <simpleType>
       <uint64_t>
         <default>0x0000000000000000</default>
@@ -3153,9 +2749,7 @@
   </attribute>
   <attribute>
     <id>PROC_PSI_UNTRUSTED_BAR1_BASE_ADDR</id>
-    <description>PSI Untrusted BAR1 base address (secure mode)
-    creator: platform firmware notes: 64-bit address representing
-    BAR RA</description>
+    <description>PSI Untrusted BAR1 base address (secure mode) creator: platform firmware notes: 64-bit address representing BAR RA</description>
     <simpleType>
       <uint64_t>
         <default>0x0000000000000000</default>
@@ -3170,8 +2764,7 @@
   </attribute>
   <attribute>
     <id>PROC_PSI_UNTRUSTED_BAR1_SIZE</id>
-    <description>PSI Untrusted BAR1 size (secure mode) creator:
-    platform firmware notes: mask applied to RA 14:43</description>
+    <description>PSI Untrusted BAR1 size (secure mode) creator: platform firmware notes: mask applied to RA 14:43</description>
     <simpleType>
       <uint64_t>
         <default>0x0000000000000000</default>
@@ -3186,10 +2779,7 @@
   </attribute>
   <attribute>
     <id>PROC_SECURITY_SETUP_VECTOR</id>
-    <description>Secureboot 64-bit proc_sbe_security_setup_vector
-    used by proc_sbe_security_setup.S. 0s are an unsecure SBE image
-    creator: platform firmware notes: 64-bit
-    proc_sbe_security_setup_vector</description>
+    <description>Secureboot 64-bit proc_sbe_security_setup_vector used by proc_sbe_security_setup.S. 0s are an unsecure SBE image creator: platform firmware notes: 64-bit proc_sbe_security_setup_vector</description>
     <simpleType>
       <uint64_t>
         <default>0x8000000080000000</default>
@@ -3205,11 +2795,7 @@
   <!-- ===== Attributes supporting memory_attributes.xml HWPF Attributes ===== -->
   <attribute>
     <id>MSS_VDDR_PROGRAM</id>
-    <description>VDDR memory programming type 0 = POWERON - domain
-    is programmed as part of regular power on sequence, 1 = STATIC
-    - domain needs to be programmed, no special computation needed,
-    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
-    logic</description>
+    <description>VDDR memory programming type 0 = POWERON - domain is programmed as part of regular power on sequence, 1 = STATIC - domain needs to be programmed, no special computation needed, 2 = DYNAMIC - domain needs to be programmed, uses dynamic vid logic</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3221,11 +2807,7 @@
   </attribute>
   <attribute>
     <id>MSS_VPP_PROGRAM</id>
-    <description>VPP memory programming type 0 = POWERON - domain
-    is programmed as part of regular power on sequence, 1 = STATIC
-    - domain needs to be programmed, no special computation needed,
-    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
-    logic</description>
+    <description>VPP memory programming type 0 = POWERON - domain is programmed as part of regular power on sequence, 1 = STATIC - domain needs to be programmed, no special computation needed, 2 = DYNAMIC - domain needs to be programmed, uses dynamic vid logic</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3237,11 +2819,7 @@
   </attribute>
   <attribute>
     <id>MSS_VCS_PROGRAM</id>
-    <description>VCS memory programming type 0 = POWERON - domain
-    is programmed as part of regular power on sequence, 1 = STATIC
-    - domain needs to be programmed, no special computation needed,
-    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
-    logic</description>
+    <description>VCS memory programming type 0 = POWERON - domain is programmed as part of regular power on sequence, 1 = STATIC - domain needs to be programmed, no special computation needed, 2 = DYNAMIC - domain needs to be programmed, uses dynamic vid logic</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3253,11 +2831,7 @@
   </attribute>
   <attribute>
     <id>MSS_AVDD_PROGRAM</id>
-    <description>AVDD memory programming type 0 = POWERON - domain
-    is programmed as part of regular power on sequence, 1 = STATIC
-    - domain needs to be programmed, no special computation needed,
-    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
-    logic</description>
+    <description>AVDD memory programming type 0 = POWERON - domain is programmed as part of regular power on sequence, 1 = STATIC - domain needs to be programmed, no special computation needed, 2 = DYNAMIC - domain needs to be programmed, uses dynamic vid logic</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3269,11 +2843,7 @@
   </attribute>
   <attribute>
     <id>MSS_VDD_PROGRAM</id>
-    <description>VDD memory programming type 0 = POWERON - domain
-    is programmed as part of regular power on sequence, 1 = STATIC
-    - domain needs to be programmed, no special computation needed,
-    2 = DYNAMIC - domain needs to be programmed, uses dynamic vid
-    logic</description>
+    <description>VDD memory programming type 0 = POWERON - domain is programmed as part of regular power on sequence, 1 = STATIC - domain needs to be programmed, no special computation needed, 2 = DYNAMIC - domain needs to be programmed, uses dynamic vid logic</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3291,10 +2861,7 @@
   <!-- TODO RTC 87603 down to here -->
   <attribute>
     <id>MSS_ZSERIES</id>
-    <description>Determines if the code is Zseries type or P
-    Series. The platform determines this and this attribute is
-    mostly used in the initfiles so that we can share the same
-    initialization code with the zSeries team</description>
+    <description>Determines if the code is Zseries type or P Series. The platform determines this and this attribute is mostly used in the initfiles so that we can share the same initialization code with the zSeries team</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3311,17 +2878,7 @@
      but recent discussions have concluded that a HWP will fill this in, this implementation is correct, memory_attributes.xml will eventually change. -->
   <attribute>
     <id>MSS_INTERLEAVE_ENABLE</id>
-    <description>Used in the setting of groups. It is a bit vector.
-    If the value BITWISE_AND 0x01 = 0x01 then groups of 1 are
-    enabled, if the value BITWISE_AND 0x02 = 0x02, then groups of 2
-    are possible, if the value BITWISE_AND 0x04 = 0x04, then group
-    of 3 are possible, if the value BITWISE_AND 0x08 = 0x08, then
-    groups of 4 are possible, if the value BITWISE_AND 0x20 = 0x20,
-    then groups of 6 are possible, if the value BITWISE_AND 0x80 =
-    0x80, then groups of 8 are possible. If no groups can formed
-    according to this input, then an error will be thrown. Provided
-    by the MRW This attribute is based on Machine-Type-Model (MTM)
-    and is setup by the service processor.</description>
+    <description>Used in the setting of groups. It is a bit vector. If the value BITWISE_AND 0x01 = 0x01 then groups of 1 are enabled, if the value BITWISE_AND 0x02 = 0x02, then groups of 2 are possible, if the value BITWISE_AND 0x04 = 0x04, then group of 3 are possible, if the value BITWISE_AND 0x08 = 0x08, then groups of 4 are possible, if the value BITWISE_AND 0x20 = 0x20, then groups of 6 are possible, if the value BITWISE_AND 0x80 = 0x80, then groups of 8 are possible. If no groups can formed according to this input, then an error will be thrown. Provided by the MRW This attribute is based on Machine-Type-Model (MTM) and is setup by the service processor.</description>
     <simpleType>
       <uint8_t>
         <default>0xAF</default>
@@ -3338,15 +2895,7 @@
   </attribute>
   <attribute>
     <id>MSS_INTERLEAVE_GRANULARITY</id>
-    <description>Determines the stride covered by each granule in
-    an interleaving group. The default stride -- 128B -- is the
-    only value intended for production FW use. All other
-    combinations are for experimental performance evaluation.
-    Regardless of this attribute value, groups of size 1, 3, and 6
-    will be forced to 128B stride based on the logic capabilities.
-    128_B = 0x00, 256_B = 0x01, 512_B = 0x02, 1_KB = 0x03, 2_KB =
-    0x04, 4_KB = 0x05, 8_KB = 0x06, 16_KB = 0x07, 32_KB =
-    0x08</description>
+    <description>Determines the stride covered by each granule in an interleaving group. The default stride -- 128B -- is the only value intended for production FW use. All other combinations are for experimental performance evaluation. Regardless of this attribute value, groups of size 1, 3, and 6 will be forced to 128B stride based on the logic capabilities. 128_B = 0x00, 256_B = 0x01, 512_B = 0x02, 1_KB = 0x03, 2_KB = 0x04, 4_KB = 0x05, 8_KB = 0x06, 16_KB = 0x07, 32_KB = 0x08</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3360,9 +2909,7 @@
   </attribute>
   <attribute>
     <id>MSS_MBA_ADDR_INTERLEAVE_BIT</id>
-    <description>sets the Centaur address bits used to interleave
-    addresses between MBA01 and MBA23. valid values are 23 through
-    32.</description>
+    <description>sets the Centaur address bits used to interleave addresses between MBA01 and MBA23. valid values are 23 through 32.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3377,8 +2924,7 @@
   </attribute>
   <attribute>
     <id>MSS_MBA_CACHELINE_INTERLEAVE_MODE</id>
-    <description>centaur interleave mode. 1 = 256-BIT, 0 =
-    128-BIT.</description>
+    <description>centaur interleave mode. 1 = 256-BIT, 0 = 128-BIT.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3393,9 +2939,7 @@
   </attribute>
   <attribute>
     <id>MSS_PREFETCH_ENABLE</id>
-    <description>Value of on or off. Determines if prefetching
-    enabled or not. See chapter 7 of the Centaur
-    Workbook.</description>
+    <description>Value of on or off. Determines if prefetching enabled or not. See chapter 7 of the Centaur Workbook.</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -3410,10 +2954,7 @@
   </attribute>
   <attribute>
     <id>MSS_CLEANER_ENABLE</id>
-    <description>Value of on or off. Determines if the cleaner of
-    the L4 cache (write modified entries to memory on idle cycles)
-    enabled or not. See chapter 7 of the Centaur
-    Workbook.</description>
+    <description>Value of on or off. Determines if the cleaner of the L4 cache (write modified entries to memory on idle cycles) enabled or not. See chapter 7 of the Centaur Workbook.</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -3443,8 +2984,7 @@
   <!--TOOD RTC: 151938 Make sure that these are set up by parseMRW script-->
   <attribute>
     <id>MSS_MRW_SUPPORTED_FREQ</id>
-    <description>List of memory frequencies supported by the
-    current system.</description>
+    <description>List of memory frequencies supported by the current system.</description>
     <simpleType>
       <uint32_t>
         <default>1866,2133,2400,2667</default>
@@ -3460,13 +3000,7 @@
   </attribute>
   <attribute>
     <id>MEMVPD_POS</id>
-    <description>The position of the MCS target's VPD selector
-    data, relative to the EEPROM that contains its data. The VPD
-    defition supports up to 16 values per EEPROM. For systems with
-    an EEPROM per chip, this value should be equivalent to
-    ATTR_CHIP_UNIT_POS. For systems with a single EEPROM for all
-    chips, the value should follow the physical position in such a
-    way to fit within the 16 available slots.</description>
+    <description>The position of the MCS target's VPD selector data, relative to the EEPROM that contains its data. The VPD defition supports up to 16 values per EEPROM. For systems with an EEPROM per chip, this value should be equivalent to ATTR_CHIP_UNIT_POS. For systems with a single EEPROM for all chips, the value should follow the physical position in such a way to fit within the 16 available slots.</description>
     <simpleType>
       <uint8_t>
         <default>0xFF</default>
@@ -3481,9 +3015,7 @@
   </attribute>
   <attribute>
     <id>MSS_ALLOW_SINGLE_PORT</id>
-    <description>When this value is true, then mss_eff config will
-    allow a single port to have one dimm and will allow ports to
-    have different sizes. Used in eff_config</description>
+    <description>When this value is true, then mss_eff config will allow a single port to have one dimm and will allow ports to have different sizes. Used in eff_config</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3503,12 +3035,7 @@
   <!-- TODO RTC 87603 down to here -->
   <attribute>
     <id>MSS_DQS_SWIZZLE_TYPE</id>
-    <description>DQS Swizzle type is set by the platform to
-    describe what kind of DQS connection is being used for register
-    acceses. Type 0 is normal, type 1 is for systems with wiring
-    like glacier 1, type 2 is for Pallmeto. Additional types maybe
-    defined if new boards have even different DQS swizzle
-    features</description>
+    <description>DQS Swizzle type is set by the platform to describe what kind of DQS connection is being used for register acceses. Type 0 is normal, type 1 is for systems with wiring like glacier 1, type 2 is for Pallmeto. Additional types maybe defined if new boards have even different DQS swizzle features</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3525,10 +3052,7 @@
   <!-- ===== End Attributes supporting memory_attributes.xml HWPF Attributes ===== -->
   <attribute>
     <id>EI_BUS_TX_LANE_INVERT</id>
-    <description>This attribute represents the polarity of a
-    differential wire pair on the DMI and A buses. creator:
-    platform (generated based on MRW data) See defintion in
-    common_attributes.xml for more information.</description>
+    <description>This attribute represents the polarity of a differential wire pair on the DMI and A buses. creator: platform (generated based on MRW data) See defintion in common_attributes.xml for more information.</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -3544,10 +3068,7 @@
   <!-- ===== Supporting poreve_memory_attributes.xml ===== -->
   <attribute>
     <id>SBE_SEEPROM_I2C_ADDRESS_BYTES</id>
-    <description>The number of address bytes required to address
-    the SEEPROM memory device that contains SBE IPL code. This will
-    vary by device based on the device capacity, and must be either
-    1, 2, 3 or 4.</description>
+    <description>The number of address bytes required to address the SEEPROM memory device that contains SBE IPL code. This will vary by device based on the device capacity, and must be either 1, 2, 3 or 4.</description>
     <simpleType>
       <uint8_t>
         <default>2</default>
@@ -3562,13 +3083,7 @@
   </attribute>
   <attribute>
     <id>PNOR_I2C_ADDRESS_BYTES</id>
-    <description>The number of address bytes required to address
-    the PNOR memory device via the pseudo-I2C (LPC, ECCAX)
-    controller. This will vary by device based on the device
-    capacity, and must be either 0, 1, 2, 3 or 4. This attribute
-    will be set to 0 for chips with no PNOR attached (PoreVe will
-    never run on these chips). Provided by the Machine Readable
-    Workbook</description>
+    <description>The number of address bytes required to address the PNOR memory device via the pseudo-I2C (LPC, ECCAX) controller. This will vary by device based on the device capacity, and must be either 0, 1, 2, 3 or 4. This attribute will be set to 0 for chips with no PNOR attached (PoreVe will never run on these chips). Provided by the Machine Readable Workbook</description>
     <simpleType>
       <uint8_t>
         <default>4</default>
@@ -3587,8 +3102,7 @@
   <!--    Support for proc_select_boot_master -->
   <attribute>
     <id>MAX_PROC_CHIPS_PER_NODE</id>
-    <description>System attribute. The max proc chips per node
-    available in the system.</description>
+    <description>System attribute. The max proc chips per node available in the system.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3597,8 +3111,7 @@
   </attribute>
   <attribute>
     <id>MAX_EXS_PER_PROC_CHIP</id>
-    <description>System attribute. The max EX units per proc chip
-    available in the system.</description>
+    <description>System attribute. The max EX units per proc chip available in the system.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3607,8 +3120,7 @@
   </attribute>
   <attribute>
     <id>MAX_DIMMS_PER_MBA_PORT</id>
-    <description>System attribute. The max DIMMs per MBA Port
-    available in the system.</description>
+    <description>System attribute. The max DIMMs per MBA Port available in the system.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3617,8 +3129,7 @@
   </attribute>
   <attribute>
     <id>MAX_MBA_PORTS_PER_MBA</id>
-    <description>System attribute. The max MBA ports per MBA
-    available in the system.</description>
+    <description>System attribute. The max MBA ports per MBA available in the system.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3627,8 +3138,7 @@
   </attribute>
   <attribute>
     <id>MAX_MBAS_PER_MEMBUF_CHIP</id>
-    <description>System attribute. The max MBAS per membuf
-    available in the system.</description>
+    <description>System attribute. The max MBAS per membuf available in the system.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3637,8 +3147,7 @@
   </attribute>
   <attribute>
     <id>MAX_CHIPLETS_PER_PROC</id>
-    <description>System attribute. The max chiplets per proc
-    available in the system.</description>
+    <description>System attribute. The max chiplets per proc available in the system.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3647,8 +3156,7 @@
   </attribute>
   <attribute>
     <id>MAX_MCS_PER_SYSTEM</id>
-    <description>System attribute. The max MCS units available in
-    the system.</description>
+    <description>System attribute. The max MCS units available in the system.</description>
     <simpleType>
       <uint8_t>
         <default>4</default>
@@ -3659,8 +3167,7 @@
   </attribute>
   <attribute>
     <id>TEST_NEGATIVE_FCN</id>
-    <description>Attribute to test signed attribute functionality
-    in the system</description>
+    <description>Attribute to test signed attribute functionality in the system</description>
     <simpleType>
       <int8_t>
         <default>-6</default>
@@ -3673,9 +3180,7 @@
   <!-- Note: This attribute is only used by FSP -->
   <attribute>
     <id>DMI_REFCLOCK_SWIZZLE</id>
-    <description>Defines Murano/Venice/Naples FSI GP8 refclock
-    enable field bit offset (0:7) associated with this MCS chip
-    unit.</description>
+    <description>Defines Murano/Venice/Naples FSI GP8 refclock enable field bit offset (0:7) associated with this MCS chip unit.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -3690,35 +3195,7 @@
   </attribute>
   <attribute>
     <id>EI_BUS_TX_MSBSWAP</id>
-    <description>Source: MRW: Downstream MSB Swap and Upstream MSB
-    Swap Usage: TX_MSBSWAP initfile setting for DMI and A buses
-    This attribute represents whether or not a single clock group
-    bus such as DMI and A bus was wired by the board designer using
-    a feature called MSB Swap where lane 0 of the TX chip wires to
-    lane n-1 on the RX chip where 'n' is the width of the bus. A
-    basic description of this capability is that the board designer
-    can save layers on the board wiring by crossing the wiring
-    between the two chips in a prescribed manner. In a non-MSB
-    Swapped bus Lane 0 on the TX chip wires to lane 0 on the RX
-    chip, lane 1 to lane 1 and so on. If a bus is MSB Swapped then
-    lane 0 of the TX chip wires to lane 'n-1' of the RX chip, lane
-    1 to lane 'n-2', etc. Random or arbitrary wiring of TX to RX
-    lanes on different chips is NOT ALLOWED. The Master Chip of two
-    connected chips is defined as the chip with the smaller value
-    of (100*Node + Pos). The Slave Chip of two connected chips is
-    defined as the chip with the larger value of (100*Node + Pos).
-    The Downstream direction is defined as the direction from the
-    Master chip to the Slave chip. The Upstream direction is
-    defined as the direction from the Slave chip to the Master
-    chip. The Downstream TX_MSBSWAP from the MRW is a uint8 value.
-    0x01 means the Downstream bus is wired msb to lsb etc. and 0x00
-    means the bus is wired normally, msb to msb, lsb to lsb (lane0
-    to lane0). The Upstream TX_MSBSWAP from the MRW is a uint8
-    value. 0x01 means the Upstream bus is wired msb to lsb etc. and
-    0x00 means the bus is wired normally, msb to msb, lsb to lsb
-    (lane0 to lane0). It is up to the platform code to set up each
-    ATTR_EI_BUS_TX_MSBSWAP value for the correct target
-    endpoints.</description>
+    <description>Source: MRW: Downstream MSB Swap and Upstream MSB Swap Usage: TX_MSBSWAP initfile setting for DMI and A buses This attribute represents whether or not a single clock group bus such as DMI and A bus was wired by the board designer using a feature called MSB Swap where lane 0 of the TX chip wires to lane n-1 on the RX chip where 'n' is the width of the bus. A basic description of this capability is that the board designer can save layers on the board wiring by crossing the wiring between the two chips in a prescribed manner. In a non-MSB Swapped bus Lane 0 on the TX chip wires to lane 0 on the RX chip, lane 1 to lane 1 and so on. If a bus is MSB Swapped then lane 0 of the TX chip wires to lane 'n-1' of the RX chip, lane 1 to lane 'n-2', etc. Random or arbitrary wiring of TX to RX lanes on different chips is NOT ALLOWED. The Master Chip of two connected chips is defined as the chip with the smaller value of (100*Node + Pos). The Slave Chip of two connected chips is defined as the chip with the larger value of (100*Node + Pos). The Downstream direction is defined as the direction from the Master chip to the Slave chip. The Upstream direction is defined as the direction from the Slave chip to the Master chip. The Downstream TX_MSBSWAP from the MRW is a uint8 value. 0x01 means the Downstream bus is wired msb to lsb etc. and 0x00 means the bus is wired normally, msb to msb, lsb to lsb (lane0 to lane0). The Upstream TX_MSBSWAP from the MRW is a uint8 value. 0x01 means the Upstream bus is wired msb to lsb etc. and 0x00 means the bus is wired normally, msb to msb, lsb to lsb (lane0 to lane0). It is up to the platform code to set up each ATTR_EI_BUS_TX_MSBSWAP value for the correct target endpoints.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3732,9 +3209,7 @@
   <!-- mcbist attributes -->
   <attribute>
     <id>PROC_DCM_INSTALLED</id>
-    <description>PROC_CHIP Attribute If true, the chip is installed
-    on a Dual Chip Module Provided by the Machine Readable
-    Workbook</description>
+    <description>PROC_CHIP Attribute If true, the chip is installed on a Dual Chip Module Provided by the Machine Readable Workbook</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -3748,10 +3223,7 @@
   <!-- === Attributes supporting erepair_thresholds.xml HWPF Attributes === -->
   <attribute>
     <id>X_EREPAIR_THRESHOLD_FIELD</id>
-    <description>This attribute represents the eRepair threshold
-    value of X-Bus used in the field. creator: platform (generated
-    based on MRW data) See defintion in erepair_thresholds.xml for
-    more information.</description>
+    <description>This attribute represents the eRepair threshold value of X-Bus used in the field. creator: platform (generated based on MRW data) See defintion in erepair_thresholds.xml for more information.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3764,10 +3236,7 @@
   </attribute>
   <attribute>
     <id>A_EREPAIR_THRESHOLD_FIELD</id>
-    <description>This attribute represents the eRepair threshold
-    value of A-Bus used in the field. creator: platform (generated
-    based on MRW data) See defintion in erepair_thresholds.xml for
-    more information.</description>
+    <description>This attribute represents the eRepair threshold value of A-Bus used in the field. creator: platform (generated based on MRW data) See defintion in erepair_thresholds.xml for more information.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3780,10 +3249,7 @@
   </attribute>
   <attribute>
     <id>DMI_EREPAIR_THRESHOLD_FIELD</id>
-    <description>This attribute represents the eRepair threshold
-    value of DMI-Bus used in the field. creator: platform
-    (generated based on MRW data) See defintion in
-    erepair_thresholds.xml for more information.</description>
+    <description>This attribute represents the eRepair threshold value of DMI-Bus used in the field. creator: platform (generated based on MRW data) See defintion in erepair_thresholds.xml for more information.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3796,10 +3262,7 @@
   </attribute>
   <attribute>
     <id>X_EREPAIR_THRESHOLD_MNFG</id>
-    <description>This attribute represents the eRepair threshold
-    value of X-Bus used by Manufacturing. creator: platform
-    (generated based on MRW data) See defintion in
-    erepair_thresholds.xml for more information.</description>
+    <description>This attribute represents the eRepair threshold value of X-Bus used by Manufacturing. creator: platform (generated based on MRW data) See defintion in erepair_thresholds.xml for more information.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3812,10 +3275,7 @@
   </attribute>
   <attribute>
     <id>A_EREPAIR_THRESHOLD_MNFG</id>
-    <description>This attribute represents the eRepair threshold
-    value of A-Bus used by Manufacturing. creator: platform
-    (generated based on MRW data) See defintion in
-    erepair_thresholds.xml for more information.</description>
+    <description>This attribute represents the eRepair threshold value of A-Bus used by Manufacturing. creator: platform (generated based on MRW data) See defintion in erepair_thresholds.xml for more information.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3828,10 +3288,7 @@
   </attribute>
   <attribute>
     <id>DMI_EREPAIR_THRESHOLD_MNFG</id>
-    <description>This attribute represents the eRepair threshold
-    value of DMI-Bus used by Manufacturing. creator: platform
-    (generated based on MRW data) See defintion in
-    erepair_thresholds.xml for more information.</description>
+    <description>This attribute represents the eRepair threshold value of DMI-Bus used by Manufacturing. creator: platform (generated based on MRW data) See defintion in erepair_thresholds.xml for more information.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -3846,8 +3303,7 @@
   <!-- Mem PLL attributes ===== -->
   <attribute>
     <id>MEMB_TP_BNDY_PLL_SCAN_SELECT</id>
-    <description>Scan select for ring image for Centaur tp_bndy_pll
-    ring creator: platform firmware notes:</description>
+    <description>Scan select for ring image for Centaur tp_bndy_pll ring creator: platform firmware notes:</description>
     <simpleType>
       <uint32_t>
         <default>0x00100008</default>
@@ -3862,8 +3318,7 @@
   </attribute>
   <attribute>
     <id>MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_MBA</id>
-    <description>Machine Readable Workbook safe mode throttle value
-    for numerator cfg_nm_n_per_mba</description>
+    <description>Machine Readable Workbook safe mode throttle value for numerator cfg_nm_n_per_mba</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -3876,8 +3331,7 @@
   </attribute>
   <attribute>
     <id>MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_CHIP</id>
-    <description>Machine Readable Workbook safe mode throttle value
-    for numerator cfg_nm_n_per_chip</description>
+    <description>Machine Readable Workbook safe mode throttle value for numerator cfg_nm_n_per_chip</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -3890,10 +3344,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_THERMAL_MEMORY_POWER_LIMIT</id>
-    <description>Machine Readable Workbook Thermal Memory Power
-    Limit Used to calculate throttles to be at or under the power
-    limit Per DIMM basis Consumers: eff_config_thermal and
-    bulk_pwr_throttles</description>
+    <description>Machine Readable Workbook Thermal Memory Power Limit Used to calculate throttles to be at or under the power limit Per DIMM basis Consumers: eff_config_thermal and bulk_pwr_throttles</description>
     <simpleType>
       <uint64_t>
         <default>0xffffe000000006a4,0,0,0,0,0,0,0,0,0</default>
@@ -3909,8 +3360,7 @@
   </attribute>
   <attribute>
     <id>FRU_ID</id>
-    <description>FRU ID attribute used to report FRU information to
-    the BMC for each fru in the system.</description>
+    <description>FRU ID attribute used to report FRU information to the BMC for each fru in the system.</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -3922,8 +3372,7 @@
   </attribute>
   <attribute>
     <id>BMC_FRU_ID</id>
-    <description>BMC FRU ID attribute to report the system firmware
-    levels to the BMC.</description>
+    <description>BMC FRU ID attribute to report the system firmware levels to the BMC.</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -3934,10 +3383,7 @@
   </attribute>
   <attribute>
     <id>CENTAUR_ECID_FRU_ID</id>
-    <description>FRU ID attribute for centaur ECID data. This fru
-    ID is used to report the ECID data to the BMC and make it
-    available for systems which have then centaur chips soldered to
-    the backplane.</description>
+    <description>FRU ID attribute for centaur ECID data. This fru ID is used to report the ECID data to the BMC and make it available for systems which have then centaur chips soldered to the backplane.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -3946,11 +3392,7 @@
   </attribute>
   <attribute>
     <id>PLCK_IPL_ATTR_OVERRIDES_EXIST</id>
-    <description>Set to 1 by HWSV to indicate that attribute
-    overrides exist in a PLCK IPL (not an IPL by steps). This is
-    read by Hostboot to determine if it needs to request the
-    attribute overrides from HWSV before starting its
-    IPL.</description>
+    <description>Set to 1 by HWSV to indicate that attribute overrides exist in a PLCK IPL (not an IPL by steps). This is read by Hostboot to determine if it needs to request the attribute overrides from HWSV before starting its IPL.</description>
     <simpleType>
       <uint8_t>
         <default>0x00</default>
@@ -3978,8 +3420,7 @@
   </attribute>
   <attribute>
     <id>PEER_PATH</id>
-    <description>Entity path of the peer target of an
-    Abus</description>
+    <description>Entity path of the peer target of an Abus</description>
     <nativeType>
       <name>EntityPath</name>
     </nativeType>
@@ -3988,13 +3429,7 @@
   </attribute>
   <attribute>
     <id>MEM_MIRROR_PLACEMENT_POLICY</id>
-    <description>Define placement policy/scheme for
-    non-mirrored/mirrored memory layout creator: platform consumer:
-    opt_memmap firmware notes: NORMAL = non-mirrored start: 0,
-    mirrored start: 512TB FLIPPED = mirrored start: 0, non-mirrored
-    start: 512TB SELECTIVE = non-mirrored/mirrored start
-    (interleaved): 0 DRAWER = non-mirrored start: 1TB*drawer,
-    mirrored start: 512TB+(1TB*drawer/2)</description>
+    <description>Define placement policy/scheme for non-mirrored/mirrored memory layout creator: platform consumer: opt_memmap firmware notes: NORMAL = non-mirrored start: 0, mirrored start: 512TB FLIPPED = mirrored start: 0, non-mirrored start: 512TB SELECTIVE = non-mirrored/mirrored start (interleaved): 0 DRAWER = non-mirrored start: 1TB*drawer, mirrored start: 512TB+(1TB*drawer/2)</description>
     <simpleType>
       <uint8_t>
         <!-- Normal -->
@@ -4011,10 +3446,7 @@
   </attribute>
   <attribute>
     <id>PROC_AS_MMIO_BAR_BASE_ADDR</id>
-    <description>AS MMIO BAR base address value creator: platform
-    consumer: proc_setup_bars firmware notes: 64-bit address
-    representing BAR RA NOTE: BAR register covers RA
-    14:51</description>
+    <description>AS MMIO BAR base address value creator: platform consumer: proc_setup_bars firmware notes: 64-bit address representing BAR RA NOTE: BAR register covers RA 14:51</description>
     <simpleType>
       <uint64_t>
         <default>0</default>
@@ -4029,8 +3461,7 @@
   </attribute>
   <attribute>
     <id>PROC_AS_MMIO_BAR_ENABLE</id>
-    <description>AS MMIO BAR enable creator: platform consumer:
-    proc_setup_bars firmware notes: none</description>
+    <description>AS MMIO BAR enable creator: platform consumer: proc_setup_bars firmware notes: none</description>
     <simpleType>
       <uint8_t>
         <!-- Disabled -->
@@ -4046,8 +3477,7 @@
   </attribute>
   <attribute>
     <id>PROC_AS_MMIO_BAR_SIZE</id>
-    <description>AS MMIO BAR size value creator: platform consumer:
-    proc_setup_bars firmware notes: none</description>
+    <description>AS MMIO BAR size value creator: platform consumer: proc_setup_bars firmware notes: none</description>
     <simpleType>
       <uint64_t>
         <!-- 2_MB -->
@@ -4063,12 +3493,7 @@
   </attribute>
   <attribute>
     <id>MRW_MEM_SENSOR_CACHE_ADDR_MAP</id>
-    <description>Machine Readable Workbook value detailing the
-    wiring of the 8 dimm temperature sensors for non custom dimms,
-    in DIMM A0, A1,B0,B1,C0,C1,D0,D1 order. One nibble per sensor
-    where bit0 (MSB) is the i2c bus the sensor is attached to (0
-    for master, 1 for spare) and bits 1:3 are for A2,A1,A0 of the
-    sensor i2c address (where A2 is MSB)</description>
+    <description>Machine Readable Workbook value detailing the wiring of the 8 dimm temperature sensors for non custom dimms, in DIMM A0, A1,B0,B1,C0,C1,D0,D1 order. One nibble per sensor where bit0 (MSB) is the i2c bus the sensor is attached to (0 for master, 1 for spare) and bits 1:3 are for A2,A1,A0 of the sensor i2c address (where A2 is MSB)</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
@@ -4081,13 +3506,7 @@
   </attribute>
   <attribute>
     <id>CDIMM_SENSOR_MAP_PRIMARY</id>
-    <description>Custom DIMM Sensor Map for Primary I2C Port (1
-    byte of data): 0x00 No sensors attached 0x01 DIMM sensor 0
-    attached 0x02 DIMM sensor 1 attached 0x04 DIMM sensor 2
-    attached 0x08 DIMM sensor 3 attached 0x10 DIMM sensor 4
-    attached 0x20 DIMM sensor 5 attached 0x40 DIMM sensor 6
-    attached 0x80 DIMM sensor 7 attached Comes from the VPD MW
-    Keyword</description>
+    <description>Custom DIMM Sensor Map for Primary I2C Port (1 byte of data): 0x00 No sensors attached 0x01 DIMM sensor 0 attached 0x02 DIMM sensor 1 attached 0x04 DIMM sensor 2 attached 0x08 DIMM sensor 3 attached 0x10 DIMM sensor 4 attached 0x20 DIMM sensor 5 attached 0x40 DIMM sensor 6 attached 0x80 DIMM sensor 7 attached Comes from the VPD MW Keyword</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4102,13 +3521,7 @@
   </attribute>
   <attribute>
     <id>CDIMM_SENSOR_MAP_SECONDARY</id>
-    <description>Custom DIMM Sensor Map for Secondary I2C Port (1
-    byte of data): 0x00 No sensors attached 0x01 DIMM sensor 0
-    attached 0x02 DIMM sensor 1 attached 0x04 DIMM sensor 2
-    attached 0x08 DIMM sensor 3 attached 0x10 DIMM sensor 4
-    attached 0x20 DIMM sensor 5 attached 0x40 DIMM sensor 6
-    attached 0x80 DIMM sensor 7 attached Comes from the VPD MW
-    Keyword</description>
+    <description>Custom DIMM Sensor Map for Secondary I2C Port (1 byte of data): 0x00 No sensors attached 0x01 DIMM sensor 0 attached 0x02 DIMM sensor 1 attached 0x04 DIMM sensor 2 attached 0x08 DIMM sensor 3 attached 0x10 DIMM sensor 4 attached 0x20 DIMM sensor 5 attached 0x40 DIMM sensor 6 attached 0x80 DIMM sensor 7 attached Comes from the VPD MW Keyword</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4123,10 +3536,7 @@
   </attribute>
   <attribute>
     <id>CDM_POLICIES</id>
-    <description>Cec Degraded Mode Policy flags Use the
-    CDM_POLICIES enum to decode. If the appropriate bit is 1 then
-    the policy mode is enabled, and those type of Guard records are
-    disabled.</description>
+    <description>Cec Degraded Mode Policy flags Use the CDM_POLICIES enum to decode. If the appropriate bit is 1 then the policy mode is enabled, and those type of Guard records are disabled.</description>
     <simpleType>
       <uint8_t>
         <default>0x00</default>
@@ -4140,38 +3550,19 @@
     <id>CDM_POLICIES</id>
     <description>Enumeration of CDM_POLICIES flags</description>
     <enumerator>
-      <description>MFG_Guard policy: Used in MFG only to prevent
-      and disable the following: . Storing or creation of new Guard
-      records from Diagno`stic or other faults through error logs.
-      This is all domains, CEC processor/memory, VPD, FSP, etc. .
-      Storing or creation of Manual Guard record from user. NOTE:
-      this does not stop FCO. . Using an already stored System or
-      Manual Guard record from deconfiguring resources. This is all
-      domains, CEC processor/memory, VPD, FSP, etc.</description>
+      <description>MFG_Guard policy: Used in MFG only to prevent and disable the following: . Storing or creation of new Guard records from Diagno`stic or other faults through error logs. This is all domains, CEC processor/memory, VPD, FSP, etc. . Storing or creation of Manual Guard record from user. NOTE: this does not stop FCO. . Using an already stored System or Manual Guard record from deconfiguring resources. This is all domains, CEC processor/memory, VPD, FSP, etc.</description>
       <name>MANUFACTURING_DISABLED</name>
       <value>0x01</value>
     </enumerator>
     <enumerator>
-      <description>Predictive_Guard policy: Used in Field or
-      development to prevent and disable the following: . Storing
-      or creation of new Guard records from diagnostics or other
-      faults through error logs with the error_type of Predictive.
-      . Using an already stored System Guard record with error_type
-      of Predictive from deconfiguring resources.</description>
+      <description>Predictive_Guard policy: Used in Field or development to prevent and disable the following: . Storing or creation of new Guard records from diagnostics or other faults through error logs with the error_type of Predictive. . Using an already stored System Guard record with error_type of Predictive from deconfiguring resources.</description>
       <name>PREDICTIVE_DISABLED</name>
       <value>0x02</value>
     </enumerator>
   </enumerationType>
   <attribute>
     <id>FIELD_CORE_OVERRIDE</id>
-    <description>Field Core Override (FCO) is the override value
-    for the number of functional cores allowed on the system. FCO
-    is used when customers order a system with N cores but they
-    only want to enable less than N cores to lower software license
-    costs. A field in the anchor VPD is set by manufacturing to
-    specify the maximum number of cores to enable. The number is
-    maintained, even if some cores are garded out due to error. A
-    value of 0 means all cores allowed;</description>
+    <description>Field Core Override (FCO) is the override value for the number of functional cores allowed on the system. FCO is used when customers order a system with N cores but they only want to enable less than N cores to lower software license costs. A field in the anchor VPD is set by manufacturing to specify the maximum number of cores to enable. The number is maintained, even if some cores are garded out due to error. A value of 0 means all cores allowed;</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -4183,8 +3574,7 @@
   </attribute>
   <attribute>
     <id>HOSTSVC_PLID</id>
-    <description>Value of the next PLID that host service should
-    send</description>
+    <description>Value of the next PLID that host service should send</description>
     <simpleType>
       <uint32_t>
         <default>0x89000000</default>
@@ -4196,11 +3586,7 @@
   </attribute>
   <attribute>
     <id>RUN_MAX_MEM_PATTERNS</id>
-    <description>Policy indicating whether to perform the maximum
-    amount of memory pattern testing possible or not. Set to 0x01
-    to perform the maximum amount of memory pattern testing
-    possible. Set to 0x00 to perform the default amount of memory
-    pattern testing.</description>
+    <description>Policy indicating whether to perform the maximum amount of memory pattern testing possible or not. Set to 0x01 to perform the maximum amount of memory pattern testing possible. Set to 0x00 to perform the default amount of memory pattern testing.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4212,11 +3598,7 @@
   </attribute>
   <attribute>
     <id>LAB_USE_JTAG_MODE</id>
-    <description>This attribute controls how the procedures operate
-    in JTAG mode under an environment called cronus flex. For
-    normal operation, this attribute should be set to FALSE.
-    Platforms should initialize this attribute to
-    FALSE.</description>
+    <description>This attribute controls how the procedures operate in JTAG mode under an environment called cronus flex. For normal operation, this attribute should be set to FALSE. Platforms should initialize this attribute to FALSE.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4265,10 +3647,7 @@
   </attribute>
   <attribute>
     <id>DISABLE_I2C_ACCESS</id>
-    <description>Set to skip physical access to i2c interface in
-    SBE execution. Consumed by SBE hooks to permit skipping of
-    selected code when running on a test platform (i.e., wafer)
-    which does not have a physical SEEPROM connected.</description>
+    <description>Set to skip physical access to i2c interface in SBE execution. Consumed by SBE hooks to permit skipping of selected code when running on a test platform (i.e., wafer) which does not have a physical SEEPROM connected.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4284,8 +3663,7 @@
   </attribute>
   <attribute>
     <id>PROC_REFCLOCK_RCVR_TERM</id>
-    <description>Defines system specific value of processor
-    refclock receiver termination (FSI GP4 bits 8:9)</description>
+    <description>Defines system specific value of processor refclock receiver termination (FSI GP4 bits 8:9)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4301,8 +3679,7 @@
   </attribute>
   <attribute>
     <id>PCI_REFCLOCK_RCVR_TERM</id>
-    <description>Defines system specific value of PCI refclock
-    receiver termination (FSI GP4 bits 10:11)</description>
+    <description>Defines system specific value of PCI refclock receiver termination (FSI GP4 bits 10:11)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4318,10 +3695,7 @@
   </attribute>
   <attribute>
     <id>DD1_SLOW_PCI_REF_CLOCK</id>
-    <description>Valid only for Nimbus DD1 If set (=1), run the PCI
-    Ref clock at 94MHz in order to enable experimental GEN4
-    support. If not set (=0), run the PCI Ref clock at
-    100MHz</description>
+    <description>Valid only for Nimbus DD1 If set (=1), run the PCI Ref clock at 94MHz in order to enable experimental GEN4 support. If not set (=0), run the PCI Ref clock at 100MHz</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4338,8 +3712,7 @@
   </attribute>
   <attribute>
     <id>MEMB_DMI_REFCLOCK_RCVR_TERM</id>
-    <description>Defines system specific value of DMI refclock
-    receiver termination (FSI GP4 bits 8:9)</description>
+    <description>Defines system specific value of DMI refclock receiver termination (FSI GP4 bits 8:9)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4355,8 +3728,7 @@
   </attribute>
   <attribute>
     <id>MEMB_DDR_REFCLOCK_RCVR_TERM</id>
-    <description>Defines system specific value of DDR refclock
-    receiver termination (FSI GP4 bits 10:11)</description>
+    <description>Defines system specific value of DDR refclock receiver termination (FSI GP4 bits 10:11)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4372,8 +3744,7 @@
   </attribute>
   <attribute>
     <id>MEM_FILTER_PLL_SOURCE</id>
-    <description>Defines source of MEM filter PLL input (FSI GP4
-    bit 23)</description>
+    <description>Defines source of MEM filter PLL input (FSI GP4 bit 23)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4389,13 +3760,7 @@
   </attribute>
   <enumerationType>
     <id>MULTI_SCOM_BUFFER_MAX_SIZE_BIT</id>
-    <description>Enumeration indicating the multi scome buffer
-    size. The values can be combined using a bitwise 'OR'. The
-    values will need to be kept in sync with the FAPI enumerator
-    values. Also the enumeration type is used by the
-    ATTR_MULTI_SCOM_BUFFER_MAX_SIZE. Should note that the
-    MULTI_SCOM_BUFFER_MAX_SIZE values are of type
-    uint32_t</description>
+    <description>Enumeration indicating the multi scome buffer size. The values can be combined using a bitwise 'OR'. The values will need to be kept in sync with the FAPI enumerator values. Also the enumeration type is used by the ATTR_MULTI_SCOM_BUFFER_MAX_SIZE. Should note that the MULTI_SCOM_BUFFER_MAX_SIZE values are of type uint32_t</description>
     <enumerator>
       <name>MULTI_SCOM_BUFFER_SIZE_1KB</name>
       <value>0x00000400</value>
@@ -4443,8 +3808,7 @@
   </enumerationType>
   <attribute>
     <id>DMI_DFE_OVERRIDE</id>
-    <description>Defines where to apply DMI bus DFE override
-    settings for HW244323.</description>
+    <description>Defines where to apply DMI bus DFE override settings for HW244323.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4459,11 +3823,7 @@
   </attribute>
   <attribute>
     <id>CPM_TURBO_BOOST_PERCENT</id>
-    <description>Percent of Boost Above Turbo for CPMs - (binary in
-    0.1 percent steps) Used in generating extra Pstate tables
-    beyond those that would result from #V data. Producer: DEF file
-    as this is CCIN based Consumers: p8_build_gpstate_table.C,
-    p8_cpm_cal_load.C Platform default: 0</description>
+    <description>Percent of Boost Above Turbo for CPMs - (binary in 0.1 percent steps) Used in generating extra Pstate tables beyond those that would result from #V data. Producer: DEF file as this is CCIN based Consumers: p8_build_gpstate_table.C, p8_cpm_cal_load.C Platform default: 0</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -4476,14 +3836,7 @@
   </attribute>
   <attribute>
     <id>PM_UNDERVOLTING_FRQ_MINIMUM</id>
-    <description>Override for Minimum frequency for which
-    undervolting is allowed. If value = 0, the value of VPD CPMin
-    data point is passed to OCC FW via Pstate SuperStructure. If
-    value != 0, this value will be passed to OCC FW via Pstate
-    SuperStructure as the floor frequency for enabled CPMs. Will be
-    internally rounded to the nearest ATTR_PROC_REFCLK_FREQUENCY /
-    8 value. Consumer: OCC FW; OCC Lab Tools Provided by the
-    Machine Readable Workbook.</description>
+    <description>Override for Minimum frequency for which undervolting is allowed. If value = 0, the value of VPD CPMin data point is passed to OCC FW via Pstate SuperStructure. If value != 0, this value will be passed to OCC FW via Pstate SuperStructure as the floor frequency for enabled CPMs. Will be internally rounded to the nearest ATTR_PROC_REFCLK_FREQUENCY / 8 value. Consumer: OCC FW; OCC Lab Tools Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4496,14 +3849,7 @@
   </attribute>
   <attribute>
     <id>PM_UNDERVOLTING_FREQ_MAXIMUM</id>
-    <description>Override for Maximum frequency for which
-    undervolting is allowed. If value = 0, the value of VPD Turbo
-    data point is passed to OCC FW via Pstate SuperStructure. If
-    value != 0, this value will be passed to OCC FW via Pstate
-    SuperStructure as the ceiling frequency for enabled CPMs. Will
-    be internally rounded to the nearest ATTR_PROC_REFCLK_FREQUENCY
-    / 8 value. Consumer: OCC FW; OCC Lab Tools Provided by the
-    Machine Readable Workbook.</description>
+    <description>Override for Maximum frequency for which undervolting is allowed. If value = 0, the value of VPD Turbo data point is passed to OCC FW via Pstate SuperStructure. If value != 0, this value will be passed to OCC FW via Pstate SuperStructure as the ceiling frequency for enabled CPMs. Will be internally rounded to the nearest ATTR_PROC_REFCLK_FREQUENCY / 8 value. Consumer: OCC FW; OCC Lab Tools Provided by the Machine Readable Workbook.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4516,12 +3862,7 @@
   </attribute>
   <attribute>
     <id>PM_WINKLE_ENTRY</id>
-    <description>Setting depends on di/dt charateristics of the
-    system. Set Assisted if power off serialization is needed and
-    WINKLE_TYPE=Fast; Set to Hardware if the system can handle the
-    unrelated powering off between cores. Hardware setting
-    decreases entry latency Producer: MRWB Consumer:
-    p8_poreslw_init.C</description>
+    <description>Setting depends on di/dt charateristics of the system. Set Assisted if power off serialization is needed and WINKLE_TYPE=Fast; Set to Hardware if the system can handle the unrelated powering off between cores. Hardware setting decreases entry latency Producer: MRWB Consumer: p8_poreslw_init.C</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4534,15 +3875,7 @@
   </attribute>
   <attribute>
     <id>PM_WINKLE_EXIT</id>
-    <description>Setting depends on di/dt charateristics of the
-    system and the setting of ATTR_PM_WINKLE_TYPE. Set to Assisted
-    if power on serialization is needed and WINKLE_TYPE=Fast; Set
-    to Hardware if the system can handle the unrelated powering off
-    between cores. Hardware setting decreases entry latency. Must
-    be set to Assisted if ATTR_PM_WINKLE_TYPE=Deep as this
-    necessary for restore. Setting to Hardware is a test mode for
-    Fast only. Producer: MRWB Consumer:
-    p8_poreslw_init.C</description>
+    <description>Setting depends on di/dt charateristics of the system and the setting of ATTR_PM_WINKLE_TYPE. Set to Assisted if power on serialization is needed and WINKLE_TYPE=Fast; Set to Hardware if the system can handle the unrelated powering off between cores. Hardware setting decreases entry latency. Must be set to Assisted if ATTR_PM_WINKLE_TYPE=Deep as this necessary for restore. Setting to Hardware is a test mode for Fast only. Producer: MRWB Consumer: p8_poreslw_init.C</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4555,8 +3888,7 @@
   </attribute>
   <enumerationType>
     <id>PROC_MASTER_TYPE</id>
-    <description>Enumeration indicating the role of proc as
-    master/alt_master/not_master</description>
+    <description>Enumeration indicating the role of proc as master/alt_master/not_master</description>
     <enumerator>
       <name>ACTING_MASTER</name>
       <value>0</value>
@@ -4573,8 +3905,7 @@
   </enumerationType>
   <attribute>
     <id>PROC_MASTER_TYPE</id>
-    <description>Type of Master, ACTING_MASTER or MASTER_CANDIDATE
-    or NOT_MASTER</description>
+    <description>Type of Master, ACTING_MASTER or MASTER_CANDIDATE or NOT_MASTER</description>
     <simpleType>
       <uint8_t>
         <default>NOT_MASTER</default>
@@ -4587,12 +3918,7 @@
   </attribute>
   <attribute>
     <id>EFFECTIVE_EC</id>
-    <description>Holds the effective EC of the system. Effective EC
-    is the lowest EC among all the functional procs in the system.
-    Some cards may "downbin" the effective ECs of their contained
-    processors, which could lower the effective EC of the system
-    beyond what would occur when considering processor ECs
-    alone</description>
+    <description>Holds the effective EC of the system. Effective EC is the lowest EC among all the functional procs in the system. Some cards may "downbin" the effective ECs of their contained processors, which could lower the effective EC of the system beyond what would occur when considering processor ECs alone</description>
     <simpleType>
       <uint8_t>
         <default>0x10</default>
@@ -4615,8 +3941,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT</id>
-    <description>Machine Readable Workbook DIMM power curve percent
-    uplift for this system</description>
+    <description>Machine Readable Workbook DIMM power curve percent uplift for this system</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4631,8 +3956,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT_IDLE</id>
-    <description>Machine Readable Workbook DIMM power curve percent
-    uplife idle for this system</description>
+    <description>Machine Readable Workbook DIMM power curve percent uplife idle for this system</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -4647,8 +3971,7 @@
   </attribute>
   <attribute>
     <id>MRW_MEM_THROTTLE_DENOMINATOR</id>
-    <description>Machine Readable Workbook throttle value for
-    denominator cfg_nm_m</description>
+    <description>Machine Readable Workbook throttle value for denominator cfg_nm_m</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -4661,9 +3984,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_MAX_DRAM_DATABUS_UTIL</id>
-    <description>Machine Readable Workbook value for maximum dram
-    data bus utilization in centi percent (c%). Used to determine
-    memory throttle values.</description>
+    <description>Machine Readable Workbook value for maximum dram data bus utilization in centi percent (c%). Used to determine memory throttle values.</description>
     <simpleType>
       <uint32_t>
         <default>0x00002328</default>
@@ -4678,13 +3999,7 @@
   </attribute>
   <attribute>
     <id>PM_SYSTEM_IVRM_VPD_MIN_LEVEL</id>
-    <description>Version level of #M that represents the minimum
-    for IVRM characterized parts. If this value is non-zero and the
-    #M version level is less than this value, IVRMs are disabled.
-    If the #M version is greater than or equal to this value, the
-    IVRMs are allowed to be enable from a level of part
-    perspective. Producer: MRWB Consumer:
-    p8_build_pstate_datablock.C</description>
+    <description>Version level of #M that represents the minimum for IVRM characterized parts. If this value is non-zero and the #M version level is less than this value, IVRMs are disabled. If the #M version is greater than or equal to this value, the IVRMs are allowed to be enable from a level of part perspective. Producer: MRWB Consumer: p8_build_pstate_datablock.C</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4697,10 +4012,7 @@
   </attribute>
   <attribute>
     <id>MRW_STRICT_MBA_PLUG_RULE_CHECKING</id>
-    <description>The MRW for a system should set this to TRUE for
-    systems that must obey plug rules. Lab environments should
-    default this to off and allow the user to override using normal
-    methods to test.</description>
+    <description>The MRW for a system should set this to TRUE for systems that must obey plug rules. Lab environments should default this to off and allow the user to override using normal methods to test.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4713,9 +4025,7 @@
   </attribute>
   <attribute>
     <id>MRW_MBA_CACHELINE_INTERLEAVE_MODE_CONTROL</id>
-    <description>At a system level, this attribute controls if
-    interleaving is required, requested or never. The
-    MRW.</description>
+    <description>At a system level, this attribute controls if interleaving is required, requested or never. The MRW.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4728,9 +4038,7 @@
   </attribute>
   <attribute>
     <id>REDUNDANT_CLOCKS</id>
-    <description>1 = System has redundant clock oscillators 0 =
-    System does not have redundant clock oscillators From the
-    Machine Readable Workbook</description>
+    <description>1 = System has redundant clock oscillators 0 = System does not have redundant clock oscillators From the Machine Readable Workbook</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4743,8 +4051,7 @@
   </attribute>
   <attribute>
     <id>MRW_HW_MIRRORING_ENABLE</id>
-    <description>0 : HW mirroring is disabled. 1 : HW mirroring is
-    enabled. Provided by the MRW.</description>
+    <description>0 : HW mirroring is disabled. 1 : HW mirroring is enabled. Provided by the MRW.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4757,10 +4064,7 @@
   </attribute>
   <attribute>
     <id>MNFG_DMI_MIN_EYE_WIDTH</id>
-    <description>System attribute. 6 bit rx_min_eye_width value for
-    DMI bus interfaces during system manufacturing; used for both
-    centaur and p8 creator: platform firmware notes: Attribute
-    value is in the Machine Readable Workbook</description>
+    <description>System attribute. 6 bit rx_min_eye_width value for DMI bus interfaces during system manufacturing; used for both centaur and p8 creator: platform firmware notes: Attribute value is in the Machine Readable Workbook</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -4773,10 +4077,7 @@
   </attribute>
   <attribute>
     <id>MNFG_DMI_MIN_EYE_HEIGHT</id>
-    <description>System attribute. 8 bit rx_min_eye_height value
-    for DMI bus interfaces during system manufacturing; used for
-    both centaur and p8 creator: platform firmware notes: Attribute
-    value is in the Machine Readable Workbook</description>
+    <description>System attribute. 8 bit rx_min_eye_height value for DMI bus interfaces during system manufacturing; used for both centaur and p8 creator: platform firmware notes: Attribute value is in the Machine Readable Workbook</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -4789,10 +4090,7 @@
   </attribute>
   <attribute>
     <id>MNFG_ABUS_MIN_EYE_WIDTH</id>
-    <description>System attribute 6 bit rx_min_eye_width value for
-    A bus interfaces during system manufacturing creator: platform
-    firmware notes: Attribute value is in the Machine Readable
-    Workbook</description>
+    <description>System attribute 6 bit rx_min_eye_width value for A bus interfaces during system manufacturing creator: platform firmware notes: Attribute value is in the Machine Readable Workbook</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -4805,10 +4103,7 @@
   </attribute>
   <attribute>
     <id>MNFG_ABUS_MIN_EYE_HEIGHT</id>
-    <description>System attribute 8 bit rx_min_eye_height value for
-    A bus interfaces during system manufacturing creator: platform
-    firmware notes: Attribute value is in the Machine Readable
-    Workbook</description>
+    <description>System attribute 8 bit rx_min_eye_height value for A bus interfaces during system manufacturing creator: platform firmware notes: Attribute value is in the Machine Readable Workbook</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -4821,10 +4116,7 @@
   </attribute>
   <attribute>
     <id>MNFG_XBUS_MIN_EYE_WIDTH</id>
-    <description>System attribute 6 bit rx_min_eye_width value for
-    X bus interfaces during system manufacturing creator: platform
-    firmware notes: Attribute value is in the Machine Readable
-    Workbook</description>
+    <description>System attribute 6 bit rx_min_eye_width value for X bus interfaces during system manufacturing creator: platform firmware notes: Attribute value is in the Machine Readable Workbook</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -4837,8 +4129,7 @@
   </attribute>
   <attribute>
     <id>HB_RSV_MEM_SIZE_MB</id>
-    <description>The amount of mainstore that PHYP needs to
-    preserve per node during MPIPL.</description>
+    <description>The amount of mainstore that PHYP needs to preserve per node during MPIPL.</description>
     <simpleType>
       <uint32_t>
         <default>256</default>
@@ -4849,8 +4140,7 @@
   </attribute>
   <attribute>
     <id>MRW_CDIMM_MASTER_I2C_TEMP_SENSOR_ENABLE</id>
-    <description>Used for Custom DIMMs to not enable the reading of
-    the dimm temperature sensor on the master i2c bus</description>
+    <description>Used for Custom DIMMs to not enable the reading of the dimm temperature sensor on the master i2c bus</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4863,8 +4153,7 @@
   </attribute>
   <attribute>
     <id>MRW_CDIMM_SPARE_I2C_TEMP_SENSOR_ENABLE</id>
-    <description>Used for Custom DIMMs to not enable the reading of
-    the dimm temperature sensor on the spare i2c bus</description>
+    <description>Used for Custom DIMMs to not enable the reading of the dimm temperature sensor on the spare i2c bus</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -4877,9 +4166,7 @@
   </attribute>
   <attribute>
     <id>DO_ABUS_DECONFIG</id>
-    <description>Indicates if system should consider abus logic
-    when deconfiguring in _deconfigureAssocProc(), will be
-    overwritten on multi-node system</description>
+    <description>Indicates if system should consider abus logic when deconfiguring in _deconfigureAssocProc(), will be overwritten on multi-node system</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -5076,8 +4363,7 @@
   </attribute>
   <attribute>
     <id>MRW_DDR3_VDDR_MAX_LIMIT</id>
-    <description>Maximum voltage limit for the dynamic VID DDR3
-    VDDR voltage setpoint. In mV.</description>
+    <description>Maximum voltage limit for the dynamic VID DDR3 VDDR voltage setpoint. In mV.</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -5112,8 +4398,7 @@
   </attribute>
   <attribute>
     <id>MRW_DDR3_VDDR_MAX_LIMIT_POST_DRAM_INIT</id>
-    <description>Maximum voltage limit for the dynamic VID DDR3
-    VDDR voltage setpoint. In mV.</description>
+    <description>Maximum voltage limit for the dynamic VID DDR3 VDDR voltage setpoint. In mV.</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -5147,8 +4432,7 @@
   </attribute>
   <attribute>
     <id>MRW_DDR4_VDDR_MAX_LIMIT</id>
-    <description>Maximum voltage limit for the dynamic VID DDR4
-    VDDR voltage setpoint. In mV.</description>
+    <description>Maximum voltage limit for the dynamic VID DDR4 VDDR voltage setpoint. In mV.</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -5183,8 +4467,7 @@
   </attribute>
   <attribute>
     <id>MRW_DDR4_VDDR_MAX_LIMIT_POST_DRAM_INIT</id>
-    <description>Maximum voltage limit for the dynamic VID DDR4
-    VDDR voltage setpoint. In mV.</description>
+    <description>Maximum voltage limit for the dynamic VID DDR4 VDDR voltage setpoint. In mV.</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -5196,8 +4479,7 @@
   </attribute>
   <enumerationType>
     <id>MSS_MRW_POWER_CONTROL_REQUESTED</id>
-    <description>Enumeration defining the type of power control
-    requested</description>
+    <description>Enumeration defining the type of power control requested</description>
     <enumerator>
       <name>OFF</name>
       <value>0</value>
@@ -5218,10 +4500,7 @@
   </enumerationType>
   <attribute>
     <id>MSS_MRW_POWER_CONTROL_REQUESTED</id>
-    <description>Memory power control settings programmed during
-    IPL Used by OCC when exiting idle powersave mode Producer: MRW
-    0x00 = OFF 0x01 = POWER_DOWN 0x02 = STR 0x03 =
-    PD_AND_STR</description>
+    <description>Memory power control settings programmed during IPL Used by OCC when exiting idle powersave mode Producer: MRW 0x00 = OFF 0x01 = POWER_DOWN 0x02 = STR 0x03 = PD_AND_STR</description>
     <simpleType>
       <uint8_t>
         <default>OFF</default>
@@ -5236,8 +4515,7 @@
   </attribute>
   <enumerationType>
     <id>MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
-    <description>Enumeration defining the type of power control
-    requested</description>
+    <description>Enumeration defining the type of power control requested</description>
     <enumerator>
       <name>OFF</name>
       <value>0</value>
@@ -5258,10 +4536,7 @@
   </enumerationType>
   <attribute>
     <id>MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
-    <description>Memory power control settings for IDLE powersave
-    mode Used by OCC when entering idle powersave mode Producer:
-    MRW 0x00 = OFF 0x01 = POWER_DOWN 0x02 = STR 0x03 =
-    PD_AND_STR</description>
+    <description>Memory power control settings for IDLE powersave mode Used by OCC when entering idle powersave mode Producer: MRW 0x00 = OFF 0x01 = POWER_DOWN 0x02 = STR 0x03 = PD_AND_STR</description>
     <simpleType>
       <uint8_t>
         <default>OFF</default>
@@ -5276,9 +4551,7 @@
   </attribute>
   <attribute>
     <id>OCC_MASTER_CAPABLE</id>
-    <description>This attribute is to determine whether an occ is
-    master capable. An OCC is master capable if it's parent
-    processor is wired to the APSS.</description>
+    <description>This attribute is to determine whether an occ is master capable. An OCC is master capable if it's parent processor is wired to the APSS.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -5290,9 +4563,7 @@
   </attribute>
   <attribute>
     <id>MSS_DRAMINIT_RESET_DISABLE</id>
-    <description>A disable switch for resetting the phy delay
-    values at the beginning of calling
-    mss_draminit_training.</description>
+    <description>A disable switch for resetting the phy delay values at the beginning of calling mss_draminit_training.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -5307,8 +4578,7 @@
   </attribute>
   <attribute>
     <id>ISDIMM_POWER_CURVE_ALGORITHM_VERSION</id>
-    <description>version of algorithm used to calculate ISDIMM
-    power curves</description>
+    <description>version of algorithm used to calculate ISDIMM power curves</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -5324,18 +4594,7 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_LANE_MASK</id>
-    <description>Effective PCIE Lane Mask Creator: Firmware
-    Purpose: Holds the effective PCIE lane mask of each PEC after
-    taking into account any IOP bifurcations. If no IOP
-    bifurcations present, this is just the value of the
-    PEC_PCIE_LANE_MASK_NON_BIFURCATED attribute Data Format: x4
-    array of uint16_t values. The uint16_t value is a mask for lane
-    0, the next for lane 1 and so on until lane 3. A lane set mask
-    indicates which groups of lanes are assigned to an IOP. For
-    instance, lane set 0 value of 0xFFFF and lane set 1 value of
-    0x0000 for PEC0 means PEC0 is a x16. Lane set 0 value of 0xFF00
-    and lane set 1 value of 0x00FF for PEC0, means the IOP is
-    bifurcated into two x8s.</description>
+    <description>Effective PCIE Lane Mask Creator: Firmware Purpose: Holds the effective PCIE lane mask of each PEC after taking into account any IOP bifurcations. If no IOP bifurcations present, this is just the value of the PEC_PCIE_LANE_MASK_NON_BIFURCATED attribute Data Format: x4 array of uint16_t values. The uint16_t value is a mask for lane 0, the next for lane 1 and so on until lane 3. A lane set mask indicates which groups of lanes are assigned to an IOP. For instance, lane set 0 value of 0xFFFF and lane set 1 value of 0x0000 for PEC0 means PEC0 is a x16. Lane set 0 value of 0xFF00 and lane set 1 value of 0x00FF for PEC0, means the IOP is bifurcated into two x8s.</description>
     <simpleType>
       <uint16_t></uint16_t>
       <array>4</array>
@@ -5346,15 +4605,7 @@
   </attribute>
   <attribute>
     <id>PEC_PCIE_IOP_REVERSAL</id>
-    <description>Effective PCIE IOP reversal configuration Creator:
-    Firmware Purpose: Holds the effective PCIE IOP reversal value
-    after taking into account any IOP bifurcations. If no IOP
-    bifurcations present, this is just the value of the
-    PROC_PCIE_IOP_REVERSAL_NON_BIFURCATED attribute. Data Format:
-    x4 array of uint8_t values. The first uint8_t value is for lane
-    set 0, the second for lane set 1 and so on. The given index in
-    the array is a mask which specifies which bit to invert in the
-    lane swap settings for the given PEC/lane set.</description>
+    <description>Effective PCIE IOP reversal configuration Creator: Firmware Purpose: Holds the effective PCIE IOP reversal value after taking into account any IOP bifurcations. If no IOP bifurcations present, this is just the value of the PROC_PCIE_IOP_REVERSAL_NON_BIFURCATED attribute. Data Format: x4 array of uint8_t values. The first uint8_t value is for lane set 0, the second for lane set 1 and so on. The given index in the array is a mask which specifies which bit to invert in the lane swap settings for the given PEC/lane set.</description>
     <simpleType>
       <uint8_t></uint8_t>
       <array>4</array>
@@ -5365,13 +4616,7 @@
   </attribute>
   <attribute>
     <id>PEC_PCIE_IOP_REVERSAL_NON_BIFURCATED</id>
-    <description>Base PCIE IOP reversal configuration Creator:
-    Firmware Purpose: Holds the base PCIE IOP reversal value
-    without considering IOP bifurcation. Data Format: x4 array of
-    uint8_t values. The first uint8_t value is for lane set 0, the
-    second for lane set 1 and so on. The given index in the array
-    is a mask which specifies which bit to invert in the lane swap
-    settings for the given lane set.</description>
+    <description>Base PCIE IOP reversal configuration Creator: Firmware Purpose: Holds the base PCIE IOP reversal value without considering IOP bifurcation. Data Format: x4 array of uint8_t values. The first uint8_t value is for lane set 0, the second for lane set 1 and so on. The given index in the array is a mask which specifies which bit to invert in the lane swap settings for the given lane set.</description>
     <simpleType>
       <uint8_t></uint8_t>
       <array>4</array>
@@ -5381,13 +4626,7 @@
   </attribute>
   <attribute>
     <id>PEC_PCIE_IOP_SWAP_NON_BIFURCATED</id>
-    <description>Base PCIE IOP swap configuration value Creator:
-    MRW Purpose: Holds the base IOP swap configuration value
-    without considering IOP bifurcation. The swap value controls
-    how PCIE lanes are recordered when the leave the IOP, to
-    provide lane routing flexibility. Data Format: A uint8_t value.
-    The value specifices for the hardware how to swap the PCIE
-    lanes for the given PEC.</description>
+    <description>Base PCIE IOP swap configuration value Creator: MRW Purpose: Holds the base IOP swap configuration value without considering IOP bifurcation. The swap value controls how PCIE lanes are recordered when the leave the IOP, to provide lane routing flexibility. Data Format: A uint8_t value. The value specifices for the hardware how to swap the PCIE lanes for the given PEC.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -5396,15 +4635,7 @@
   </attribute>
   <attribute>
     <id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
-    <description>PCIE Lane Mask base configuration Creator: MRW
-    Purpose: Holds the base PCIE lane mask assuming no dynamic IOP
-    bifurcations. Data Format: x4 array of uint16_t values. The
-    first uint8_t value is lane set 0, the second for lane set 2
-    and so on. A lane set mask indicates which groups of lanes are
-    assigned to an IOP. For instance, lane set 0 value of 0xFFFF
-    and lane set 1 value of 0x0000 means the PEC is a x16. Lane set
-    0 value of 0xFF00 and lane set 1 value of 0x00FF, means the PEC
-    is split into two x8s.</description>
+    <description>PCIE Lane Mask base configuration Creator: MRW Purpose: Holds the base PCIE lane mask assuming no dynamic IOP bifurcations. Data Format: x4 array of uint16_t values. The first uint8_t value is lane set 0, the second for lane set 2 and so on. A lane set mask indicates which groups of lanes are assigned to an IOP. For instance, lane set 0 value of 0xFFFF and lane set 1 value of 0x0000 means the PEC is a x16. Lane set 0 value of 0xFF00 and lane set 1 value of 0x00FF, means the PEC is split into two x8s.</description>
     <simpleType>
       <uint16_t></uint16_t>
       <array>4</array>
@@ -5414,13 +4645,7 @@
   </attribute>
   <attribute>
     <id>PEC_PCIE_IOP_REVERSAL_BIFURCATED</id>
-    <description>Base PCIE IOP reversal configuration Creator:
-    Firmware Purpose: Holds the PCIE IOP reversal value for cases
-    where the IOP is bifurcated Data Format: x4 array of uint8_t
-    values. The first uint8_t value is lane set 0, the second for
-    lane set 2 and so on. The given index in the array is a mask
-    which specifies which bit to invert in the lane swap settings
-    for the given lane set</description>
+    <description>Base PCIE IOP reversal configuration Creator: Firmware Purpose: Holds the PCIE IOP reversal value for cases where the IOP is bifurcated Data Format: x4 array of uint8_t values. The first uint8_t value is lane set 0, the second for lane set 2 and so on. The given index in the array is a mask which specifies which bit to invert in the lane swap settings for the given lane set</description>
     <simpleType>
       <uint8_t></uint8_t>
       <array>4</array>
@@ -5430,13 +4655,7 @@
   </attribute>
   <attribute>
     <id>PEC_PCIE_IOP_SWAP_BIFURCATED</id>
-    <description>Bifurcated PCIE IOP swap configuration value
-    Creator: MRW Purpose: Holds the base IOP swap configuration
-    value for the IOPs in the case where they are bifurcated. The
-    swap value controls how PCIE lanes are recordered when the
-    leave the IOP, to provide lane routing flexibility. Data
-    Format: A uint8_t value. The value specifices for the hardware
-    how to swap the PCIE lanes for the given PEC.</description>
+    <description>Bifurcated PCIE IOP swap configuration value Creator: MRW Purpose: Holds the base IOP swap configuration value for the IOPs in the case where they are bifurcated. The swap value controls how PCIE lanes are recordered when the leave the IOP, to provide lane routing flexibility. Data Format: A uint8_t value. The value specifices for the hardware how to swap the PCIE lanes for the given PEC.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -5445,14 +4664,7 @@
   </attribute>
   <attribute>
     <id>PEC_PCIE_LANE_MASK_BIFURCATED</id>
-    <description>PCIE Lane Mask bifurcated configuration Creator:
-    MRW Purpose: Holds the PCIE lane mask assuming IOPs are
-    bifurcated. Data Format: x4 array of uint16_t values. The first
-    uint8_t value is lane set 0, the second for lane set 2 and so
-    on. A lane set mask indicates which groups of lanes are
-    assigned to an IOP. For instance, lane set 0 value of 0xFF00
-    and lane set 1 value of 0x00FF means the IOP is bifurcated into
-    two x8s.</description>
+    <description>PCIE Lane Mask bifurcated configuration Creator: MRW Purpose: Holds the PCIE lane mask assuming IOPs are bifurcated. Data Format: x4 array of uint16_t values. The first uint8_t value is lane set 0, the second for lane set 2 and so on. A lane set mask indicates which groups of lanes are assigned to an IOP. For instance, lane set 0 value of 0xFF00 and lane set 1 value of 0x00FF means the IOP is bifurcated into two x8s.</description>
     <simpleType>
       <uint16_t></uint16_t>
       <array>4</array>
@@ -5462,17 +4674,7 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_IS_SLOT</id>
-    <description>Indicates whether PCIE lanes terminate at a
-    pluggable slot Creator: MRW Purpose: Used by FW to know whether
-    the given PCIE lanes terminate at a pluggable slot or not. If
-    this is the case, and the platform supports bifurcation, the
-    card's VPD should be interrogated to determine whether to
-    bifurcate the IOP or not. Data Format: x4 array of uint8_t
-    values. The first value indicates whether lane set 0 terminates
-    at a pluggable slot. The next three values indicate the same
-    for lane sets 1-3. A value of 1 at a given array index
-    indicates the lanes terminate at a pluggable slot, 0
-    otherwise.</description>
+    <description>Indicates whether PCIE lanes terminate at a pluggable slot Creator: MRW Purpose: Used by FW to know whether the given PCIE lanes terminate at a pluggable slot or not. If this is the case, and the platform supports bifurcation, the card's VPD should be interrogated to determine whether to bifurcate the IOP or not. Data Format: x4 array of uint8_t values. The first value indicates whether lane set 0 terminates at a pluggable slot. The next three values indicate the same for lane sets 1-3. A value of 1 at a given array index indicates the lanes terminate at a pluggable slot, 0 otherwise.</description>
     <simpleType>
       <uint8_t></uint8_t>
       <array>4</array>
@@ -5482,8 +4684,7 @@
   </attribute>
   <enumerationType>
     <id>CDM_DOMAIN</id>
-    <description>Enumeration specifying a target's CEC degraded
-    mode domain</description>
+    <description>Enumeration specifying a target's CEC degraded mode domain</description>
     <enumerator>
       <name>NONE</name>
       <value>0</value>
@@ -5532,9 +4733,7 @@
   </enumerationType>
   <attribute>
     <id>CDM_DOMAIN</id>
-    <description>Specifies a target's CEC degraded mode domain. For
-    example, all DIMMs are part of the DIMM CEC degraded mode
-    domain.</description>
+    <description>Specifies a target's CEC degraded mode domain. For example, all DIMMs are part of the DIMM CEC degraded mode domain.</description>
     <simpleType>
       <enumeration>
         <id>CDM_DOMAIN</id>
@@ -5546,27 +4745,19 @@
   </attribute>
   <attribute>
     <id>I2C_BUS_SPEED_ARRAY</id>
-    <description>Designates the speed at which a given I2C bus
-    should run. Creator: MRW Purpose: Used by FW to know the
-    fastest possible bus speed that all of the devices on a given
-    bus are able to use. Data Format: 4x4 array of uint16_t values.
-    The first index indicates the engine number of the bus. The
-    second index indicates the port number of the bus. The value in
-    the array is the I2C bus speed used for that engine/port
-    combination in KHz.</description>
+    <description>Designates the speed at which a given I2C bus should run. Creator: MRW Purpose: Used by FW to know the fastest possible bus speed that all of the devices on a given bus are able to use. Data Format: 4x13 array of uint16_t values. The first index indicates the engine number of the bus. The second index indicates the port number of the bus. The value in the array is the I2C bus speed used for that engine/port combination in KHz.</description>
     <simpleType>
       <uint16_t>
-        <default>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>
+        <default>0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0</default>
       </uint16_t>
-      <array>4,4</array>
+      <array>4,13</array>
     </simpleType>
     <persistency>non-volatile</persistency>
     <readable />
   </attribute>
   <enumerationType>
     <id>SUPPORTED_HOT_PLUG</id>
-    <description>Enumeration indication which Hot Plug Controllers
-    are supported by the current system.</description>
+    <description>Enumeration indication which Hot Plug Controllers are supported by the current system.</description>
     <enumerator>
       <name>NA</name>
       <value>0</value>
@@ -5583,24 +4774,10 @@
   </enumerationType>
   <attribute>
     <id>HOT_PLUG_POWER_CONTROLLER_INFO</id>
-    <description>Hot Plug Controller values for a specific
-    processor. Purpose: Holds information about the hot plug
-    controllers so that a Hardware procedure is able to turn them
-    on and off. Data Format: up to 8 Hot Plug Controllers x 7
-    variables of information This data is at the processor level.
-    The needed information and their individual sizes are as
-    follows: (1) I2C Master processor engine (uint8_t) (2) I2C
-    Master processor port (uint8_t) (3) Bus Speed (uint16_t value:
-    2 uint8_t values: MSB, LSB) (4) Slave address (uint8_t) (5)
-    Device type (uint8_t: see SUPPORTED_HOT_PLUG enum) (6) I2C
-    Master processor node (uint8_t) (7) I2C Master processor
-    position (uint8_t) Thus, the information will be 8
-    bytes.</description>
+    <description>Hot Plug Controller values for a specific processor. Purpose: Holds information about the hot plug controllers so that a Hardware procedure is able to turn them on and off. Data Format: up to 8 Hot Plug Controllers x 7 variables of information This data is at the processor level. The needed information and their individual sizes are as follows: (1) I2C Master processor engine (uint8_t) (2) I2C Master processor port (uint8_t) (3) Bus Speed (uint16_t value: 2 uint8_t values: MSB, LSB) (4) Slave address (uint8_t) (5) Device type (uint8_t: see SUPPORTED_HOT_PLUG enum) (6) I2C Master processor node (uint8_t) (7) I2C Master processor position (uint8_t) Thus, the information will be 8 bytes.</description>
     <simpleType>
       <uint8_t>
-        <default>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>
+        <default>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>
       </uint8_t>
       <array>8,8</array>
     </simpleType>
@@ -5613,9 +4790,7 @@
   </attribute>
   <attribute>
     <id>OPT_MEMMAP_GROUP_POLICY</id>
-    <description>Controls scope of grouping performed in memory map
-    calculations Possible values defined in FAPI
-    ATTR_OPT_MEMMAP_GROUP_POLICY</description>
+    <description>Controls scope of grouping performed in memory map calculations Possible values defined in FAPI ATTR_OPT_MEMMAP_GROUP_POLICY</description>
     <simpleType>
       <uint8_t>
         <default>0x00</default>
@@ -5631,8 +4806,7 @@
   </attribute>
   <attribute>
     <id>TPM_REQUIRED</id>
-    <description>Setting to require(0x1) or not require(0x0) a
-    functional TPM to boot the system.</description>
+    <description>Setting to require(0x1) or not require(0x0) a functional TPM to boot the system.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -5643,9 +4817,7 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_NUM_PHB</id>
-    <description>creator: platform Number of PCIe PHB units present
-    on target Murano/Venice: 3 Naples: 4 Nimbus: 6 Cumulus:
-    6</description>
+    <description>creator: platform Number of PCIe PHB units present on target Murano/Venice: 3 Naples: 4 Nimbus: 6 Cumulus: 6</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -5658,8 +4830,7 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_NUM_IOP</id>
-    <description>creator: platform Number of PCIe IOP units present
-    on target Murano/Venice: 2 Naples: 3 Nimbus: 3</description>
+    <description>creator: platform Number of PCIe IOP units present on target Murano/Venice: 2 Naples: 3 Nimbus: 3</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -5672,8 +4843,7 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_NUM_PEC</id>
-    <description>creator: platform Number of PCIe PEC units present
-    on target Nimbus: 3</description>
+    <description>creator: platform Number of PCIe PEC units present on target Nimbus: 3</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -5686,9 +4856,7 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_NUM_LANES</id>
-    <description>creator: platform Number of PCIe I/O lanes
-    supported by target Murano: 24 Venice: 32 Naples: 40 Nimbus:
-    48</description>
+    <description>creator: platform Number of PCIe I/O lanes supported by target Murano: 24 Venice: 32 Naples: 40 Nimbus: 48</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -5702,9 +4870,7 @@
   <!-- === start configurable threshold attributes for PRD === -->
   <attribute>
     <id>MNFG_TH_P8EX_L2_CACHE_CES</id>
-    <description>This attribute represents the Maximum number of L2
-    Cache CEs allowed during Manufacturing. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L2 Cache CEs allowed during Manufacturing. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -5715,9 +4881,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_P8EX_L2_DIR_CES</id>
-    <description>This attribute represents the Maximum number of L2
-    Directory CEs allowed during Manufacturing. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L2 Directory CEs allowed during Manufacturing. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -5728,9 +4892,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_P8EX_L3_CACHE_CES</id>
-    <description>This attribute represents the Maximum number of L3
-    Cache CEs allowed during Manufacturing. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L3 Cache CEs allowed during Manufacturing. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>3</default>
@@ -5741,9 +4903,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_P8EX_L3_DIR_CES</id>
-    <description>This attribute represents the Maximum number of L3
-    Directory CEs allowed during Manufacturing. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L3 Directory CEs allowed during Manufacturing. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -5754,9 +4914,7 @@
   </attribute>
   <attribute>
     <id>FIELD_TH_P8EX_L2_LINE_DELETES</id>
-    <description>This attribute represents the Maximum number of L2
-    Line Deletes allowed in the Field. creator: platform (generated
-    based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L2 Line Deletes allowed in the Field. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>6</default>
@@ -5767,9 +4925,7 @@
   </attribute>
   <attribute>
     <id>FIELD_TH_P8EX_L3_LINE_DELETES</id>
-    <description>This attribute represents the Maximum number of L3
-    Line Deletes allowed in the Field. creator: platform (generated
-    based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L3 Line Deletes allowed in the Field. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>6</default>
@@ -5780,9 +4936,7 @@
   </attribute>
   <attribute>
     <id>FIELD_TH_P8EX_L2_COL_REPAIRS</id>
-    <description>This attribute represents the Maximum number of L2
-    Column Repairs allowed in the Field. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L2 Column Repairs allowed in the Field. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>7</default>
@@ -5793,9 +4947,7 @@
   </attribute>
   <attribute>
     <id>FIELD_TH_P8EX_L3_COL_REPAIRS</id>
-    <description>This attribute represents the Maximum number of L3
-    Column Repairs allowed in the Field. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L3 Column Repairs allowed in the Field. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>7</default>
@@ -5806,9 +4958,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_P8EX_L2_LINE_DELETES</id>
-    <description>This attribute represents the Maximum number of L2
-    Line Deletes allowed during Manufacturing. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L2 Line Deletes allowed during Manufacturing. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -5819,9 +4969,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_P8EX_L3_LINE_DELETES</id>
-    <description>This attribute represents the Maximum number of L3
-    Line Deletes allowed during Manufacturing. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L3 Line Deletes allowed during Manufacturing. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -5832,9 +4980,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_P8EX_L2_COL_REPAIRS</id>
-    <description>This attribute represents the Maximum number of L2
-    Column Repairs allowed during Manufacturing. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L2 Column Repairs allowed during Manufacturing. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -5845,9 +4991,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_P8EX_L3_COL_REPAIRS</id>
-    <description>This attribute represents the Maximum number of L3
-    Column Repairs allowed during Manufacturing. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Maximum number of L3 Column Repairs allowed during Manufacturing. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -5858,9 +5002,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_CEN_MBA_RT_SOFT_CE_TH_ALGO</id>
-    <description>This attribute represents the Base threshold (for
-    2GB DRAM ) of Memory CEs allowed during runtime. creator:
-    platform (generated based on MRW data)</description>
+    <description>This attribute represents the Base threshold (for 2GB DRAM ) of Memory CEs allowed during runtime. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>2</default>
@@ -5871,9 +5013,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_CEN_MBA_IPL_SOFT_CE_TH_ALGO</id>
-    <description>This attribute represents the Base threshold (for
-    2GB DRAM ) of Memory CEs allowed during IPL. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the Base threshold (for 2GB DRAM ) of Memory CEs allowed during IPL. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>2</default>
@@ -5884,9 +5024,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_CEN_MBA_RT_RCE_PER_RANK</id>
-    <description>This attribute represents the maximum number of
-    Memory RCEs allowed per Rank during runtime. creator: platform
-    (generated based on MRW data)</description>
+    <description>This attribute represents the maximum number of Memory RCEs allowed per Rank during runtime. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>2</default>
@@ -5897,9 +5035,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_CEN_L4_CACHE_CES</id>
-    <description>This attribute represents the maximum number of L4
-    Cache CEs allowed. creator: platform (generated based on MRW
-    data)</description>
+    <description>This attribute represents the maximum number of L4 Cache CEs allowed. creator: platform (generated based on MRW data)</description>
     <simpleType>
       <uint8_t>
         <default>2</default>
@@ -5910,10 +5046,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_RCD_PARITY_ERRORS</id>
-    <description>With MNFG thresholds enabled, PRD will make a
-    predictive callout when an RCD parity error (recovery enabled)
-    attention count is equal to this value. A value of 0 defaults
-    to the max threshold of 0xff.</description>
+    <description>With MNFG thresholds enabled, PRD will make a predictive callout when an RCD parity error (recovery enabled) attention count is equal to this value. A value of 0 defaults to the max threshold of 0xff.</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -5924,10 +5057,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_MEMORY_IUES</id>
-    <description>With MNFG thresholds enabled, PRD will make a
-    predictive callout when a memory intermittent UE attention
-    count is equal to this value. A value of 0 defaults to the max
-    threshold of 0xff.</description>
+    <description>With MNFG thresholds enabled, PRD will make a predictive callout when a memory intermittent UE attention count is equal to this value. A value of 0 defaults to the max threshold of 0xff.</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -5938,10 +5068,7 @@
   </attribute>
   <attribute>
     <id>MNFG_TH_MEMORY_IMPES</id>
-    <description>With MNFG thresholds enabled, PRD will make a
-    predictive callout when a memory intermittent MPE attention
-    count is equal to this value. A value of 0 defaults to the max
-    threshold of 0xff.</description>
+    <description>With MNFG thresholds enabled, PRD will make a predictive callout when a memory intermittent MPE attention count is equal to this value. A value of 0 defaults to the max threshold of 0xff.</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -5954,12 +5081,7 @@
   <!-- === start RCD parity error reconfig loop attributes for PRD/MDIA === -->
   <attribute>
     <id>RCD_PARITY_RECONFIG_LOOPS_ALLOWED</id>
-    <description>The number of reconfig loops allowed due to RCD
-    parity errors when recovery is disabled. PRD will make a
-    predictive callout and stop issuing reconfigs due to RCD parity
-    errors when RCD_PARITY_RECONFIG_LOOP_COUNT is greater than this
-    value. A value of 0 indicates that no reconfig loops are
-    allowed due to RCD parity errors.</description>
+    <description>The number of reconfig loops allowed due to RCD parity errors when recovery is disabled. PRD will make a predictive callout and stop issuing reconfigs due to RCD parity errors when RCD_PARITY_RECONFIG_LOOP_COUNT is greater than this value. A value of 0 indicates that no reconfig loops are allowed due to RCD parity errors.</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -5970,11 +5092,7 @@
   </attribute>
   <attribute>
     <id>RCD_PARITY_RECONFIG_LOOP_COUNT</id>
-    <description>PRD will increment this count and issue a reconfig
-    loop each time an RCD parity error (recovery disabled) is
-    detected during Memory Diagnostics. This value will be cleared
-    at the end of Memory Diagnostics if it is able to complete
-    without the need to issue a reconfig loop.</description>
+    <description>PRD will increment this count and issue a reconfig loop each time an RCD parity error (recovery disabled) is detected during Memory Diagnostics. This value will be cleared at the end of Memory Diagnostics if it is able to complete without the need to issue a reconfig loop.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -5987,9 +5105,7 @@
   <!-- === end RCD parity error reconfig loop attributes for PRD/MDIA === -->
   <attribute>
     <id>RESOURCE_IS_CRITICAL</id>
-    <description>Used to tell if a resource is critical to perform
-    an IPL. If this attribute is set to 1 and the target is
-    deconfigured, the IPL MUST terminate.</description>
+    <description>Used to tell if a resource is critical to perform an IPL. If this attribute is set to 1 and the target is deconfigured, the IPL MUST terminate.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -6000,9 +5116,7 @@
   </attribute>
   <attribute>
     <id>BRAZOS_RX_FIFO_OVERRIDE</id>
-    <description>Defines where to apply Brazos
-    rx_fifo_final_l2u_dly override settings for
-    SW299500.</description>
+    <description>Defines where to apply Brazos rx_fifo_final_l2u_dly override settings for SW299500.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -6018,9 +5132,7 @@
   <!-- === Manufacturing threshold Attributes of PRD === -->
   <attribute>
     <id>MSS_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
-    <description>Machine Readable Workbook enablement of the HWP
-    code to adjust the VMEM regulator power limit based on number
-    of installed DIMMs.</description>
+    <description>Machine Readable Workbook enablement of the HWP code to adjust the VMEM regulator power limit based on number of installed DIMMs.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -6029,16 +5141,13 @@
     <persistency>non-volatile</persistency>
     <readable />
     <hwpfToHbAttrMap>
-      <id>
-      ATTR_MSS_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
+      <id>ATTR_MSS_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
       <macro>DIRECT</macro>
     </hwpfToHbAttrMap>
   </attribute>
   <attribute>
     <id>MSS_MRW_MAX_NUMBER_DIMMS_POSSIBLE_PER_VMEM_REGULATOR</id>
-    <description>Machine Readable Workbook value for the maximum
-    possible number of dimms that can be installed under any of the
-    VMEM regulators.</description>
+    <description>Machine Readable Workbook value for the maximum possible number of dimms that can be installed under any of the VMEM regulators.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -6047,26 +5156,7 @@
     <persistency>non-volatile</persistency>
     <readable />
     <hwpfToHbAttrMap>
-      <id>
-      ATTR_MSS_MRW_MAX_NUMBER_DIMMS_POSSIBLE_PER_VMEM_REGULATOR</id>
-      <macro>DIRECT</macro>
-    </hwpfToHbAttrMap>
-  </attribute>
-  <attribute>
-    <id>WOF_ENABLED</id>
-    <description>Defines if the Workload Optimization Frequency
-    (WOF) system feature where OCC algorithms will change
-    (typically boost) the operational frequency based on measured
-    power available and any currently idling cores.</description>
-    <simpleType>
-      <uint8_t>
-        <default>0</default>
-      </uint8_t>
-    </simpleType>
-    <persistency>non-volatile</persistency>
-    <readable />
-    <hwpfToHbAttrMap>
-      <id>ATTR_WOF_ENABLED</id>
+      <id>ATTR_MSS_MRW_MAX_NUMBER_DIMMS_POSSIBLE_PER_VMEM_REGULATOR</id>
       <macro>DIRECT</macro>
     </hwpfToHbAttrMap>
   </attribute>
@@ -6080,8 +5170,7 @@
   <!--Deprecated-->
   <attribute>
     <id>VAS_HYPERVISOR_WINDOW_CONTEXT_ADDR</id>
-    <description>VAS - Hypervisor Window Contexts address MMIO
-    consumed by PHYP</description>
+    <description>VAS - Hypervisor Window Contexts address MMIO consumed by PHYP</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -6090,8 +5179,7 @@
   </attribute>
   <attribute>
     <id>VAS_USER_WINDOW_CONTEXT_ADDR</id>
-    <description>VAS - User Window Context address MMIO consumed by
-    PHYP</description>
+    <description>VAS - User Window Context address MMIO consumed by PHYP</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -6100,8 +5188,7 @@
   </attribute>
   <attribute>
     <id>NVIDIA_NPU_PRIVILEGED_ADDR</id>
-    <description>Nvidia Link - NPU Privileged Regs address MMIO
-    consumed by PHYP</description>
+    <description>Nvidia Link - NPU Privileged Regs address MMIO consumed by PHYP</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -6110,8 +5197,7 @@
   </attribute>
   <attribute>
     <id>NVIDIA_NPU_USER_REG_ADDR</id>
-    <description>Nvidia Link - NPU User Regs address MMIO consumed
-    by PHYP</description>
+    <description>Nvidia Link - NPU User Regs address MMIO consumed by PHYP</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -6120,8 +5206,7 @@
   </attribute>
   <attribute>
     <id>NVIDIA_PHY0_REG_ADDR</id>
-    <description>Nvidia Link - Phy 0 Regs address MMIO consumed by
-    PHYP</description>
+    <description>Nvidia Link - Phy 0 Regs address MMIO consumed by PHYP</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -6130,8 +5215,7 @@
   </attribute>
   <attribute>
     <id>NVIDIA_PHY1_REG_ADDR</id>
-    <description>Nvidia Link - Phy 1 Regs address MMIO consumed by
-    PHYP</description>
+    <description>Nvidia Link - Phy 1 Regs address MMIO consumed by PHYP</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -6140,8 +5224,7 @@
   </attribute>
   <attribute>
     <id>PSI_HB_ESB_ADDR</id>
-    <description>PSIHB - ESB space address - MMIO consumed by
-    PHYP</description>
+    <description>PSIHB - ESB space address - MMIO consumed by PHYP</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -6151,8 +5234,7 @@
   </attribute>
   <attribute>
     <id>NX_RNG_ADDR</id>
-    <description>NX - RNG space - MMIO consumed by
-    PHYP</description>
+    <description>NX - RNG space - MMIO consumed by PHYP</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -6177,11 +5259,7 @@
   </enumerationType>
   <attribute>
     <id>FUSED_CORE_MODE</id>
-    <description>Stores the SMT setting used to determine fused
-    mode. SMT4_DEFAULT: Nimbus_DD1, boot in SMT4 but can change to
-    SMT8 SMT4_ONLY: Nimbus_DD2/Cumulus, set based on PVR info
-    SMT8_ONLY: Nimbus_DD2/Cumulus, set based on PVR
-    info</description>
+    <description>Stores the SMT setting used to determine fused mode. SMT4_DEFAULT: Nimbus_DD1, boot in SMT4 but can change to SMT8 SMT4_ONLY: Nimbus_DD2/Cumulus, set based on PVR info SMT8_ONLY: Nimbus_DD2/Cumulus, set based on PVR info</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6375,8 +5453,7 @@
   </attribute>
   <attribute>
     <id>PFET_POWERUP_DELAY_NS</id>
-    <description>Time (in nanoseconds) between PFET controller
-    steps (7 of them) when turning the PFES ON</description>
+    <description>Time (in nanoseconds) between PFET controller steps (7 of them) when turning the PFES ON</description>
     <simpleType>
       <uint32_t>
         <!-- Will be set by HWP -->
@@ -6431,13 +5508,7 @@
 </attribute>-->
   <attribute>
     <id>REQUIRED_SYNCH_MODE</id>
-    <description>Specify the system policy to enforce synchronous
-    mode between memory and nest. This drives the value of
-    ATTR_MC_SYNC_MODE. 0 = UNDETERMINED : Run synchronously if the
-    dimm and nest freq matches 1 = ALWAYS : Require matching
-    frequencies and deconfigure memory that does not match the nest
-    2 = NEVER : Do not run synchronously, even if the frequencies
-    match</description>
+    <description>Specify the system policy to enforce synchronous mode between memory and nest. This drives the value of ATTR_MC_SYNC_MODE. 0 = UNDETERMINED : Run synchronously if the dimm and nest freq matches 1 = ALWAYS : Require matching frequencies and deconfigure memory that does not match the nest 2 = NEVER : Do not run synchronously, even if the frequencies match</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6450,17 +5521,7 @@
   </attribute>
   <attribute>
     <id>MAX_ALLOWED_DIMM_FREQ</id>
-    <description>Maximum frequency (in MHz) that this system can
-    run the DIMMs at. There are 5 possible values determined by the
-    dimm configuration. For configurations which have mixed rank
-    configurations, the lowest frequency based on ranks of either
-    DIMM is chosen. For example if there was a 1R and a 2R DIMM
-    installed, and 1R dual drop was a lower max freq than 2R dual
-    drop, then the 1R max freq would be the max allowed. [0]=One
-    rank, single drop [1]=Two rank, single drop [2]=Four rank,
-    single drop [3]=One rank, dual drop [4]=Two rank, dual drop A
-    value of zero would indicate an unsupported
-    configuration.</description>
+    <description>Maximum frequency (in MHz) that this system can run the DIMMs at. There are 5 possible values determined by the dimm configuration. For configurations which have mixed rank configurations, the lowest frequency based on ranks of either DIMM is chosen. For example if there was a 1R and a 2R DIMM installed, and 1R dual drop was a lower max freq than 2R dual drop, then the 1R max freq would be the max allowed. [0]=One rank, single drop [1]=Two rank, single drop [2]=Four rank, single drop [3]=One rank, dual drop [4]=Two rank, dual drop A value of zero would indicate an unsupported configuration.</description>
     <simpleType>
       <uint32_t>
         <default>2400,2400,2400,2400,2400</default>
@@ -6497,10 +5558,7 @@
 </attribute>-->
   <attribute>
     <id>VDD_AVSBUS_BUSNUM</id>
-    <description>Defines the AVSBus (0 or 1) which has the core VDD
-    rail VRM Producer: Machine Readable Workbook Consumers:
-    p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock
-    -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
+    <description>Defines the AVSBus (0 or 1) which has the core VDD rail VRM Producer: Machine Readable Workbook Consumers: p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6513,10 +5571,7 @@
   </attribute>
   <attribute>
     <id>VDN_AVSBUS_BUSNUM</id>
-    <description>Defines the AVSBus (0 or 1) which has the chip VDN
-    rail VRM Producer: Machine Readable Workbook Consumers:
-    p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock
-    -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
+    <description>Defines the AVSBus (0 or 1) which has the chip VDN rail VRM Producer: Machine Readable Workbook Consumers: p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6529,11 +5584,7 @@
   </attribute>
   <attribute>
     <id>VDD_AVSBUS_RAIL</id>
-    <description>Defines the AVSBus rail selector number (0 - 15)
-    for the VDD VRM on the bus defined by ATTR_AVSBUS_VDD_BUSNUM.
-    Producer: Machine Readable Workbook Consumers: p9_set_evid;
-    p9_set_voltage (tool); p9_build_pstate_datablock -&gt; Pstate
-    Parameter Block (PSPB) for PGPE</description>
+    <description>Defines the AVSBus rail selector number (0 - 15) for the VDD VRM on the bus defined by ATTR_AVSBUS_VDD_BUSNUM. Producer: Machine Readable Workbook Consumers: p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6546,11 +5597,7 @@
   </attribute>
   <attribute>
     <id>VDN_AVSBUS_RAIL</id>
-    <description>Defines the AVSBus rail selector number (0 - 15)
-    for the VDN VRM on the bus defined by ATTR_AVSBUS_VDN_BUSNUM.
-    Producer: Machine Readable Workbook Consumers:
-    p9_set_avsbus_voltage (tool); p9_build_pstate_datablock -&gt;
-    Pstate Parameter Block (PSPB) for PGPE</description>
+    <description>Defines the AVSBus rail selector number (0 - 15) for the VDN VRM on the bus defined by ATTR_AVSBUS_VDN_BUSNUM. Producer: Machine Readable Workbook Consumers: p9_set_avsbus_voltage (tool); p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6563,11 +5610,7 @@
   </attribute>
   <attribute>
     <id>VCS_AVSBUS_RAIL</id>
-    <description>Defines the AVSBus rail selector number (0 - 15)
-    for the VCS VRM on the bus defined by ATTR_AVSBUS_VCS_BUSNUM.
-    Producer: Machine Readable Workbook Consumers:
-    p9_set_avsbus_voltage (tool); p9_build_pstate_datablock -&gt;
-    Pstate Parameter Block (PSPB) for PGPE</description>
+    <description>Defines the AVSBus rail selector number (0 - 15) for the VCS VRM on the bus defined by ATTR_AVSBUS_VCS_BUSNUM. Producer: Machine Readable Workbook Consumers: p9_set_avsbus_voltage (tool); p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6580,10 +5623,7 @@
   </attribute>
   <attribute>
     <id>VCS_AVSBUS_BUSNUM</id>
-    <description>Defines the AVSBus (0 or 1) which has the core VCS
-    rail VRM Producer: Machine Readable Workbook Consumers:
-    p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock
-    -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
+    <description>Defines the AVSBus (0 or 1) which has the core VCS rail VRM Producer: Machine Readable Workbook Consumers: p9_set_evid; p9_set_voltage (tool); p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for PGPE</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6596,9 +5636,7 @@
   </attribute>
   <attribute>
     <id>VCS_I2C_BUSNUM</id>
-    <description>Defines the I2C bus number (0 - 15) that has the
-    VCS VRM. Producer: Machine Readable Workbook Consumers:
-    p9_set_evid; sp9_set_voltage (tool)</description>
+    <description>Defines the I2C bus number (0 - 15) that has the VCS VRM. Producer: Machine Readable Workbook Consumers: p9_set_evid; sp9_set_voltage (tool)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -6613,9 +5651,7 @@
   </attribute>
   <attribute>
     <id>PM_APSS_CHIP_SELECT</id>
-    <description>Defines which of the PSS chip selects (0 or 1)
-    that the APSS is connected Provided by the Machine Readable
-    Workbook. Consumer: p9_pm_pss_init</description>
+    <description>Defines which of the PSS chip selects (0 or 1) that the APSS is connected Provided by the Machine Readable Workbook. Consumer: p9_pm_pss_init</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6628,8 +5664,7 @@
   </attribute>
   <enumerationType>
     <id>PM_APSS_CHIP_SELECT</id>
-    <description>Enumeration for the
-    ATTR_PM_APSS_CHIP_SELECT</description>
+    <description>Enumeration for the ATTR_PM_APSS_CHIP_SELECT</description>
     <enumerator>
       <name>NONE</name>
       <value>0xFF</value>
@@ -6645,10 +5680,7 @@
   </enumerationType>
   <attribute>
     <id>STOP5_DISABLE</id>
-    <description>Control CME response to execution of PowerPC STOP
-    instruction if OFF, treat STOP5 as STOP5 if ON, treat STOP5 as
-    STOP4 Producer: ??? Consumer: p8_hcode_image_build.C Platform
-    default: OFF</description>
+    <description>Control CME response to execution of PowerPC STOP instruction if OFF, treat STOP5 as STOP5 if ON, treat STOP5 as STOP4 Producer: ??? Consumer: p8_hcode_image_build.C Platform default: OFF</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -6663,11 +5695,7 @@
   </attribute>
   <attribute>
     <id>SYSTEM_IVRMS_ENABLED</id>
-    <description>System control to allow (if all other attribute
-    tests yield true values) or categorically disallow IVRM
-    enablement Producer: MRWB Consumers: p9_build_pstate_datablock
-    -&gt; Pstate Parameter Block (PSPB) for PGPE/OCC CME Quad
-    Pstate Region (CQPR) for CM Quad Manager</description>
+    <description>System control to allow (if all other attribute tests yield true values) or categorically disallow IVRM enablement Producer: MRWB Consumers: p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for PGPE/OCC CME Quad Pstate Region (CQPR) for CM Quad Manager</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -6681,11 +5709,7 @@
   </attribute>
   <attribute>
     <id>SYSTEM_WOF_ENABLED</id>
-    <description>System control to allow Work Load Optimized
-    Frequency (WOF) algorithms to modify frequency based on active
-    core count and other inputs. Producer: MRWB Consumers:
-    p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB)
-    for PGPE/OCC Platform default: FALSE</description>
+    <description>System control to allow Work Load Optimized Frequency (WOF) algorithms to modify frequency based on active core count and other inputs. Producer: MRWB Consumers: p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for PGPE/OCC Platform default: FALSE</description>
     <simpleType>
       <uint8_t>
         <default>OFF</default>
@@ -6701,8 +5725,7 @@
   </attribute>
   <enumerationType>
     <id>SYSTEM_WOF_ENABLED</id>
-    <description>Enumeration for Work Load Optimized
-    Frequency</description>
+    <description>Enumeration for Work Load Optimized Frequency</description>
     <enumerator>
       <name>OFF</name>
       <value>0x00</value>
@@ -6714,9 +5737,7 @@
   </enumerationType>
   <attribute>
     <id>WOF_ENABLE_FRATIO</id>
-    <description>If wof_enabled, defines the Frequency Ratio
-    calculation performed. (THIS IS NOT SUPPORTED IN P9 GA1!).
-    Producer: MRWB Consumers: p9_hcode_image_build.C</description>
+    <description>If wof_enabled, defines the Frequency Ratio calculation performed. (THIS IS NOT SUPPORTED IN P9 GA1!). Producer: MRWB Consumers: p9_hcode_image_build.C</description>
     <simpleType>
       <uint8_t>
         <default>FIXED</default>
@@ -6732,8 +5753,7 @@
   </attribute>
   <enumerationType>
     <id>WOF_ENABLE_FRATIO</id>
-    <description>Enumeration for Work Load Optimized Frequency
-    ratio</description>
+    <description>Enumeration for Work Load Optimized Frequency ratio</description>
     <enumerator>
       <name>FIXED</name>
       <value>0x00</value>
@@ -6745,10 +5765,7 @@
   </enumerationType>
   <attribute>
     <id>WOF_ENABLE_VRATIO</id>
-    <description>If wof_enabled, defines the Voltage Ratio
-    calculation performed. THIS IS NOT SUPPORTED AT PRESENT. GA1
-    SUPPORT IS TBD). Producer: MRWB Consumers:
-    p9_hcode_image_build.C</description>
+    <description>If wof_enabled, defines the Voltage Ratio calculation performed. THIS IS NOT SUPPORTED AT PRESENT. GA1 SUPPORT IS TBD). Producer: MRWB Consumers: p9_hcode_image_build.C</description>
     <simpleType>
       <uint8_t>
         <default>FIXED</default>
@@ -6764,8 +5781,7 @@
   </attribute>
   <enumerationType>
     <id>WOF_ENABLE_VRATIO</id>
-    <description>Enumeration for Work Load Optimized Frequency
-    ratio</description>
+    <description>Enumeration for Work Load Optimized Frequency ratio</description>
     <enumerator>
       <name>FIXED</name>
       <value>0x00</value>
@@ -6777,15 +5793,7 @@
   </enumerationType>
   <attribute>
     <id>WOF_VRATIO_SELECT</id>
-    <description>If wof_enabled AND ATTR_WOF_ENABLE_VRATIO =
-    CALCULATED, this attribute selects the Vratio calculation type.
-    ACTIVE_CORES: Vratio is the number of active cores to the
-    number of good cores FULL: Vratio is Vaverage to Vclip(Fclip)
-    where Vclip(Fclip) is the normal interpolated regulator voltage
-    (including load line uplife @ RDP current) derated with
-    presently measured Idd current (from the AVSBus) and the
-    loadline. Producer: MRWB Consumers:
-    p9_hcode_image_build.C</description>
+    <description>If wof_enabled AND ATTR_WOF_ENABLE_VRATIO = CALCULATED, this attribute selects the Vratio calculation type. ACTIVE_CORES: Vratio is the number of active cores to the number of good cores FULL: Vratio is Vaverage to Vclip(Fclip) where Vclip(Fclip) is the normal interpolated regulator voltage (including load line uplife @ RDP current) derated with presently measured Idd current (from the AVSBus) and the loadline. Producer: MRWB Consumers: p9_hcode_image_build.C</description>
     <simpleType>
       <uint8_t>
         <default>ACTIVE_CORES</default>
@@ -6801,8 +5809,7 @@
   </attribute>
   <enumerationType>
     <id>WOF_VRATIO_SELECT</id>
-    <description>Enumeration for Work Load Optimized Frequency
-    ratio</description>
+    <description>Enumeration for Work Load Optimized Frequency ratio</description>
     <enumerator>
       <name>ACTIVE_CORES</name>
       <value>0x00</value>
@@ -6814,8 +5821,7 @@
   </enumerationType>
   <enumerationType>
     <id>WOF_POWER_LIMIT</id>
-    <description>Enumeration to select WOF Power
-    Limit</description>
+    <description>Enumeration to select WOF Power Limit</description>
     <enumerator>
       <name>NOMINAL</name>
       <value>0</value>
@@ -6827,10 +5833,7 @@
   </enumerationType>
   <attribute>
     <id>WOF_POWER_LIMIT</id>
-    <description>System control to set the power limit for Workload
-    Optimized Frequency (WOF) algorithms. This is used to select
-    the proper VFRT tables. Producer: TMGT Consumers: FW that
-    selects VFRT tables</description>
+    <description>System control to set the power limit for Workload Optimized Frequency (WOF) algorithms. This is used to select the proper VFRT tables. Producer: TMGT Consumers: FW that selects VFRT tables</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -6842,9 +5845,7 @@
   </attribute>
   <attribute>
     <id>WOF_TABLE_LID_NUMBER</id>
-    <description>LID id used to load tables for Workload Optimized
-    Frequency (WOF) algorithms. Producer: TMGT Consumers: FW that
-    selects VFRT tables</description>
+    <description>LID id used to load tables for Workload Optimized Frequency (WOF) algorithms. Producer: TMGT Consumers: FW that selects VFRT tables</description>
     <simpleType>
       <uint32_t>
         <!-- @todo-RTC:172776-Get rid of default value that points to ZZ -->
@@ -6857,9 +5858,7 @@
   </attribute>
   <attribute>
     <id>SYS_VFRT_STATIC_DATA_ENABLE</id>
-    <description>Enables pstate parameter block code to use the
-    static system vfrt data Consumer: p9_pstate_parameter_block.C 0
-    = OFF, 1 = ON Platform default: OFF 
+    <description>Enables pstate parameter block code to use the static system vfrt data Consumer: p9_pstate_parameter_block.C 0 = OFF, 1 = ON Platform default: OFF 
     <!--
         @todo RTC 169662 at some point in the program, this default may be switched to
          the opposite setting.  However, coordination needs to occur with all CIs
@@ -6877,10 +5876,7 @@
   </attribute>
   <attribute>
     <id>SYSTEM_RESCLK_STEP_DELAY</id>
-    <description>Minimum delay (in nanoseconds) between resonant
-    clock transition steps Producer: MRWB Consumers:
-    p9_build_pstate_datablock -&gt; CME Quad Pstate Region (CQPR)
-    for CM Quad Manager Platform default: 0</description>
+    <description>Minimum delay (in nanoseconds) between resonant clock transition steps Producer: MRWB Consumers: p9_build_pstate_datablock -&gt; CME Quad Pstate Region (CQPR) for CM Quad Manager Platform default: 0</description>
     <simpleType>
       <uint16_t></uint16_t>
     </simpleType>
@@ -6917,9 +5913,7 @@
 </attribute>-->
   <attribute>
     <id>PFET_POWERDOWN_DELAY_NS</id>
-    <description>Time (in nanoseconds) between PFET controller
-    steps (7 of them) when turning the PFES OFF Producer: MRWB
-    Consumers: p9_pm_pfet_init Platform default:</description>
+    <description>Time (in nanoseconds) between PFET controller steps (7 of them) when turning the PFES OFF Producer: MRWB Consumers: p9_pm_pfet_init Platform default:</description>
     <simpleType>
       <uint32_t>
         <!-- Will be set by HWP -->
@@ -6935,9 +5929,7 @@
   </attribute>
   <attribute>
     <id>PFET_VDD_VOFF_SEL</id>
-    <description>Selection of the OFF setting for the core and
-    cache chiplet VDD PFET controllers Producer: MRWB Consumers:
-    p9_pm_pfet_init Platform default:</description>
+    <description>Selection of the OFF setting for the core and cache chiplet VDD PFET controllers Producer: MRWB Consumers: p9_pm_pfet_init Platform default:</description>
     <simpleType>
       <uint8_t>
         <!-- Will be set by HWP -->
@@ -6953,8 +5945,7 @@
   </attribute>
   <enumerationType>
     <id>PFET_VDD_VOFF_SEL</id>
-    <description>Enumeration indicating the OFF setting for the
-    core and cache chiplet DD PFET controllers</description>
+    <description>Enumeration indicating the OFF setting for the core and cache chiplet DD PFET controllers</description>
     <enumerator>
       <name>NOOFF</name>
       <value>0</value>
@@ -6994,9 +5985,7 @@
   </enumerationType>
   <attribute>
     <id>PFET_VCS_VOFF_SEL</id>
-    <description>Selection of the OFF setting for the core and
-    cache chiplet VCS PFET controllers Producer: MRWB Consumers:
-    p9_pm_pfet_init Platform default:</description>
+    <description>Selection of the OFF setting for the core and cache chiplet VCS PFET controllers Producer: MRWB Consumers: p9_pm_pfet_init Platform default:</description>
     <simpleType>
       <uint8_t>
         <!-- Will be set by HWP -->
@@ -7012,8 +6001,7 @@
   </attribute>
   <enumerationType>
     <id>PFET_VCS_VOFF_SEL</id>
-    <description>Enumeration indicating the OFF setting for the
-    core and cache chiplet VCS PFET controllers</description>
+    <description>Enumeration indicating the OFF setting for the core and cache chiplet VCS PFET controllers</description>
     <enumerator>
       <name>NOOFF</name>
       <value>0</value>
@@ -7053,10 +6041,7 @@
   </enumerationType>
   <attribute>
     <id>VCS_I2C_RAIL</id>
-    <description>Step delay (binary in microseconds) after a
-    voltage change Consumer: p9_build_pstate_datablock -&gt; Pstate
-    Parameter Block (PSPB) for PGPE Provided by the Machine
-    Readable Workbook after system characterization.</description>
+    <description>Step delay (binary in microseconds) after a voltage change Consumer: p9_build_pstate_datablock -&gt; Pstate Parameter Block (PSPB) for PGPE Provided by the Machine Readable Workbook after system characterization.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -7071,8 +6056,7 @@
   </attribute>
   <enumerationType>
     <id>FAPI_POS</id>
-    <description>Enumeration defining special FAPI_POS
-    values</description>
+    <description>Enumeration defining special FAPI_POS values</description>
     <enumerator>
       <name>NA</name>
       <value>0xFFFFFFFF</value>
@@ -7081,18 +6065,7 @@
   </enumerationType>
   <attribute>
     <id>FAPI_POS</id>
-    <description>Logical position of target within a system. This
-    is derived from the SMP location of each processor and each
-    target's relationship to a proc. - PROC = based on SMP
-    groupid+chipid - MEMBUF = PROC:FAPI_POS * [max membuf per proc]
-    - 1st level child unit = [parent chip]:FAPI_POS * [max children
-    of this type per chip] - 2nd+ level child unit = [immediate
-    parent unit]:FAPI_POS * [max units below parent] Note: This
-    should not be used algorithmically by HWPs directly. Note:
-    Value ignores physical drawer boundaries, the value is unique
-    across the entire system. This data is derived from the MRW.
-    Default of NA is 0xFFFFFFFF (to avoid confusion with legitimate
-    0 values)</description>
+    <description>Logical position of target within a system. This is derived from the SMP location of each processor and each target's relationship to a proc. - PROC = based on SMP groupid+chipid - MEMBUF = PROC:FAPI_POS * [max membuf per proc] - 1st level child unit = [parent chip]:FAPI_POS * [max children of this type per chip] - 2nd+ level child unit = [immediate parent unit]:FAPI_POS * [max units below parent] Note: This should not be used algorithmically by HWPs directly. Note: Value ignores physical drawer boundaries, the value is unique across the entire system. This data is derived from the MRW. Default of NA is 0xFFFFFFFF (to avoid confusion with legitimate 0 values)</description>
     <simpleType>
       <uint32_t>
         <default>0xFFFFFFFF</default>
@@ -7107,8 +6080,7 @@
   </attribute>
   <attribute>
     <id>I2C_BUS_DIV_REF</id>
-    <description>Ref clock I2C bus divider consumed by code running
-    out of OTPROM</description>
+    <description>Ref clock I2C bus divider consumed by code running out of OTPROM</description>
     <simpleType>
       <uint16_t>
         <default>0x0003</default>
@@ -7124,8 +6096,7 @@
   </attribute>
   <attribute>
     <id>NEST_PLL_BUCKET</id>
-    <description>Select Nest I2C and pll setting from one of the
-    supported frequencies</description>
+    <description>Select Nest I2C and pll setting from one of the supported frequencies</description>
     <simpleType>
       <uint8_t>
         <default>0x05</default>
@@ -7147,10 +6118,7 @@
      ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== -->
   <attribute>
     <id>SBE_UPDATE_DISABLE</id>
-    <description>Control execution of updateProcessorSbeSeeproms()
-    if 0, enable SBE update of processor SEEPROM if 1, disable SBE
-    update of processor SEEPROM Consumer: sbe_update.C Default:
-    0</description>
+    <description>Control execution of updateProcessorSbeSeeproms() if 0, enable SBE update of processor SEEPROM if 1, disable SBE update of processor SEEPROM Consumer: sbe_update.C Default: 0</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -7199,8 +6167,7 @@
   <!-- Deprecated -->
   <attribute>
     <id>I2C_BUS_DIV_NEST</id>
-    <description>I2C Bus speed based on nest freq, ref
-    clock</description>
+    <description>I2C Bus speed based on nest freq, ref clock</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -7243,10 +6210,7 @@
   <!-- name changed in ekb, need to have both to push interim commits through -->
   <attribute>
     <id>PROC_FABRIC_SYSTEM_ID</id>
-    <description>Logical fabric system ID associated with this
-    chip. Would only need to be a non-zero to support CCSM
-    (coherent cluster shared memory) system topologies Provided by
-    the MRW.</description>
+    <description>Logical fabric system ID associated with this chip. Would only need to be a non-zero to support CCSM (coherent cluster shared memory) system topologies Provided by the MRW.</description>
     <simpleType>
       <uint32_t>
         <default>0</default>
@@ -7290,11 +6254,7 @@
   <!--SBE ONLY-->
   <attribute>
     <id>CHIPLET_ID</id>
-    <description>The address offset which each Chiplet types
-    pervasive address space used to represent the a chiplet. 0x00
-    to 0x0F =&gt; For P9 all non-core and non-cache chiplets 0x10
-    to 0x1F =&gt; All Cache Chiplets 0x20 to 0x37 =&gt; All Core
-    Chiplets 0x38 to 0x3F =&gt; Multicast Operation</description>
+    <description>The address offset which each Chiplet types pervasive address space used to represent the a chiplet. 0x00 to 0x0F =&gt; For P9 all non-core and non-cache chiplets 0x10 to 0x1F =&gt; All Cache Chiplets 0x20 to 0x37 =&gt; All Core Chiplets 0x38 to 0x3F =&gt; Multicast Operation</description>
     <simpleType>
       <uint8_t>
         <default>0xFF</default>
@@ -7305,9 +6265,7 @@
   </attribute>
   <attribute>
     <id>SYSTEM_IPL_PHASE</id>
-    <description>Define context for current phase of system IPL.
-    Provided by the platform. HB_IPL = 0x1,HB_RUNTIME =
-    0x2,CACHE_CONTAINED = 0x4</description>
+    <description>Define context for current phase of system IPL. Provided by the platform. HB_IPL = 0x1,HB_RUNTIME = 0x2,CACHE_CONTAINED = 0x4</description>
     <simpleType>
       <uint8_t>
         <default>0x01</default>
@@ -7323,8 +6281,7 @@
   </attribute>
   <attribute>
     <id>PARENT_PERVASIVE</id>
-    <description>Physical entity path of the target's associated
-    pervasive target</description>
+    <description>Physical entity path of the target's associated pervasive target</description>
     <nativeType>
       <name>EntityPath</name>
     </nativeType>
@@ -7335,8 +6292,7 @@
   <!-- ********************************************************************** -->
   <enumerationType>
     <id>PROC_FABRIC_A_BUS_WIDTH</id>
-    <description>Enumeration indicating the
-    PROC_FABRIC_A_BUS_WIDTH</description>
+    <description>Enumeration indicating the PROC_FABRIC_A_BUS_WIDTH</description>
     <!--  Note: Values must match numbers from nest_attributes.xml -->
     <enumerator>
       <name>2_BYTE</name>
@@ -7350,8 +6306,7 @@
   <attribute>
     <id>PROC_FABRIC_A_BUS_WIDTH</id>
     <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-    <description>Processor SMP A bus width. Provided by the MRW.
-    2_BYTE = 0x01, 4_BYTE = 0x02</description>
+    <description>Processor SMP A bus width. Provided by the MRW. 2_BYTE = 0x01, 4_BYTE = 0x02</description>
     <simpleType>
       <uint8_t>
         <default>4_BYTE</default>
@@ -7366,8 +6321,7 @@
   </attribute>
   <enumerationType>
     <id>PROC_FABRIC_X_BUS_WIDTH</id>
-    <description>Enumeration indicating the
-    PROC_FABRIC_X_BUS_WIDTH</description>
+    <description>Enumeration indicating the PROC_FABRIC_X_BUS_WIDTH</description>
     <!--  Note: Values must match numbers from nest_attributes.xml -->
     <enumerator>
       <name>2_BYTE</name>
@@ -7381,8 +6335,7 @@
   <attribute>
     <id>PROC_FABRIC_X_BUS_WIDTH</id>
     <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-    <description>Processor SMP X bus width. Provided by the MRW.
-    2_BYTE = 0x01, 4_BYTE = 0x02</description>
+    <description>Processor SMP X bus width. Provided by the MRW. 2_BYTE = 0x01, 4_BYTE = 0x02</description>
     <simpleType>
       <uint8_t>
         <default>4_BYTE</default>
@@ -7398,9 +6351,7 @@
   <attribute>
     <id>PROC_FABRIC_CCSM_MODE</id>
     <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-    <description>Processor SMP topology configuration. 0 = default
-    = 1 or 2 hop topology (PHYP image spans system) Provided by the
-    MRW. OFF = 0x0 (default)</description>
+    <description>Processor SMP topology configuration. 0 = default = 1 or 2 hop topology (PHYP image spans system) Provided by the MRW. OFF = 0x0 (default)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -7415,8 +6366,7 @@
   </attribute>
   <enumerationType>
     <id>OPTICS_CONFIG_MODE</id>
-    <description>Enumeration indicating the
-    OPTICS_CONFIG_MODE</description>
+    <description>Enumeration indicating the OPTICS_CONFIG_MODE</description>
     <enumerator>
       <name>SMP</name>
       <value>0x0</value>
@@ -7432,11 +6382,10 @@
   </enumerationType>
   <attribute>
     <id>OPTICS_CONFIG_MODE</id>
-    <description>Per-link optics configuration 0 = SMP (default) 1
-    = CAPI 2.0 2 = NV 2.0 Provided by the MRW.</description>
+    <description>Per-link optics configuration 0 = SMP (default) 1 = CAPI 2.0 2 = NV 2.0 Provided by the MRW.</description>
     <simpleType>
       <uint8_t>
-        <default>SMP</default>
+        <default>NVLINK</default>
       </uint8_t>
     </simpleType>
     <persistency>non-volatile</persistency>
@@ -7448,10 +6397,7 @@
   </attribute>
   <attribute>
     <id>OBUS_BRICK_LANE_MASK</id>
-    <description>Lane mask for which 8 lanes belong to this brick
-    This is a right justified 24-bit value. Only 8 of the 24 bits
-    will be set representing the lanes belonging to the associated
-    brick. Provided by the MRW.</description>
+    <description>Lane mask for which 8 lanes belong to this brick This is a right justified 24-bit value. Only 8 of the 24 bits will be set representing the lanes belonging to the associated brick. Provided by the MRW.</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
@@ -7464,11 +6410,7 @@
   </attribute>
   <attribute>
     <id>OBUS_SLOT_INDEX</id>
-    <description>Position of the obus slot that the Obus brick is
-    connected to (represented in decimal). There is only one slot
-    that a given brick connects to and there are only 6 slots per
-    proc, so, we just need a single uint8_t representing the
-    position of the slot. Provided by the MRW.</description>
+    <description>Position of the obus slot that the Obus brick is connected to (represented in decimal). There is only one slot that a given brick connects to and there are only 6 slots per proc, so, we just need a single uint8_t representing the position of the slot. Provided by the MRW.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -7481,8 +6423,7 @@
   </attribute>
   <enumerationType>
     <id>PROC_FABRIC_SMP_OPTICS_MODE</id>
-    <description>Enumeration indicating the
-    PROC_FABRIC_SMP_OPTICS_MODE</description>
+    <description>Enumeration indicating the PROC_FABRIC_SMP_OPTICS_MODE</description>
     <!--  Note: Values must match numbers from nest_attributes.xml -->
     <enumerator>
       <name>OPTICS_IS_X_BUS</name>
@@ -7496,9 +6437,7 @@
   <attribute>
     <id>PROC_FABRIC_SMP_OPTICS_MODE</id>
     <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-    <description>Processor SMP optics mode. 0 = Optics_is_X_bus
-    (default) 1 = Optics_is_A_bus Provided by the MRW.
-    OPTICS_IS_X_BUS = 0x0, OPTICS_IS_A_BUS = 0x1</description>
+    <description>Processor SMP optics mode. 0 = Optics_is_X_bus (default) 1 = Optics_is_A_bus Provided by the MRW. OPTICS_IS_X_BUS = 0x0, OPTICS_IS_A_BUS = 0x1</description>
     <simpleType>
       <uint8_t>
         <default>OPTICS_IS_X_BUS</default>
@@ -7513,8 +6452,7 @@
   </attribute>
   <enumerationType>
     <id>PROC_FABRIC_CAPI_MODE</id>
-    <description>Enumeration indicating the
-    PROC_FABRIC_CAPI_MODE</description>
+    <description>Enumeration indicating the PROC_FABRIC_CAPI_MODE</description>
     <!--  Note: Values must match numbers from nest_attributes.xml -->
     <enumerator>
       <name>OFF</name>
@@ -7528,9 +6466,7 @@
   <attribute>
     <id>PROC_FABRIC_CAPI_MODE</id>
     <!-- <targetType>TARGET_TYPE_SYSTEM</targetType> -->
-    <description>Processor CAPI attachment protocol mode. 0 = no:
-    SMPA CAPI attachment (default) 1 = yes: SMPA CAPI attachment
-    Provided by the MRW.</description>
+    <description>Processor CAPI attachment protocol mode. 0 = no: SMPA CAPI attachment (default) 1 = yes: SMPA CAPI attachment Provided by the MRW.</description>
     <simpleType>
       <uint8_t>
         <default>OFF</default>
@@ -7546,10 +6482,7 @@
   <attribute>
     <id>PROC_PCIE_BAR_ENABLE</id>
     <!-- TARGET_TYPE_PHB -->
-    <description>PCIE MMIO BAR enable creator: platform consumer:
-    p9_pcie_config firmware notes: Array index: BAR number (0:2)
-    index 0~1 for MMIO BAR0/1 index 2 for PHB register space
-    DISABLE = 0x0, ENABLE = 0x1</description>
+    <description>PCIE MMIO BAR enable creator: platform consumer: p9_pcie_config firmware notes: Array index: BAR number (0:2) index 0~1 for MMIO BAR0/1 index 2 for PHB register space DISABLE = 0x0, ENABLE = 0x1</description>
     <simpleType>
       <uint8_t />
       <array>3</array>
@@ -7564,12 +6497,7 @@
   <attribute>
     <id>PROC_PCIE_BAR_BASE_ADDR</id>
     <!-- TARGET_TYPE_PHB -->
-    <description>PCIE MMIO BAR base address value creator: platform
-    consumer: p9_setup_bars firmware notes: 64-bit address
-    representing BAR RA Array index: BAR number (0:2) NOTE: BAR0/1
-    registers cover RA 8:47 NOTE: BAR2 registers covers RA 8:49
-    index 0~1 for BAR0/1 index 2 for PHB index 3 for
-    interrupt</description>
+    <description>PCIE MMIO BAR base address value creator: platform consumer: p9_setup_bars firmware notes: 64-bit address representing BAR RA Array index: BAR number (0:2) NOTE: BAR0/1 registers cover RA 8:47 NOTE: BAR2 registers covers RA 8:49 index 0~1 for BAR0/1 index 2 for PHB index 3 for interrupt</description>
     <simpleType>
       <uint64_t />
       <array>4</array>
@@ -7584,31 +6512,7 @@
   <attribute>
     <id>PROC_PCIE_BAR_SIZE</id>
     <!-- TARGET_TYPE_PHB -->
-    <description>PCIE MMIO BAR size values creator: platform
-    consumer: p9_pcie_config firmware notes: Array index: BAR
-    number (0:2) NOTE: supported MMIO BAR0/1 sizes are from
-    64KB-32PB NOTE: only supported PHB register size is 16KB 32_PB
-    = 0x8000000000000000, 16_PB = 0xC000000000000000, 8_PB =
-    0xE000000000000000, 4_PB = 0xF000000000000000, 2_PB =
-    0xF800000000000000, 1_PB = 0xFC00000000000000, 512_TB =
-    0xFE00000000000000, 256_TB = 0xFF00000000000000, 128_TB =
-    0xFF80000000000000, 64_TB = 0xFFC0000000000000, 32_TB =
-    0xFFE0000000000000, 16_TB = 0xFFF0000000000000, 8_TB =
-    0xFFF8000000000000, 4_TB = 0xFFFC000000000000, 2_TB =
-    0xFFFE000000000000, 1_TB = 0xFFFF000000000000, 512_GB =
-    0xFFFF800000000000, 256_GB = 0xFFFFC00000000000, 128_GB =
-    0xFFFFE00000000000, 64_GB = 0xFFFFF00000000000, 32_GB =
-    0xFFFFF80000000000, 16_GB = 0xFFFFFC0000000000, 8_GB =
-    0xFFFFFE0000000000, 4_GB = 0xFFFFFF0000000000, 2_GB =
-    0xFFFFFF8000000000, 1_GB = 0xFFFFFFC000000000, 512_MB =
-    0xFFFFFFE000000000, 256_MB = 0xFFFFFFF000000000, 128_MB =
-    0xFFFFFFF800000000, 64_MB = 0xFFFFFFFC00000000, 32_MB =
-    0xFFFFFFFE00000000, 16_MB = 0xFFFFFFFF00000000, 8_MB =
-    0xFFFFFFFF80000000, 4_MB = 0xFFFFFFFFC0000000, 2_MB =
-    0xFFFFFFFFE0000000, 1_MB = 0xFFFFFFFFF0000000, 512_KB =
-    0xFFFFFFFFF8000000, 256_KB = 0xFFFFFFFFFC000000, 128_KB =
-    0xFFFFFFFFFE000000, 64_KB = 0xFFFFFFFFFF000000, 16_KB =
-    0xFFFFFFFFFFFFFFFF</description>
+    <description>PCIE MMIO BAR size values creator: platform consumer: p9_pcie_config firmware notes: Array index: BAR number (0:2) NOTE: supported MMIO BAR0/1 sizes are from 64KB-32PB NOTE: only supported PHB register size is 16KB 32_PB = 0x8000000000000000, 16_PB = 0xC000000000000000, 8_PB = 0xE000000000000000, 4_PB = 0xF000000000000000, 2_PB = 0xF800000000000000, 1_PB = 0xFC00000000000000, 512_TB = 0xFE00000000000000, 256_TB = 0xFF00000000000000, 128_TB = 0xFF80000000000000, 64_TB = 0xFFC0000000000000, 32_TB = 0xFFE0000000000000, 16_TB = 0xFFF0000000000000, 8_TB = 0xFFF8000000000000, 4_TB = 0xFFFC000000000000, 2_TB = 0xFFFE000000000000, 1_TB = 0xFFFF000000000000, 512_GB = 0xFFFF800000000000, 256_GB = 0xFFFFC00000000000, 128_GB = 0xFFFFE00000000000, 64_GB = 0xFFFFF00000000000, 32_GB = 0xFFFFF80000000000, 16_GB = 0xFFFFFC0000000000, 8_GB = 0xFFFFFE0000000000, 4_GB = 0xFFFFFF0000000000, 2_GB = 0xFFFFFF8000000000, 1_GB = 0xFFFFFFC000000000, 512_MB = 0xFFFFFFE000000000, 256_MB = 0xFFFFFFF000000000, 128_MB = 0xFFFFFFF800000000, 64_MB = 0xFFFFFFFC00000000, 32_MB = 0xFFFFFFFE00000000, 16_MB = 0xFFFFFFFF00000000, 8_MB = 0xFFFFFFFF80000000, 4_MB = 0xFFFFFFFFC0000000, 2_MB = 0xFFFFFFFFE0000000, 1_MB = 0xFFFFFFFFF0000000, 512_KB = 0xFFFFFFFFF8000000, 256_KB = 0xFFFFFFFFFC000000, 128_KB = 0xFFFFFFFFFE000000, 64_KB = 0xFFFFFFFFFF000000, 16_KB = 0xFFFFFFFFFFFFFFFF</description>
     <simpleType>
       <uint64_t />
       <array>3</array>
@@ -7623,8 +6527,7 @@
   <attribute>
     <id>PROC_PCIE_HOTPLUG_I2C_DEVICE_ADDRESS</id>
     <!-- TARGET_TYPE_PROC_CHIP -->
-    <description>I2C device address for PCIE hotplug controller
-    creator: platform consumer: p9_pcie_hotplug</description>
+    <description>I2C device address for PCIE hotplug controller creator: platform consumer: p9_pcie_hotplug</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -7638,11 +6541,7 @@
   <attribute>
     <id>PROC_PCIE_HOTPLUG_ENABLE_ACTIONS</id>
     <!-- TARGET_TYPE_PROC_CHIP -->
-    <description>Sequence of PCIE hotplug controller register
-    writes required to enable slot power creator: platform
-    consumer: p9_pcie_hotplug firmware notes: Primary array index:
-    Sequence number Secondary array index: Address (0) / Data
-    (1)</description>
+    <description>Sequence of PCIE hotplug controller register writes required to enable slot power creator: platform consumer: p9_pcie_hotplug firmware notes: Primary array index: Sequence number Secondary array index: Address (0) / Data (1)</description>
     <simpleType>
       <uint8_t />
       <array>8,2</array>
@@ -7657,11 +6556,7 @@
   <attribute>
     <id>PROC_PCIE_HOTPLUG_NUM_ENABLE_ACTIONS</id>
     <!-- TARGET_TYPE_PROC_CHIP -->
-    <description>Number of valid entries in primary index of
-    ATTR_PROC_PCIE_HOTPLUG_ENABLE_ACTIONS creator: platform
-    consumer: p9_pcie_hotplug ZERO = 0x0, ONE = 0x1, TWO = 0x2,
-    THREE = 0x3, FOUR = 0x4, FIVE = 0x5, SIX = 0x6, SEVEN = 0x7,
-    EIGHT = 0x8</description>
+    <description>Number of valid entries in primary index of ATTR_PROC_PCIE_HOTPLUG_ENABLE_ACTIONS creator: platform consumer: p9_pcie_hotplug ZERO = 0x0, ONE = 0x1, TWO = 0x2, THREE = 0x3, FOUR = 0x4, FIVE = 0x5, SIX = 0x6, SEVEN = 0x7, EIGHT = 0x8</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -7675,11 +6570,7 @@
   <attribute>
     <id>PROC_PCIE_HOTPLUG_DISABLE_ACTIONS</id>
     <!-- TARGET_TYPE_PROC_CHIP -->
-    <description>Sequence of PCIE hotplug controller register
-    writes required to disable slot power creator: platform
-    consumer: p9_pcie_hotplug firmware notes: Primary array index:
-    Sequence number Secondary array index: Address (0) / Data
-    (1)</description>
+    <description>Sequence of PCIE hotplug controller register writes required to disable slot power creator: platform consumer: p9_pcie_hotplug firmware notes: Primary array index: Sequence number Secondary array index: Address (0) / Data (1)</description>
     <simpleType>
       <uint8_t />
       <array>8,2</array>
@@ -7694,11 +6585,7 @@
   <attribute>
     <id>PROC_PCIE_HOTPLUG_NUM_DISABLE_ACTIONS</id>
     <!-- TARGET_TYPE_PROC_CHIP -->
-    <description>Number of valid entries in primary index of
-    ATTR_PROC_PCIE_HOTPLUG_DISABLE_ACTIONS creator: platform
-    consumer: p9_pcie_hotplug ZERO = 0x0, ONE = 0x1, TWO = 0x2,
-    THREE = 0x3, FOUR = 0x4, FIVE = 0x5, SIX = 0x6, SEVEN = 0x7,
-    EIGHT = 0x8</description>
+    <description>Number of valid entries in primary index of ATTR_PROC_PCIE_HOTPLUG_DISABLE_ACTIONS creator: platform consumer: p9_pcie_hotplug ZERO = 0x0, ONE = 0x1, TWO = 0x2, THREE = 0x3, FOUR = 0x4, FIVE = 0x5, SIX = 0x6, SEVEN = 0x7, EIGHT = 0x8</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -7712,10 +6599,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_CDR_GAIN</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>PCS rx cdr gains creator: platform consumer:
-    p9_pcie_scominit firmware notes: The value of rx cdr gains for
-    PCS. Array index: Configuration number index 0~3 for
-    CONFIG0~3</description>
+    <description>PCS rx cdr gains creator: platform consumer: p9_pcie_scominit firmware notes: The value of rx cdr gains for PCS. Array index: Configuration number index 0~3 for CONFIG0~3</description>
     <simpleType>
       <uint8_t />
       <array>4</array>
@@ -7730,10 +6614,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_PK_INIT</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>PCS rx vga peak init value creator: platform
-    consumer: p9_pcie_scominit firmware notes: The value of rx vga
-    peak init for PCS. Array index: Configuration number index 0~3
-    for CONFIG0~3 lane 0~15 for each PCIE Lane</description>
+    <description>PCS rx vga peak init value creator: platform consumer: p9_pcie_scominit firmware notes: The value of rx vga peak init for PCS. Array index: Configuration number index 0~3 for CONFIG0~3 lane 0~15 for each PCIE Lane</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -7750,10 +6631,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_INIT_GAIN</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>PCS rx vga gain init value creator: platform
-    consumer: p9_pcie_scominit firmware notes: The value of rx vga
-    gain init for PCS. Array index: Configuration number index 0~3
-    for CONFIG0~3 lane 0~15 for each PCIE Lane</description>
+    <description>PCS rx vga gain init value creator: platform consumer: p9_pcie_scominit firmware notes: The value of rx vga gain init for PCS. Array index: Configuration number index 0~3 for CONFIG0~3 lane 0~15 for each PCIE Lane</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -7770,10 +6648,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_SIGDET_LVL</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>PCS rx sigdet lvl value creator: platform
-    consumer: p9_pcie_scominit firmware notes: The value of rx
-    sigdet lvl for PCS. Array index: Configuration number index 0~3
-    for CONFIG0~3</description>
+    <description>PCS rx sigdet lvl value creator: platform consumer: p9_pcie_scominit firmware notes: The value of rx sigdet lvl for PCS. Array index: Configuration number index 0~3 for CONFIG0~3</description>
     <simpleType>
       <uint8_t>
         <default>0x0B</default>
@@ -7790,10 +6665,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_ROT_RST_FW</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS RX ROT rstfw latch creator: platform
-    consumer: p9_pcie_scominit firmware notes: 0 normal, flywheel
-    is enabled (default) 1 assert reset to the phase rotator
-    flywheel (disable the flywheel)</description>
+    <description>Value of PCS RX ROT rstfw latch creator: platform consumer: p9_pcie_scominit firmware notes: 0 normal, flywheel is enabled (default) 1 assert reset to the phase rotator flywheel (disable the flywheel)</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -7809,10 +6681,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_LOFF_CONTROL</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>PCS rx loff control creator: platform consumer:
-    p9_pcie_scominit firmware notes: The value of rx loff control
-    for PCS. Array index: Configuration number index 0~3 for
-    CONFIG0~3</description>
+    <description>PCS rx loff control creator: platform consumer: p9_pcie_scominit firmware notes: The value of rx loff control for PCS. Array index: Configuration number index 0~3 for CONFIG0~3</description>
     <simpleType>
       <uint16_t />
       <array>4</array>
@@ -7827,10 +6696,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_VGA_CONTRL_REGISTER3</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>PCS rx vga control register3 creator: platform
-    consumer: p9_pcie_scominit firmware notes: The value of rx vga
-    control register3. Array index: Configuration number index 0~3
-    for CONFIG0~3</description>
+    <description>PCS rx vga control register3 creator: platform consumer: p9_pcie_scominit firmware notes: The value of rx vga control register3. Array index: Configuration number index 0~3 for CONFIG0~3</description>
     <simpleType>
       <uint16_t />
       <array>4</array>
@@ -7845,9 +6711,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_ROT_CDR_LOOKAHEAD</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS RX ROT CNTL CDR lookahead creator:
-    platform consumer: p9_pcie_scominit firmware notes: 0 for
-    disable, 1 for enable</description>
+    <description>Value of PCS RX ROT CNTL CDR lookahead creator: platform consumer: p9_pcie_scominit firmware notes: 0 for disable, 1 for enable</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -7861,9 +6725,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_ROT_CDR_SSC</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS RX ROT CNTL CDR ssc creator: platform
-    consumer: p9_pcie_scominit firmware notes: 0 for disable, 1 for
-    enable</description>
+    <description>Value of PCS RX ROT CNTL CDR ssc creator: platform consumer: p9_pcie_scominit firmware notes: 0 for disable, 1 for enable</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -7877,8 +6739,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLA</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS pclck control plla creator: platform
-    consumer: p9_pcie_scominit</description>
+    <description>Value of PCS pclck control plla creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -7892,8 +6753,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_PCLCK_CNTL_PLLB</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS pclck control pllb creator: platform
-    consumer: p9_pcie_scominit</description>
+    <description>Value of PCS pclck control pllb creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -7907,8 +6767,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_TX_DCLCK_ROT</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS tx dclck rotator override creator:
-    platform consumer: p9_pcie_scominit</description>
+    <description>Value of PCS tx dclck rotator override creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint16_t />
     </simpleType>
@@ -7922,8 +6781,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_TX_FIFO_CONFIG_OFFSET</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS tx fifo config offset creator:
-    platform consumer: p9_pcie_scominit</description>
+    <description>Value of PCS tx fifo config offset creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -7937,9 +6795,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG1</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS tx pcie receiver detect control
-    register 1 creator: platform consumer:
-    p9_pcie_scominit</description>
+    <description>Value of PCS tx pcie receiver detect control register 1 creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint16_t />
     </simpleType>
@@ -7953,9 +6809,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_TX_PCIE_RECV_DETECT_CNTL_REG2</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS tx pcie receiver detect control
-    register 2 creator: platform consumer:
-    p9_pcie_scominit</description>
+    <description>Value of PCS tx pcie receiver detect control register 2 creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint16_t />
     </simpleType>
@@ -7969,8 +6823,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_TX_POWER_SEQ_ENABLE</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS tx power sequence enable creator:
-    platform consumer: p9_pcie_scominit</description>
+    <description>Value of PCS tx power sequence enable creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -7984,8 +6837,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_PHASE_ROTATOR_CNTL</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS rx phase rotator control creator:
-    platform consumer: p9_pcie_scominit</description>
+    <description>Value of PCS rx phase rotator control creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint16_t />
     </simpleType>
@@ -7999,8 +6851,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG1</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS rx vga control register 1 creator:
-    platform consumer: p9_pcie_scominit</description>
+    <description>Value of PCS rx vga control register 1 creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint16_t />
     </simpleType>
@@ -8014,8 +6865,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_VGA_CNTL_REG2</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS rx vga control register 2 creator:
-    platform consumer: p9_pcie_scominit</description>
+    <description>Value of PCS rx vga control register 2 creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint16_t />
     </simpleType>
@@ -8029,8 +6879,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_RX_SIGDET_CNTL</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS rx sigdet control creator: platform
-    consumer: p9_pcie_scominit</description>
+    <description>Value of PCS rx sigdet control creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint16_t />
     </simpleType>
@@ -8044,8 +6893,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_SYSTEM_CNTL</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS system control creator: platform
-    consumer: p9_pcie_scominit</description>
+    <description>Value of PCS system control creator: platform consumer: p9_pcie_scominit</description>
     <simpleType>
       <uint16_t />
     </simpleType>
@@ -8060,9 +6908,7 @@
   <attribute>
     <id>PROC_PCIE_PCS_M_CNTL</id>
     <!-- TARGET_TYPE_PEC -->
-    <description>Value of PCS m1-m4 control creator: platform
-    consumer: p9_pcie_scominit Array index: 0 -&gt; M1 1 -&gt; M2 2
-    -&gt; M3 3 -&gt; M4</description>
+    <description>Value of PCS m1-m4 control creator: platform consumer: p9_pcie_scominit Array index: 0 -&gt; M1 1 -&gt; M2 2 -&gt; M3 3 -&gt; M4</description>
     <simpleType>
       <uint16_t />
       <array>4</array>
@@ -8081,9 +6927,7 @@
      result of getDimmSize() function called in p9_mss_eff_grouping -->
   <attribute>
     <id>PROC_PCIE_IOP_SWAP</id>
-    <description>PCIE IOP swap configuration creator: platform
-    consumer: p9_pcie_scominit firmware notes: Encoded PCIE IOP
-    swap configuration</description>
+    <description>PCIE IOP swap configuration creator: platform consumer: p9_pcie_scominit firmware notes: Encoded PCIE IOP swap configuration</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -8098,8 +6942,7 @@
   <attribute>
     <id>IO_XBUS_TX_MARGIN_RATIO</id>
     <!-- <targetType>TARGET_TYPE_XBUS</targetType> -->
-    <description>Value to select amount of margin to be
-    applied.</description>
+    <description>Value to select amount of margin to be applied.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -8113,8 +6956,7 @@
   <attribute>
     <id>IO_XBUS_TX_FFE_PRECURSOR</id>
     <!-- <targetType>TARGET_TYPE_XBUS</targetType> -->
-    <description>Value to select amount of tx ffe precusor to
-    apply.</description>
+    <description>Value to select amount of tx ffe precusor to apply.</description>
     <simpleType>
       <uint8_t>
         <default>6</default>
@@ -8129,42 +6971,33 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
-    <description>Machine Readable Workbook safe mode throttle value
-    for numerator cfg_nm_n_per_port Set to below optimum value/
-    rate. On a per port (MCA) basis Consumer:
-    thermal_init</description>
+    <description>Machine Readable Workbook safe mode throttle value for numerator cfg_nm_n_per_port Set to below optimum value/ rate. On a per port (MCA) basis Consumer: thermal_init</description>
     <simpleType>
       <uint16_t></uint16_t>
     </simpleType>
     <persistency>non-volatile</persistency>
     <readable />
     <hwpfToHbAttrMap>
-      <id>
-      ATTR_MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+      <id>ATTR_MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
       <macro>DIRECT</macro>
     </hwpfToHbAttrMap>
   </attribute>
   <attribute>
     <id>MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
-    <description>Machine Readable Workbook safe mode throttle value
-    for numerator cfg_nm_n_per_slot</description>
+    <description>Machine Readable Workbook safe mode throttle value for numerator cfg_nm_n_per_slot</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
     <persistency>non-volatile</persistency>
     <readable />
     <hwpfToHbAttrMap>
-      <id>
-      ATTR_MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
+      <id>ATTR_MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
       <macro>DIRECT</macro>
     </hwpfToHbAttrMap>
   </attribute>
   <attribute>
     <id>MSS_MRW_MEM_M_DRAM_CLOCKS</id>
-    <description>Machine Readable Workbook for the number of M DRAM
-    clocks. One approach to curbing DRAM power usage is by
-    throttling traffic through a programmable N commands over M
-    window.</description>
+    <description>Machine Readable Workbook for the number of M DRAM clocks. One approach to curbing DRAM power usage is by throttling traffic through a programmable N commands over M window.</description>
     <simpleType>
       <uint32_t>
         <default>0x00000200</default>
@@ -8179,8 +7012,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_AVDD_OFFSET_DISABLE</id>
-    <description>Used for to determine whether to apply an offset
-    to AVDD. Supplied by MRW.</description>
+    <description>Used for to determine whether to apply an offset to AVDD. Supplied by MRW.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -8193,8 +7025,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_VDD_OFFSET_DISABLE</id>
-    <description>Used for to determine whether to apply an offset
-    to VDD. Supplied by MRW</description>
+    <description>Used for to determine whether to apply an offset to VDD. Supplied by MRW</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -8207,8 +7038,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_VCS_OFFSET_DISABLE</id>
-    <description>Used for to determine whether to apply an offset
-    to VCS. Supplied by MRW.</description>
+    <description>Used for to determine whether to apply an offset to VCS. Supplied by MRW.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -8221,8 +7051,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_VPP_OFFSET_DISABLE</id>
-    <description>Used for to determine whether to apply an offset
-    to VPP. Supplied by MRW.</description>
+    <description>Used for to determine whether to apply an offset to VPP. Supplied by MRW.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -8235,8 +7064,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_VDDR_OFFSET_DISABLE</id>
-    <description>Used for to determine whether to apply an offset
-    to VDDR. Supplied by MRW.</description>
+    <description>Used for to determine whether to apply an offset to VDDR. Supplied by MRW.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -8249,8 +7077,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_FINE_REFRESH_MODE</id>
-    <description>Fine refresh mode. Should be defaulted to normal
-    mode. This is for DDR4 MRS3.</description>
+    <description>Fine refresh mode. Should be defaulted to normal mode. This is for DDR4 MRS3.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -8263,12 +7090,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_TEMP_REFRESH_RANGE</id>
-    <description>Temp ref range. Should be defaulted to extended
-    range. This is for DDR4 MRS4. Should be defaulted to extended
-    range. NORMAL for running at 85 degrees C or less, EXTENDED for
-    95 or less degrees C Used for calculating periodic refresh
-    intervals JEDEC DDR4 spec 1716.78C from 07-2016 page 46
-    4.8.1</description>
+    <description>Temp ref range. Should be defaulted to extended range. This is for DDR4 MRS4. Should be defaulted to extended range. NORMAL for running at 85 degrees C or less, EXTENDED for 95 or less degrees C Used for calculating periodic refresh intervals JEDEC DDR4 spec 1716.78C from 07-2016 page 46 4.8.1</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -8285,8 +7107,7 @@
   <!--Deprecated-->
   <attribute>
     <id>MSS_MRW_PERIODIC_MEMCAL_MODE_OPTIONS</id>
-    <description>Describes the settings for periodic calibration
-    for all ports: Reading left to right</description>
+    <description>Describes the settings for periodic calibration for all ports: Reading left to right</description>
     <simpleType>
       <uint16_t></uint16_t>
     </simpleType>
@@ -8299,10 +7120,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_PERIODIC_ZQCAL_MODE_OPTIONS</id>
-    <description>Describes the settings for periodic ZQ calibration
-    for all ports: Reading left to right. For each bit: OFF = 0, ON
-    = 1. Setting to 0 indicates to disable periodic zqcal. Byte 0:
-    0: ZQCAL All others reserved for future use</description>
+    <description>Describes the settings for periodic ZQ calibration for all ports: Reading left to right. For each bit: OFF = 0, ON = 1. Setting to 0 indicates to disable periodic zqcal. Byte 0: 0: ZQCAL All others reserved for future use</description>
     <simpleType>
       <uint16_t></uint16_t>
     </simpleType>
@@ -8315,9 +7133,7 @@
   </attribute>
   <attribute>
     <id>MRW_DRAMINIT_RESET_DISABLE</id>
-    <description>A disable switch for resetting the phy delay
-    values at the beginning of calling
-    mss_draminit_training.</description>
+    <description>A disable switch for resetting the phy delay values at the beginning of calling mss_draminit_training.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -8330,8 +7146,7 @@
   </attribute>
   <attribute>
     <id>SECURITY_ENABLE</id>
-    <description>Holds the state of Security Access Bit
-    (SAB)</description>
+    <description>Holds the state of Security Access Bit (SAB)</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -8345,9 +7160,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_PREFETCH_ENABLE</id>
-    <description>0 = OFF 1 = ON Value of on or off. Determines if
-    prefetching enabled or not. See chapter 7 of the Centaur
-    Workbook.</description>
+    <description>0 = OFF 1 = ON Value of on or off. Determines if prefetching enabled or not. See chapter 7 of the Centaur Workbook.</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -8362,10 +7175,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_CLEANER_ENABLE</id>
-    <description>Value of on or off. Determines if the cleaner of
-    the L4 cache (write modified entries to memory on idle cycles)
-    enabled or not. See chapter 7 of the Centaur
-    Workbook.</description>
+    <description>Value of on or off. Determines if the cleaner of the L4 cache (write modified entries to memory on idle cycles) enabled or not. See chapter 7 of the Centaur Workbook.</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -8381,8 +7191,7 @@
   <!--SBE ONLY-->
   <attribute>
     <id>SUPPORTS_DYNAMIC_MEM_VOLT</id>
-    <description>Do we support dynamically updating memory
-    voltages? 0 = no, 1 = yes</description>
+    <description>Do we support dynamically updating memory voltages? 0 = no, 1 = yes</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -8392,9 +7201,21 @@
     <readable />
   </attribute>
   <attribute>
+    <id>LPC_BASE_ADDR</id>
+    <description>Defines LPC base address on each processor level.</description>
+    <simpleType>
+      <uint64_t></uint64_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <hwpfToHbAttrMap>
+      <id>ATTR_LPC_BASE_ADDR</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+  </attribute>
+  <attribute>
     <id>PROC_FSP_BAR_ENABLE</id>
-    <description>FSP BAR enable DISABLE = 0x0, ENABLE =
-    0x1</description>
+    <description>FSP BAR enable DISABLE = 0x0, ENABLE = 0x1</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -8409,8 +7230,7 @@
   </attribute>
   <attribute>
     <id>PROC_PSI_BRIDGE_BAR_ENABLE</id>
-    <description>PSI Bridge BAR enable DISABLE = 0x0, ENABLE =
-    0x1</description>
+    <description>PSI Bridge BAR enable DISABLE = 0x0, ENABLE = 0x1</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -8425,11 +7245,7 @@
   </attribute>
   <attribute>
     <id>VDM_ENABLE</id>
-    <description>Controls the enablement of Voltage Droop Monitors
-    (VDM) in the system. OFF = 0x00, ON = 0x01 Producer: Machine
-    Readable Workbook Consumers: p9_pstate_parameter_block to set
-    flag for CME QuadManager Hcode reaction p9_hcd_cache procedures
-    to power on VDMs before CME booting</description>
+    <description>Controls the enablement of Voltage Droop Monitors (VDM) in the system. OFF = 0x00, ON = 0x01 Producer: Machine Readable Workbook Consumers: p9_pstate_parameter_block to set flag for CME QuadManager Hcode reaction p9_hcd_cache procedures to power on VDMs before CME booting</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -8442,8 +7258,7 @@
   </attribute>
   <enumerationType>
     <id>VDM_ENABLE</id>
-    <description>Enumeration for Voltage Drop Monitor
-    enable</description>
+    <description>Enumeration for Voltage Drop Monitor enable</description>
     <enumerator>
       <name>OFF</name>
       <value>0x00</value>
@@ -8456,11 +7271,7 @@
   <!-- p9_setup_bars - Begin -->
   <attribute>
     <id>PROC_PCIE_MMIO_BAR0_BASE_ADDR_OFFSET</id>
-    <description>PCIE MMIO0 BAR base address offset Attribute holds
-    offset (relative to chip MMIO origin) to program into chip
-    address range field of BAR -- RA bits 8:47 (excludes
-    system/memory select/group/chip fields) Array index: PHB number
-    (0:5)</description>
+    <description>PCIE MMIO0 BAR base address offset Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 8:47 (excludes system/memory select/group/chip fields) Array index: PHB number (0:5)</description>
     <simpleType>
       <uint64_t></uint64_t>
       <array>6</array>
@@ -8474,11 +7285,7 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_MMIO_BAR1_BASE_ADDR_OFFSET</id>
-    <description>PCIE MMIO1 BAR base address offset Attribute holds
-    offset (relative to chip MMIO origin) to program into chip
-    address range field of BAR -- RA bits 8:47 (excludes
-    system/memory select/group/chip fields) Array index: PHB number
-    (0:5)</description>
+    <description>PCIE MMIO1 BAR base address offset Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 8:47 (excludes system/memory select/group/chip fields) Array index: PHB number (0:5)</description>
     <simpleType>
       <uint64_t></uint64_t>
       <array>6</array>
@@ -8492,10 +7299,7 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_REGISTER_BAR_BASE_ADDR_OFFSET</id>
-    <description>PCIE PHB register space BAR base address offset
-    chip address range field of BAR -- RA bits 8:49 (excludes
-    system/memory select/group/chip fields) Array index: PHB number
-    (0:5)</description>
+    <description>PCIE PHB register space BAR base address offset chip address range field of BAR -- RA bits 8:49 (excludes system/memory select/group/chip fields) Array index: PHB number (0:5)</description>
     <simpleType>
       <uint64_t></uint64_t>
       <array>6</array>
@@ -8509,11 +7313,7 @@
   </attribute>
   <attribute>
     <id>PROC_XSCOM_BAR_BASE_ADDR_OFFSET</id>
-    <description>XSCOM BAR base address offset Defines 16GB range
-    (size implied) mapped for XSCOM usage Attribute holds offset
-    (relative to chip MMIO origin) to program into chip address
-    range field of BAR -- RA bits 22:29 (excludes system/memory
-    select/group/chip fields)</description>
+    <description>XSCOM BAR base address offset Defines 16GB range (size implied) mapped for XSCOM usage Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 22:29 (excludes system/memory select/group/chip fields)</description>
     <simpleType>
       <uint64_t></uint64_t>
     </simpleType>
@@ -8526,26 +7326,21 @@
   </attribute>
   <attribute>
     <id>PROC_LPC_BAR_BASE_ADDR_OFFSET</id>
-    <description>LPC BAR base address offset Defines 4GB range
-    (size implied) mapped for LPC usage Attribute holds offset
-    (relative to chip MMIO origin) to program into chip address
-    range field of BAR -- RA bits 22:31 (excludes system/memory
-    select/group/chip fields)</description>
+    <description>LPC BAR base address offset Defines 4GB range (size implied) mapped for LPC usage Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 22:31 (excludes system/memory select/group/chip fields)</description>
     <simpleType>
       <uint64_t></uint64_t>
     </simpleType>
     <persistency>non-volatile</persistency>
     <readable />
+    <writeable />
     <hwpfToHbAttrMap>
       <id>ATTR_PROC_LPC_BAR_BASE_ADDR_OFFSET</id>
       <macro>DIRECT</macro>
     </hwpfToHbAttrMap>
-    <writeable />
   </attribute>
   <attribute>
     <id>PROC_FSP_BAR_SIZE</id>
-    <description>FSP BAR size value creator: platform consumer:
-    p9_setup_bars firmware notes: none</description>
+    <description>FSP BAR size value creator: platform consumer: p9_setup_bars firmware notes: none</description>
     <simpleType>
       <uint64_t>
         <default>0xFFFFFC00FFFFFFFF</default>
@@ -8560,10 +7355,7 @@
   </attribute>
   <attribute>
     <id>PROC_FSP_BAR_BASE_ADDR_OFFSET</id>
-    <description>FSP BAR Defines range mapped for FSP MMIO
-    Attribute holds offset (relative to chip MMIO origin) to
-    program into chip address range field of BAR -- RA bits
-    22:43</description>
+    <description>FSP BAR Defines range mapped for FSP MMIO Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 22:43</description>
     <simpleType>
       <uint64_t>
         <default>0x0000030100000000</default>
@@ -8578,11 +7370,7 @@
   </attribute>
   <attribute>
     <id>PROC_FSP_MMIO_MASK_SIZE</id>
-    <description>FSP MMIO mask size value AND mask applied to RA
-    32:35 when transmitting address to FSP NOTE: RA 8:31 are always
-    replaced with zero 4_GB = 0x00F0000000000000, 2_GB =
-    0x0070000000000000, 1_GB = 0x0030000000000000, 512_MB =
-    0x0010000000000000, 256_MB = 0x0000000000000000</description>
+    <description>FSP MMIO mask size value AND mask applied to RA 32:35 when transmitting address to FSP NOTE: RA 8:31 are always replaced with zero 4_GB = 0x00F0000000000000, 2_GB = 0x0070000000000000, 1_GB = 0x0030000000000000, 512_MB = 0x0010000000000000, 256_MB = 0x0000000000000000</description>
     <simpleType>
       <uint64_t>
         <default>0x0010000000000000</default>
@@ -8597,11 +7385,7 @@
   </attribute>
   <attribute>
     <id>PROC_PSI_BRIDGE_BAR_BASE_ADDR_OFFSET</id>
-    <description>PSI Bridge BAR base address offset Defines 1MB
-    range (size implied) mapped for PSI host-bridge Attribute holds
-    offset (relative to chip MMIO origin) to program into chip
-    address range field of BAR -- RA bits 22:43 (excludes
-    system/memory select/group/chip fields)</description>
+    <description>PSI Bridge BAR base address offset Defines 1MB range (size implied) mapped for PSI host-bridge Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 22:43 (excludes system/memory select/group/chip fields)</description>
     <simpleType>
       <uint64_t>
         <default>0x0000030203000000</default>
@@ -8616,8 +7400,7 @@
   </attribute>
   <attribute>
     <id>PROC_NPU_PHY0_BAR_ENABLE</id>
-    <description>NPU PHY0 (stack0) BAR enable DISABLE = 0x0, ENABLE
-    = 0x1</description>
+    <description>NPU PHY0 (stack0) BAR enable DISABLE = 0x0, ENABLE = 0x1</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -8632,11 +7415,7 @@
   </attribute>
   <attribute>
     <id>PROC_NPU_PHY0_BAR_BASE_ADDR_OFFSET</id>
-    <description>NPU PHY0 (stack0) BAR Defines 2MB range (size
-    implied) mapped to PHY0 registers Attribute holds offset
-    (relative to chip MMIO origin) to program into chip address
-    range field of BAR -- RA bits 22:42 (excludes system/memory
-    select/group/chip fields)</description>
+    <description>NPU PHY0 (stack0) BAR Defines 2MB range (size implied) mapped to PHY0 registers Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 22:42 (excludes system/memory select/group/chip fields)</description>
     <simpleType>
       <uint64_t>
         <default>0x0000030201200000</default>
@@ -8651,8 +7430,7 @@
   </attribute>
   <attribute>
     <id>PROC_NPU_PHY1_BAR_ENABLE</id>
-    <description>NPU PHY1 (stack1) BAR enable DISABLE = 0x0, ENABLE
-    = 0x1</description>
+    <description>NPU PHY1 (stack1) BAR enable DISABLE = 0x0, ENABLE = 0x1</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -8667,11 +7445,7 @@
   </attribute>
   <attribute>
     <id>PROC_NPU_PHY1_BAR_BASE_ADDR_OFFSET</id>
-    <description>NPU PHY1 (stack1) BAR Defines 2MB range (size
-    implied) mapped to PHY1 registers Attribute holds offset
-    (relative to chip MMIO origin) to program into chip address
-    range field of BAR -- RA bits 22:42 (excludes system/memory
-    select/group/chip fields)</description>
+    <description>NPU PHY1 (stack1) BAR Defines 2MB range (size implied) mapped to PHY1 registers Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 22:42 (excludes system/memory select/group/chip fields)</description>
     <simpleType>
       <uint64_t>
         <default>0x0000030201400000</default>
@@ -8686,8 +7460,7 @@
   </attribute>
   <attribute>
     <id>PROC_NPU_MMIO_BAR_ENABLE</id>
-    <description>NPU MMIO (stack2) BAR enable DISABLE = 0x0, ENABLE
-    = 0x1</description>
+    <description>NPU MMIO (stack2) BAR enable DISABLE = 0x0, ENABLE = 0x1</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -8702,11 +7475,7 @@
   </attribute>
   <attribute>
     <id>PROC_NPU_MMIO_BAR_BASE_ADDR_OFFSET</id>
-    <description>NPU MMIO (stack2) BAR Defines 16MB range mapped to
-    all NPU registers Attribute holds offset (relative to chip MMIO
-    origin) to program into chip address range field of BAR -- RA
-    bits 22:39 (excludes system/memory select/group/chip
-    fields)</description>
+    <description>NPU MMIO (stack2) BAR Defines 16MB range mapped to all NPU registers Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 22:39 (excludes system/memory select/group/chip fields)</description>
     <simpleType>
       <uint64_t>
         <default>0x0000030200000000</default>
@@ -8721,8 +7490,7 @@
   </attribute>
   <attribute>
     <id>PROC_NX_RNG_BAR_ENABLE</id>
-    <description>NX RNG BAR enable DISABLE = 0x0, ENABLE =
-    0x1</description>
+    <description>NX RNG BAR enable DISABLE = 0x0, ENABLE = 0x1</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -8737,11 +7505,7 @@
   </attribute>
   <attribute>
     <id>PROC_NX_RNG_BAR_BASE_ADDR_OFFSET</id>
-    <description>NX RNG BAR Defines 8KB range (size implied) mapped
-    for NX RNG function Attribute holds offset (relative to chip
-    MMIO origin) to program into chip address range field of BAR --
-    RA bits 22:51 (excludes system/memory select/group/chip
-    fields)</description>
+    <description>NX RNG BAR Defines 8KB range (size implied) mapped for NX RNG function Attribute holds offset (relative to chip MMIO origin) to program into chip address range field of BAR -- RA bits 22:51 (excludes system/memory select/group/chip fields)</description>
     <simpleType>
       <uint64_t>
         <default>0x00000302031D0000</default>
@@ -8759,11 +7523,7 @@
     so we will init them to zero -->
   <attribute>
     <id>PROC_R_LOADLINE_VDD_UOHM</id>
-    <description>Impedance (binary microOhms) of the load line from
-    a processor VDD VRM to the Processor Module pins. This value is
-    applied to each processor instance. Producer: Machine Readable
-    Workbook (per the power subsystem design) Consumers:
-    p9_pstate_parameter_block</description>
+    <description>Impedance (binary microOhms) of the load line from a processor VDD VRM to the Processor Module pins. This value is applied to each processor instance. Producer: Machine Readable Workbook (per the power subsystem design) Consumers: p9_pstate_parameter_block</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -8776,11 +7536,7 @@
   </attribute>
   <attribute>
     <id>PROC_R_DISTLOSS_VDD_UOHM</id>
-    <description>Impedance (binary in microOhms) of the VDD
-    distribution loss sense point to the circuit. This value is
-    applied to each processor instance. Producer: Machine Readable
-    Workbook (per the power subsystem design) Consumers:
-    p9_pstate_parameter_block</description>
+    <description>Impedance (binary in microOhms) of the VDD distribution loss sense point to the circuit. This value is applied to each processor instance. Producer: Machine Readable Workbook (per the power subsystem design) Consumers: p9_pstate_parameter_block</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -8793,12 +7549,7 @@
   </attribute>
   <attribute>
     <id>PROC_VRM_VOFFSET_VDD_UV</id>
-    <description>Offset voltage (binary in microvolts) to apply to
-    the VDD VRM distribution to the processor module. This value is
-    applied to each processor instance. Note: no loadline may be
-    present in the system; thus, a value of 0 is legal. Producer:
-    Machine Readable Workbook (per the power subsystem design)
-    Consumers: p9_pstate_parameter_block</description>
+    <description>Offset voltage (binary in microvolts) to apply to the VDD VRM distribution to the processor module. This value is applied to each processor instance. Note: no loadline may be present in the system; thus, a value of 0 is legal. Producer: Machine Readable Workbook (per the power subsystem design) Consumers: p9_pstate_parameter_block</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -8811,12 +7562,7 @@
   </attribute>
   <attribute>
     <id>PROC_R_LOADLINE_VDN_UOHM</id>
-    <description>Impedance (binary microOhms) of the load line from
-    a processor VDN VRM to the Processor Module pins. This value is
-    applied to each processor instance. Note: no loadline may be
-    present in the system; thus, a value of 0 is legal. Producer:
-    Machine Readable Workbook (per the power subsystem design)
-    Consumers: p9_pstate_parameter_block</description>
+    <description>Impedance (binary microOhms) of the load line from a processor VDN VRM to the Processor Module pins. This value is applied to each processor instance. Note: no loadline may be present in the system; thus, a value of 0 is legal. Producer: Machine Readable Workbook (per the power subsystem design) Consumers: p9_pstate_parameter_block</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
@@ -8829,11 +7575,7 @@
   </attribute>
   <attribute>
     <id>PROC_R_DISTLOSS_VDN_UOHM</id>
-    <description>Impedance (binary in microOhms) of the VDN
-    distribution loss sense point to the circuit. This value is
-    applied to each processor instance. Producer: Machine Readable
-    Workbook (per the power subsystem design) Consumers:
-    p9_pstate_parameter_block</description>
+    <description>Impedance (binary in microOhms) of the VDN distribution loss sense point to the circuit. This value is applied to each processor instance. Producer: Machine Readable Workbook (per the power subsystem design) Consumers: p9_pstate_parameter_block</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
@@ -8846,11 +7588,7 @@
   </attribute>
   <attribute>
     <id>PROC_VRM_VOFFSET_VDN_UV</id>
-    <description>Offset voltage (binary in microvolts) to apply to
-    the VDN VRM distribution to the processor module. This value is
-    applied to each processor instance. Producer: Machine Readable
-    Workbook (per the power subsystem design) Consumers:
-    p9_pstate_parameter_block</description>
+    <description>Offset voltage (binary in microvolts) to apply to the VDN VRM distribution to the processor module. This value is applied to each processor instance. Producer: Machine Readable Workbook (per the power subsystem design) Consumers: p9_pstate_parameter_block</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
@@ -8863,12 +7601,7 @@
   </attribute>
   <attribute>
     <id>PROC_R_LOADLINE_VCS_UOHM</id>
-    <description>Impedance (binary microOhms) of the load line from
-    a processor VCS VRM to the Processor Module pins. This value is
-    applied to each processor instance. Note: no loadline may be
-    present in the system; thus, a value of 0 is legal. Producer:
-    Machine Readable Workbook (per the power subsystem design)
-    Consumers: p9_pstate_parameter_block</description>
+    <description>Impedance (binary microOhms) of the load line from a processor VCS VRM to the Processor Module pins. This value is applied to each processor instance. Note: no loadline may be present in the system; thus, a value of 0 is legal. Producer: Machine Readable Workbook (per the power subsystem design) Consumers: p9_pstate_parameter_block</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -8881,11 +7614,7 @@
   </attribute>
   <attribute>
     <id>PROC_R_DISTLOSS_VCS_UOHM</id>
-    <description>Impedance (binary in microOhms) of the VCS
-    distribution loss sense point to the circuit. This value is
-    applied to each processor instance. Producer: Machine Readable
-    Workbook (via the power subsystem design per system) Consumer:
-    p9_pstate_parameter_block</description>
+    <description>Impedance (binary in microOhms) of the VCS distribution loss sense point to the circuit. This value is applied to each processor instance. Producer: Machine Readable Workbook (via the power subsystem design per system) Consumer: p9_pstate_parameter_block</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -8898,11 +7627,7 @@
   </attribute>
   <attribute>
     <id>PROC_VRM_VOFFSET_VCS_UV</id>
-    <description>Offset voltage (binary in microvolts) to apply to
-    the VCS VRM distribution to the processor module. This value is
-    applied to each processor instance. Producer: Machine Readable
-    Workbook (via the power subsystem design per system) Consumer:
-    FSP</description>
+    <description>Offset voltage (binary in microvolts) to apply to the VCS VRM distribution to the processor module. This value is applied to each processor instance. Producer: Machine Readable Workbook (via the power subsystem design per system) Consumer: FSP</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -8915,9 +7640,7 @@
   </attribute>
   <attribute>
     <id>IVRM_DEADZONE_MV</id>
-    <description>Indicates the size of the deadzone where the iVRM
-    cannot regulate (binary in millivolts) Producer:
-    MRWB.</description>
+    <description>Indicates the size of the deadzone where the iVRM cannot regulate (binary in millivolts) Producer: MRWB.</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -8930,8 +7653,7 @@
   </attribute>
   <attribute>
     <id>TDP_RDP_CURRENT_FACTOR</id>
-    <description>TODO RTC 157943 -- Placeholder description
-    Consumers: p9_pstate_parameter_block</description>
+    <description>TODO RTC 157943 -- Placeholder description Consumers: p9_pstate_parameter_block</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
@@ -8944,9 +7666,7 @@
   </attribute>
   <attribute>
     <id>PM_SAFE_FREQUENCY_MHZ</id>
-    <description>Frequency (in MHz) to move to if the Power
-    Management function fails. This is the same for all cores in
-    the system. Provided by the MRW.</description>
+    <description>Frequency (in MHz) to move to if the Power Management function fails. This is the same for all cores in the system. Provided by the MRW.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -8959,9 +7679,7 @@
   </attribute>
   <attribute>
     <id>MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR4</id>
-    <description>Machine Readable Workbook VMEM regulator power
-    limit per DIMM assuming a full configuration. Units in cW
-    Consumed in mss_eff_config_thermal</description>
+    <description>Machine Readable Workbook VMEM regulator power limit per DIMM assuming a full configuration. Units in cW Consumed in mss_eff_config_thermal</description>
     <simpleType>
       <uint32_t>
         <default>0x000006A4</default>
@@ -8970,36 +7688,26 @@
     <persistency>non-volatile</persistency>
     <readable />
     <hwpfToHbAttrMap>
-      <id>
-      ATTR_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR4</id>
+      <id>ATTR_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR4</id>
       <macro>DIRECT</macro>
     </hwpfToHbAttrMap>
   </attribute>
   <attribute>
     <id>MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR3</id>
-    <description>Machine Readable Workbook VMEM regulator power
-    limit per CDIMM assuming a full configuration. Units in cW Used
-    for Cumulus Consumed in mss_eff_config_thermal</description>
+    <description>Machine Readable Workbook VMEM regulator power limit per CDIMM assuming a full configuration. Units in cW Used for Cumulus Consumed in mss_eff_config_thermal</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
     <persistency>non-volatile</persistency>
     <readable />
     <hwpfToHbAttrMap>
-      <id>
-      ATTR_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR3</id>
+      <id>ATTR_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR3</id>
       <macro>DIRECT</macro>
     </hwpfToHbAttrMap>
   </attribute>
   <attribute>
     <id>SYSTEM_FAMILY</id>
-    <description>This field is of the form "vendor,name" where the
-    name indicates the family of the systems. The textual portion
-    of the string has a maximum length of 63 characters to
-    accommodate a terminating NULL. Both vendor and name fields are
-    lower case US ASCII. No special characters other than ",", "-",
-    and "+" as described below should be used in the
-    string.</description>
+    <description>This field is of the form "vendor,name" where the name indicates the family of the systems. The textual portion of the string has a maximum length of 63 characters to accommodate a terminating NULL. Both vendor and name fields are lower case US ASCII. No special characters other than ",", "-", and "+" as described below should be used in the string.</description>
     <simpleType>
       <string>
         <default>ibm,p9</default>
@@ -9011,18 +7719,7 @@
   </attribute>
   <attribute>
     <id>SYSTEM_TYPE</id>
-    <description>This field is of the form ?vendor,type? where the
-    type indicates a type of system within the System Family. The
-    textual portion of the string has a maximum length of 63
-    characters to accommodate a terminating NULL. Both vendor and
-    name fields are lower case US ASCII. No special characters
-    other than ",", "-", and "+" as described below should be used
-    in the string. If identification of specific models within a
-    system type is desired, "-model" should be appended to the end
-    of the name. The "-model" portion is optional and could be used
-    to identify the packaging, specific model numbers, etc. NOTE:
-    No Hostboot code should ever key off of this
-    value.</description>
+    <description>This field is of the form ?vendor,type? where the type indicates a type of system within the System Family. The textual portion of the string has a maximum length of 63 characters to accommodate a terminating NULL. Both vendor and name fields are lower case US ASCII. No special characters other than ",", "-", and "+" as described below should be used in the string. If identification of specific models within a system type is desired, "-model" should be appended to the end of the name. The "-model" portion is optional and could be used to identify the packaging, specific model numbers, etc. NOTE: No Hostboot code should ever key off of this value.</description>
     <simpleType>
       <string>
         <default>ibm,miscopenpower</default>
@@ -9034,15 +7731,7 @@
   </attribute>
   <attribute>
     <id>SUPPORTED_STOP_STATES</id>
-    <description>STOP levels supported at runtime (sent to Host via
-    HDAT): Bit 0: STOP0 Supported - Quiesce thread only Bit 1:
-    STOP1 Supported - P8 Nap Bit 2: STOP2 Supported - P8 Fast Sleep
-    Bit 3: STOP3 Supported - P8 Fast Sleep using iVRMs Bit 4: STOP4
-    supported - P8 Deep Sleep Bit 5: STOP5 Supported - WOF-friendly
-    "Instant on" Bit 6,7: Reserved Bit 8: STOP8 supported - Half
-    Quad Sleep Bit 9: STOP9 supported - P8 Fast Winkle Bit 10:
-    Reserved Bit 11: STOP11 supported - P8 Deep Winkle Bit 12-15 :
-    Reserved Bits 16..31 - Reserved</description>
+    <description>STOP levels supported at runtime (sent to Host via HDAT): Bit 0: STOP0 Supported - Quiesce thread only Bit 1: STOP1 Supported - P8 Nap Bit 2: STOP2 Supported - P8 Fast Sleep Bit 3: STOP3 Supported - P8 Fast Sleep using iVRMs Bit 4: STOP4 supported - P8 Deep Sleep Bit 5: STOP5 Supported - WOF-friendly "Instant on" Bit 6,7: Reserved Bit 8: STOP8 supported - Half Quad Sleep Bit 9: STOP9 supported - P8 Fast Winkle Bit 10: Reserved Bit 11: STOP11 supported - P8 Deep Winkle Bit 12-15 : Reserved Bits 16..31 - Reserved</description>
     <simpleType>
       <uint32_t>
         <default>0xEC900000</default>
@@ -9053,10 +7742,7 @@
   </attribute>
   <attribute>
     <id>SBE_IMAGE_MINIMUM_VALID_ECS</id>
-    <description>The minimum number of valid ECs that is required
-    to be used when customizing an SBE image. The customization
-    will fail if it cannot create an image with at least this many
-    ECs.</description>
+    <description>The minimum number of valid ECs that is required to be used when customizing an SBE image. The customization will fail if it cannot create an image with at least this many ECs.</description>
     <simpleType>
       <uint8_t>
         <default>2</default>
@@ -9071,8 +7757,7 @@
   </attribute>
   <attribute>
     <id>REL_POS</id>
-    <description>Logical position of this unit/dimm relative to its
-    immediate parent</description>
+    <description>Logical position of this unit/dimm relative to its immediate parent</description>
     <simpleType>
       <uint8_t>
         <default>0xFF</default>
@@ -9087,20 +7772,10 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_LANE_EQUALIZATION_GEN3</id>
-    <description>PCIE Lane Equalization values for each PHB
-    Creator: MRW Purpose: Holds settings which are loaded into the
-    HW to optimize the PCIE lane signal eye between the chips +
-    PCIE Gen3 endpoints Data Format: 16 entries of 16 bytes of EQ
-    data per PHB. Each PHB has an EQ value for each of its 16
-    lanes. Each value is a uint16 formatted as follows: Bit 0:3 -
-    up_rx_hint (bit 0 reserved) Bit 4:7 - up_tx_preset Bit 8:11 -
-    dn_rx_hint (bit 0 reserved) Bit 12:15 -
-    dn_tx_preset</description>
+    <description>PCIE Lane Equalization values for each PHB Creator: MRW Purpose: Holds settings which are loaded into the HW to optimize the PCIE lane signal eye between the chips + PCIE Gen3 endpoints Data Format: 16 entries of 16 bytes of EQ data per PHB. Each PHB has an EQ value for each of its 16 lanes. Each value is a uint16 formatted as follows: Bit 0:3 - up_rx_hint (bit 0 reserved) Bit 4:7 - up_tx_preset Bit 8:11 - dn_rx_hint (bit 0 reserved) Bit 12:15 - dn_tx_preset</description>
     <simpleType>
       <uint16_t>
-        <default>0x7777,0x7777,0x7777,0x7777,
-        0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777,
-        0x7777,0x7777,0x7777,0x7777</default>
+        <default>0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777</default>
       </uint16_t>
       <array>16</array>
       <!-- Lane -->
@@ -9110,20 +7785,10 @@
   </attribute>
   <attribute>
     <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
-    <description>PCIE Lane Equalization values for each PHB
-    Creator: MRW Purpose: Holds settings which are loaded into the
-    HW to optimize the PCIE lane signal eye between the chips +
-    PCIE Gen4 endpoints Data Format: 16 entries of 16 bytes of EQ
-    data per PHB. Each PHB has an EQ value for each of its 16
-    lanes. Each value is a uint16 formatted as follows: Bit 0:3 -
-    up_rx_hint (bit 0 reserved) Bit 4:7 - up_tx_preset Bit 8:11 -
-    dn_rx_hint (bit 0 reserved) Bit 12:15 -
-    dn_tx_preset</description>
+    <description>PCIE Lane Equalization values for each PHB Creator: MRW Purpose: Holds settings which are loaded into the HW to optimize the PCIE lane signal eye between the chips + PCIE Gen4 endpoints Data Format: 16 entries of 16 bytes of EQ data per PHB. Each PHB has an EQ value for each of its 16 lanes. Each value is a uint16 formatted as follows: Bit 0:3 - up_rx_hint (bit 0 reserved) Bit 4:7 - up_tx_preset Bit 8:11 - dn_rx_hint (bit 0 reserved) Bit 12:15 - dn_tx_preset</description>
     <simpleType>
       <uint16_t>
-        <default>0x7777,0x7777,0x7777,0x7777,
-        0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777,
-        0x7777,0x7777,0x7777,0x7777</default>
+        <default>0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777, 0x7777,0x7777,0x7777,0x7777</default>
       </uint16_t>
       <array>16</array>
       <!-- Lane -->
@@ -9133,8 +7798,7 @@
   </attribute>
   <attribute>
     <id>SBE_SYS_CONFIG</id>
-    <description>System Configuration information - 1 indicates a
-    chip present</description>
+    <description>System Configuration information - 1 indicates a chip present</description>
     <simpleType>
       <uint64_t>
         <default>0x0</default>
@@ -9150,28 +7814,10 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_PWR_INTERCEPT</id>
-    <description>Machine Readable Workbook Power Curve Intercept
-    for DIMM Used to get the VDDR and VDDR+VPP power curve for each
-    DIMM Decoded and used to set ATTR_MSS_TOTAL_PWR_INTERCEPT Key
-    Value pair KEY (0-19): In order DIMM_SIZE = bits 0-3, DIMM_GEN
-    = 4-5, DIMM_TYPE = 6-7, DIMM_WIDTH = 8-9, DIMM_DENSITY = 10-12,
-    DIMM_STACK_TYPE = 13-14, DRAM_MFGID = 15-16, DIMMS_PER_PORT =
-    17-18, Bits 19-32: Not used VALUE (bits 32-63) in cW: VMEM
-    power curve = 32-47 VMEM+VPP power curve = 48-63 Consumers:
-    eff_config_thermal</description>
+    <description>Machine Readable Workbook Power Curve Intercept for DIMM Used to get the VDDR and VDDR+VPP power curve for each DIMM Decoded and used to set ATTR_MSS_TOTAL_PWR_INTERCEPT Key Value pair KEY (0-19): In order DIMM_SIZE = bits 0-3, DIMM_GEN = 4-5, DIMM_TYPE = 6-7, DIMM_WIDTH = 8-9, DIMM_DENSITY = 10-12, DIMM_STACK_TYPE = 13-14, DRAM_MFGID = 15-16, DIMMS_PER_PORT = 17-18, Bits 19-32: Not used VALUE (bits 32-63) in cW: VMEM power curve = 32-47 VMEM+VPP power curve = 48-63 Consumers: eff_config_thermal</description>
     <simpleType>
       <uint64_t>
-        <default>
-        0xffffe00002CC03AE,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0</default>
+        <default>0xffffe00002CC03AE,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0</default>
       </uint64_t>
       <array>100</array>
     </simpleType>
@@ -9184,28 +7830,10 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_PWR_SLOPE</id>
-    <description>Machine Readable Workbook Power Curve Slope for
-    DIMM Used to get the VDDR and VDDR+VPP power curve for each
-    DIMM Decoded and used to set ATTR_MSS_TOTAL_PWR_INTERCEPT Key
-    Value pair KEY (0-19): In order DIMM_SIZE = bits 0-3, DIMM_GEN
-    = 4-5, DIMM_TYPE = 6-7, DIMM_WIDTH = 8-9, DIMM_DENSITY = 10-12,
-    DIMM_STACK_TYPE = 13-14, DRAM_MFGID = 15-16, DIMMS_PER_PORT =
-    17-18, Bits 19-32: Not used VALUE (bits 32-63) in cW: VMEM
-    power curve = 32-47 VMEM+VPP power curve = 48-63 Consumers:
-    eff_config_thermal</description>
+    <description>Machine Readable Workbook Power Curve Slope for DIMM Used to get the VDDR and VDDR+VPP power curve for each DIMM Decoded and used to set ATTR_MSS_TOTAL_PWR_INTERCEPT Key Value pair KEY (0-19): In order DIMM_SIZE = bits 0-3, DIMM_GEN = 4-5, DIMM_TYPE = 6-7, DIMM_WIDTH = 8-9, DIMM_DENSITY = 10-12, DIMM_STACK_TYPE = 13-14, DRAM_MFGID = 15-16, DIMMS_PER_PORT = 17-18, Bits 19-32: Not used VALUE (bits 32-63) in cW: VMEM power curve = 32-47 VMEM+VPP power curve = 48-63 Consumers: eff_config_thermal</description>
     <simpleType>
       <uint64_t>
-        <default>
-        0xffffe00003FD0546,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0</default>
+        <default>0xffffe00003FD0546,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0, 0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0</default>
       </uint64_t>
       <array>100</array>
     </simpleType>
@@ -9218,11 +7846,7 @@
   </attribute>
   <attribute>
     <id>MSS_MRW_REFRESH_RATE_REQUEST</id>
-    <description>Machine Readable Workbook Refresh Rate Desired
-    refresh interval used in refresh register 0,
-    MBAREF0Q_CFG_REFRESH_INTERVAL 7.8 us (SINGLE) 3.9 us (DOUBLE)
-    7.02 us (SINGLE_10_PERCENT_FASTER) 3.51 us
-    (DOUBLE_10_PERCENT_FASTER)</description>
+    <description>Machine Readable Workbook Refresh Rate Desired refresh interval used in refresh register 0, MBAREF0Q_CFG_REFRESH_INTERVAL 7.8 us (SINGLE) 3.9 us (DOUBLE) 7.02 us (SINGLE_10_PERCENT_FASTER) 3.51 us (DOUBLE_10_PERCENT_FASTER)</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -9235,8 +7859,7 @@
   </attribute>
   <attribute>
     <id>PM_SAFE_VOLTAGE_MV</id>
-    <description>Voltage (in mV) to move to if the Power Management
-    function fails. Provided by the MRW.</description>
+    <description>Voltage (in mV) to move to if the Power Management function fails. Provided by the MRW.</description>
     <simpleType>
       <uint32_t />
     </simpleType>
@@ -9316,10 +7939,7 @@
   </attribute>
   <attribute>
     <id>SYSTEM_RESCLK_ENABLE</id>
-    <description>Controls the enablement of resonant clocking in
-    the system. Producer: Machine Readable Workbook Consumers:
-    p9_pstate_parameter_block to set flag for CME QuadManager Hcode
-    reaction</description>
+    <description>Controls the enablement of resonant clocking in the system. Producer: Machine Readable Workbook Consumers: p9_pstate_parameter_block to set flag for CME QuadManager Hcode reaction</description>
     <simpleType>
       <uint8_t></uint8_t>
     </simpleType>
@@ -9344,9 +7964,7 @@
   </attribute>
   <attribute>
     <id>POUND_W_STATIC_DATA_ENABLE</id>
-    <description>Enables pstate parameter block code to use the
-    static #W data Consumer: p9_pstate_parameter_block.C -&gt;
-    Platform default: OFF=0</description>
+    <description>Enables pstate parameter block code to use the static #W data Consumer: p9_pstate_parameter_block.C -&gt; Platform default: OFF=0</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -9361,13 +7979,7 @@
   </attribute>
   <attribute>
     <id>PGPE_HCODE_FUNCTION_ENABLE</id>
-    <description>Enables the PGPE Hcode to physically perform
-    frequency and voltage operations based on constructed
-    parameters (eg #V VPD, system parameters, biases, WPF VFRTs.
-    etc). If OFF, the PGPE provides an immedicate good response to
-    all Pstate/WOF IPC operations from the OCC for firmware
-    integration testing purposes. Consumer: p9_hcode_image_build.c
-    -&gt; PGPE Header field Platform default: OFF</description>
+    <description>Enables the PGPE Hcode to physically perform frequency and voltage operations based on constructed parameters (eg #V VPD, system parameters, biases, WPF VFRTs. etc). If OFF, the PGPE provides an immedicate good response to all Pstate/WOF IPC operations from the OCC for firmware integration testing purposes. Consumer: p9_hcode_image_build.c -&gt; PGPE Header field Platform default: OFF</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -9382,9 +7994,7 @@
   </attribute>
   <attribute>
     <id>XIVE_HW_RESET</id>
-    <description>Used to tell INTRP code whether to use the XIVE HW
-    Reset or a software based reset. 0 = Software based reset 1 =
-    XIVE HW reset</description>
+    <description>Used to tell INTRP code whether to use the XIVE HW Reset or a software based reset. 0 = Software based reset 1 = XIVE HW reset</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -9395,14 +8005,7 @@
   </attribute>
   <attribute>
     <id>MAX_SBE_SEEPROM_SIZE</id>
-    <description>Defines the maximum Seeprom storage size for the
-    fully-customized SBE image permitted by the platform. For
-    platforms (FSP/HB FW) which require the image to be constrained
-    into a physical storage device (SEEPROM), this should reflect
-    the maximum size of that memory (e.g., 256KB). For platforms
-    (Cronus) which may use a customized image in a virtual
-    envrionment with no physical storage constraints, this size may
-    be larger than the physical SEEPROM size.</description>
+    <description>Defines the maximum Seeprom storage size for the fully-customized SBE image permitted by the platform. For platforms (FSP/HB FW) which require the image to be constrained into a physical storage device (SEEPROM), this should reflect the maximum size of that memory (e.g., 256KB). For platforms (Cronus) which may use a customized image in a virtual envrionment with no physical storage constraints, this size may be larger than the physical SEEPROM size.</description>
     <simpleType>
       <uint32_t>
         <default>0x40000</default>
@@ -9419,9 +8022,7 @@
   <!-- @fixme RTC:166754 Remove old attribute -->
   <attribute>
     <id>DISABLE_I2C_ENGINE2_PORT0_DIAG_MODE</id>
-    <description>Used to tell I2C code whether to run I2C Engine 2
-    Port 0 in diag mode or not 0 = Use Diag Mode 1 = Disable Diag
-    Mode</description>
+    <description>Used to tell I2C code whether to run I2C Engine 2 Port 0 in diag mode or not 0 = Use Diag Mode 1 = Disable Diag Mode</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -9432,8 +8033,7 @@
   </attribute>
   <enumerationType>
     <id>MSS_MRW_TEMP_REFRESH_MODE</id>
-    <description>Enumeration for Temperature refresh
-    mode</description>
+    <description>Enumeration for Temperature refresh mode</description>
     <enumerator>
       <name>DISABLE</name>
       <value>0</value>
@@ -9445,8 +8045,7 @@
   </enumerationType>
   <attribute>
     <id>MSS_MRW_TEMP_REFRESH_MODE</id>
-    <description>Used in MR4 A3 Temperature refresh mode Should be
-    defaulted to disable</description>
+    <description>Used in MR4 A3 Temperature refresh mode Should be defaulted to disable</description>
     <simpleType>
       <uint8_t>
         <default>DISABLE</default>
@@ -9461,8 +8060,7 @@
   </attribute>
   <enumerationType>
     <id>HDAT_I2C_DEVICE_TYPE</id>
-    <description>Pulled from the MRW, this describes the device
-    type to the HDAT. This is for I2C devices only.</description>
+    <description>Pulled from the MRW, this describes the device type to the HDAT. This is for I2C devices only.</description>
     <enumerator>
       <name>955X</name>
       <value>1</value>
@@ -9494,9 +8092,7 @@
   </enumerationType>
   <enumerationType>
     <id>HDAT_I2C_DEVICE_PURPOSE</id>
-    <description>Pulled from the MRW, this describes the device
-    purpose to the HDAT. This is for I2C devices
-    only.</description>
+    <description>Pulled from the MRW, this describes the device purpose to the HDAT. This is for I2C devices only.</description>
     <enumerator>
       <name>CABLE_CARD_PRES</name>
       <value>1</value>
@@ -9554,10 +8150,108 @@
       <value>FF</value>
     </enumerator>
   </enumerationType>
+  <attribute>
+    <id>SLOT_NAME</id>
+    <description>PCIe slot name definition</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>SLOT_INDEX</id>
+    <description>PCIe slot index definition</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PCIE_32BIT_MMIO_SIZE</id>
+    <description>PCIe slot 32bit MMIO size definition</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PCIE_64BIT_MMIO_SIZE</id>
+    <description>PCIe slot 64bit MMIO size definition</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PCIE_32BIT_DMA_SIZE</id>
+    <description>PCIe slot 32bit DMA size definition</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PCIE_64BIT_DMA_SIZE</id>
+    <description>PCIe slot 64bit DMA size definition</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>HDDW_ORDER</id>
+    <description>PCIe slot HDDW order definition</description>
+    <simpleType>
+      <uint8_t></uint8_t>
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MGC_LOAD_SOURCE</id>
+    <description>defines MGC load source</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>PCIE_CAPABILITES</id>
+    <description>Denotes the capabilites of this pcie slot</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>VENDOR_ID</id>
+    <description>PCIe vendor ID definition</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
+  <attribute>
+    <id>MAX_POWER</id>
+    <description>Defines the maximum power consumption for a PCIe slot</description>
+    <simpleType>
+      <uint8_t />
+    </simpleType>
+    <persistency>non-volatile</persistency>
+    <readable />
+  </attribute>
   <enumerationType>
     <id>IPMI_SENSOR_ARRAY</id>
-    <description>Enumeration defining the offsets into the
-    IPMI_SENSORS array.</description>
+    <description>Enumeration defining the offsets into the IPMI_SENSORS array.</description>
     <enumerator>
       <name>NAME_OFFSET</name>
       <value>0x00</value>
@@ -9569,12 +8263,7 @@
   </enumerationType>
   <enumerationType>
     <id>SENSOR_NAME</id>
-    <description>Enumeration indicating the IPMI sensor name, which
-    will be used by hostboot when determining the sensor number to
-    return. he sensor name consists of one byte of sensor type plus
-    one byte of sub-type, to differentiate similar sensors under
-    the same target. Our implementaion uses the IPMI defined entity
-    ID as the sub-type.</description>
+    <description>Enumeration indicating the IPMI sensor name, which will be used by hostboot when determining the sensor number to return. he sensor name consists of one byte of sensor type plus one byte of sub-type, to differentiate similar sensors under the same target. Our implementaion uses the IPMI defined entity ID as the sub-type.</description>
     <enumerator>
       <name>PROC_TEMP</name>
       <value>0x0103</value>
@@ -9686,10 +8375,7 @@
   </enumerationType>
   <enumerationType>
     <id>ENTITY_ID</id>
-    <description>Enumeration indicating the IPMI entity ID, these
-    values are defined in the IPMI specification. These values will
-    be used in place of target type when events are sent to the
-    BMC.</description>
+    <description>Enumeration indicating the IPMI entity ID, these values are defined in the IPMI specification. These values will be used in place of target type when events are sent to the BMC.</description>
     <enumerator>
       <name>NA</name>
       <value>0</value>
@@ -9757,10 +8443,7 @@
   </enumerationType>
   <enumerationType>
     <id>SENSOR_TYPE</id>
-    <description>Enumeration indicating the IPMI sensor type, these
-    values are defined in the IPMI specification. These values will
-    be used when sending sensor reading events to the
-    BMC.</description>
+    <description>Enumeration indicating the IPMI sensor type, these values are defined in the IPMI specification. These values will be used when sending sensor reading events to the BMC.</description>
     <enumerator>
       <name>NA</name>
       <value>0</value>
@@ -9820,8 +8503,7 @@
   </enumerationType>
   <attribute>
     <id>ADC_CHANNEL_FUNC_IDS</id>
-    <description>ADC Channel function id. 16
-    channels.</description>
+    <description>ADC Channel function id. 16 channels.</description>
     <simpleType>
       <uint8_t />
       <array>16</array>
@@ -9832,8 +8514,7 @@
   </attribute>
   <attribute>
     <id>ADC_CHANNEL_SENSOR_NUMBERS</id>
-    <description>ADC Channel IPMI sensor numbers. 16
-    channels.</description>
+    <description>ADC Channel IPMI sensor numbers. 16 channels.</description>
     <simpleType>
       <uint32_t />
       <array>16</array>
@@ -9855,8 +8536,7 @@
   </attribute>
   <attribute>
     <id>ADC_CHANNEL_GAINS</id>
-    <description>ADC channel gain * 1000. 16
-    channels.</description>
+    <description>ADC channel gain * 1000. 16 channels.</description>
     <simpleType>
       <uint32_t />
       <array>16</array>
@@ -9867,8 +8547,7 @@
   </attribute>
   <attribute>
     <id>ADC_CHANNEL_OFFSETS</id>
-    <description>ADC channel offset * 1000. 16
-    channels</description>
+    <description>ADC channel offset * 1000. 16 channels</description>
     <simpleType>
       <uint32_t />
       <array>16</array>
@@ -9890,8 +8569,7 @@
   </attribute>
   <attribute>
     <id>APSS_GPIO_PORT_PINS</id>
-    <description>APSS GPIO PORT PINS Port0 pin 0-7 Port1 pin
-    8-15</description>
+    <description>APSS GPIO PORT PINS Port0 pin 0-7 Port1 pin 8-15</description>
     <simpleType>
       <uint8_t />
       <array>16</array>
@@ -9902,43 +8580,36 @@
   </attribute>
   <attribute>
     <id>GPIO_INFO</id>
-    <description>Information needed to address GPIO
-    device</description>
+    <description>Information needed to address GPIO device</description>
     <complexType>
-      <description>Structure to define the addessing for an I2C
-      slave device.</description>
+      <description>Structure to define the addessing for an I2C slave device.</description>
       <field>
         <name>i2cMasterPath</name>
-        <description>Entity path to the chip that contains the I2C
-        master</description>
+        <description>Entity path to the chip that contains the I2C master</description>
         <type>EntityPath</type>
         <default>physical:sys-0</default>
       </field>
       <field>
         <name>port</name>
-        <description>Port from the I2C Master device. This is a
-        6-bit value.</description>
+        <description>Port from the I2C Master device. This is a 6-bit value.</description>
         <type>uint8_t</type>
         <default>0</default>
       </field>
       <field>
         <name>devAddr</name>
-        <description>Device address on the I2C bus. This is a 7-bit
-        value, but then shifted 1 bit left.</description>
+        <description>Device address on the I2C bus. This is a 7-bit value, but then shifted 1 bit left.</description>
         <type>uint8_t</type>
         <default>0</default>
       </field>
       <field>
         <name>engine</name>
-        <description>I2C master engine. This is a 2-bit
-        value.</description>
+        <description>I2C master engine. This is a 2-bit value.</description>
         <type>uint8_t</type>
         <default>0</default>
       </field>
       <field>
         <name>vddrPin</name>
-        <description>Logical GPIO pin number used to
-        enabled/disable VDDR</description>
+        <description>Logical GPIO pin number used to enabled/disable VDDR</description>
         <type>uint8_t</type>
         <default>0</default>
       </field>
@@ -9949,9 +8620,7 @@
   </attribute>
   <attribute>
     <id>HDAT_I2C_ENGINE</id>
-    <description>This attribute holds the values of the I2C Engine
-    from the i2c device connections as defined in the MRW. It is
-    parsed into a struct in i2c.C</description>
+    <description>This attribute holds the values of the I2C Engine from the i2c device connections as defined in the MRW. It is parsed into a struct in i2c.C</description>
     <simpleType>
       <uint8_t />
       <array>32</array>
@@ -9963,9 +8632,7 @@
   </attribute>
   <attribute>
     <id>HDAT_I2C_MASTER_PORT</id>
-    <description>This attribute holds the values of the I2C Master
-    Port from the i2c device connections as defined in the MRW. It
-    is parsed into a struct in i2c.C</description>
+    <description>This attribute holds the values of the I2C Master Port from the i2c device connections as defined in the MRW. It is parsed into a struct in i2c.C</description>
     <simpleType>
       <uint8_t />
       <array>32</array>
@@ -9977,9 +8644,7 @@
   </attribute>
   <attribute>
     <id>HDAT_I2C_DEVICE_TYPE</id>
-    <description>This attribute holds the values of the I2C device
-    type from the i2c device connections as defined in the MRW. It
-    is parsed into a struct in i2c.C</description>
+    <description>This attribute holds the values of the I2C device type from the i2c device connections as defined in the MRW. It is parsed into a struct in i2c.C</description>
     <simpleType>
       <uint8_t />
       <array>32</array>
@@ -9991,9 +8656,7 @@
   </attribute>
   <attribute>
     <id>HDAT_I2C_ADDR</id>
-    <description>This attribute holds the values of the I2C address
-    from the i2c device connections as defined in the MRW. It is
-    parsed into a struct in i2c.C</description>
+    <description>This attribute holds the values of the I2C address from the i2c device connections as defined in the MRW. It is parsed into a struct in i2c.C</description>
     <simpleType>
       <uint8_t />
       <array>32</array>
@@ -10005,9 +8668,7 @@
   </attribute>
   <attribute>
     <id>HDAT_I2C_SLAVE_PORT</id>
-    <description>This attribute holds the values of the I2C slave
-    port from the i2c device connections as defined in the MRW. It
-    is parsed into a struct in i2c.C</description>
+    <description>This attribute holds the values of the I2C slave port from the i2c device connections as defined in the MRW. It is parsed into a struct in i2c.C</description>
     <simpleType>
       <uint8_t />
       <array>32</array>
@@ -10019,9 +8680,7 @@
   </attribute>
   <attribute>
     <id>HDAT_I2C_BUS_FREQ</id>
-    <description>This attribute holds the values of the I2C bus
-    frequency in Hz from the i2c device connections as defined in
-    the MRW. It is parsed into a struct in i2c.C</description>
+    <description>This attribute holds the values of the I2C bus frequency in Hz from the i2c device connections as defined in the MRW. It is parsed into a struct in i2c.C</description>
     <simpleType>
       <uint8_t />
       <array>32</array>
@@ -10033,9 +8692,7 @@
   </attribute>
   <attribute>
     <id>HDAT_I2C_DEVICE_PURPOSE</id>
-    <description>This attribute holds the values of the I2C device
-    purpose from the i2c device connections as defined in the MRW.
-    It is parsed into a struct in i2c.C</description>
+    <description>This attribute holds the values of the I2C device purpose from the i2c device connections as defined in the MRW. It is parsed into a struct in i2c.C</description>
     <simpleType>
       <uint8_t />
       <array>32</array>
@@ -10047,9 +8704,7 @@
   </attribute>
   <attribute>
     <id>HDAT_I2C_ELEMENTS</id>
-    <description>This attribute holds the number of elements that
-    were found under this particular target, and how many devices
-    are stored in the arrays.</description>
+    <description>This attribute holds the number of elements that were found under this particular target, and how many devices are stored in the arrays.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -10062,9 +8717,7 @@
   </attribute>
   <attribute>
     <id>ISDIMM_MBVPD_INDEX</id>
-    <description>Multiple centaurs can sometimes have their VPD
-    located in one physical SEEPROM. This is the index into the
-    memory buffer VPD for this centaur.</description>
+    <description>Multiple centaurs can sometimes have their VPD located in one physical SEEPROM. This is the index into the memory buffer VPD for this centaur.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -10080,8 +8733,7 @@
   </attribute>
   <attribute>
     <id>IPMI_INSTANCE</id>
-    <description>Holds the IPMI instance number for this
-    entity.</description>
+    <description>Holds the IPMI instance number for this entity.</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
@@ -10091,9 +8743,7 @@
   </attribute>
   <attribute>
     <id>IPMI_SENSORS</id>
-    <description>Attribute to hold 16 pairs of sensor name, sensor
-    number pairs. A sensor name consists of one byte of general
-    sensor type and one byte of sub-type</description>
+    <description>Attribute to hold 16 pairs of sensor name, sensor number pairs. A sensor name consists of one byte of general sensor type and one byte of sub-type</description>
     <simpleType>
       <uint16_t />
       <array>16,2</array>
@@ -10104,8 +8754,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_DIMM_THROTTLE_TEMP_DEG_C</id>
-    <description>DIMM temperature threshold where throttling will
-    occur in degrees C</description>
+    <description>DIMM temperature threshold where throttling will occur in degrees C</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10115,8 +8764,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_DIMM_ERROR_TEMP_DEG_C</id>
-    <description>DIMM temperature where an error will be generated
-    in degrees C</description>
+    <description>DIMM temperature where an error will be generated in degrees C</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10126,8 +8774,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_MEMCTRL_THROTTLE_TEMP_DEG_C</id>
-    <description>Memory controller temperature threshold where
-    throttling will occur in degrees C</description>
+    <description>Memory controller temperature threshold where throttling will occur in degrees C</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10137,8 +8784,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_PROC_WEIGHT</id>
-    <description>Weight factor (in 1/10ths) for each core DTS to
-    calculate a core temperature.</description>
+    <description>Weight factor (in 1/10ths) for each core DTS to calculate a core temperature.</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10148,8 +8794,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_QUAD_WEIGHT</id>
-    <description>Weight factor (in 1/10ths) for each quad (cache)
-    DTS to calculate a core temperature.</description>
+    <description>Weight factor (in 1/10ths) for each quad (cache) DTS to calculate a core temperature.</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10159,8 +8804,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_PROC_DVFS_TEMP_DEG_C</id>
-    <description>Processor temperature where DVFS will occur in
-    degrees C</description>
+    <description>Processor temperature where DVFS will occur in degrees C</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10170,8 +8814,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_MEMCTRL_ERROR_TEMP_DEG_C</id>
-    <description>Memory controller temperature where an error will
-    occur in degrees C</description>
+    <description>Memory controller temperature where an error will occur in degrees C</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10181,8 +8824,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_N_BULK_POWER_LIMIT_WATTS</id>
-    <description>N mode bulk power supply limit in
-    Watts</description>
+    <description>N mode bulk power supply limit in Watts</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10192,8 +8834,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_N_MAX_MEM_POWER_WATTS</id>
-    <description>Maximum power allocated to DIMMs in
-    Watts</description>
+    <description>Maximum power allocated to DIMMs in Watts</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10203,8 +8844,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_MEMCTRL_READ_TIMEOUT_SEC</id>
-    <description>Memory controller read timeout in
-    seconds</description>
+    <description>Memory controller read timeout in seconds</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10224,8 +8864,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_PROC_ERROR_TEMP_DEG_C</id>
-    <description>Processor temperature error threshold in degrees
-    C</description>
+    <description>Processor temperature error threshold in degrees C</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10235,8 +8874,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_MIN_MEM_UTILIZATION_THROTTLING</id>
-    <description>Minimum memory utilization for memory
-    throttling</description>
+    <description>Minimum memory utilization for memory throttling</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10286,8 +8924,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_N_PLUS_ONE_BULK_POWER_LIMIT_WATTS</id>
-    <description>N+1 bulk power limit in Watts for systems running
-    with redundant power supplies (default)</description>
+    <description>N+1 bulk power limit in Watts for systems running with redundant power supplies (default)</description>
     <simpleType>
       <uint64_t />
     </simpleType>
@@ -10297,9 +8934,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_N_PLUS_ONE_HPC_BULK_POWER_LIMIT_WATTS</id>
-    <description>N+1 bulk power limit in Watts for High Performance
-    Computing systems running with a non-redundant power supply
-    policy</description>
+    <description>N+1 bulk power limit in Watts for High Performance Computing systems running with a non-redundant power supply policy</description>
     <simpleType>
       <uint64_t>
         <default>0</default>
@@ -10321,8 +8956,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_TURBO_MODE_SUPPORTED</id>
-    <description>If this system supports Turbo frequency mode. 0x00
-    = no 0x01 = yes</description>
+    <description>If this system supports Turbo frequency mode. 0x00 = no 0x01 = yes</description>
     <simpleType>
       <uint8_t />
     </simpleType>
@@ -10332,9 +8966,7 @@
   </attribute>
   <attribute>
     <id>OPAL_MODEL</id>
-    <description>Specifies the compatible model name for Opal to
-    key off of. This is sourced from the MRW and should be of the
-    format 'vendor,model', e.g. 'tyan,palmetto'.</description>
+    <description>Specifies the compatible model name for Opal to key off of. This is sourced from the MRW and should be of the format 'vendor,model', e.g. 'tyan,palmetto'.</description>
     <simpleType>
       <string>
         <default>ibm,miscopenpower</default>
@@ -10347,8 +8979,7 @@
   </attribute>
   <enumerationType>
     <id>CHIP_VER</id>
-    <description>Enumeration indicating the chip
-    version</description>
+    <description>Enumeration indicating the chip version</description>
     <enumerator>
       <name>DD10</name>
       <value>0x10</value>
@@ -10369,8 +9000,7 @@
   </enumerationType>
   <enumerationType>
     <id>HW_VER</id>
-    <description>Enumeration indicating the chip HW
-    version</description>
+    <description>Enumeration indicating the chip HW version</description>
     <enumerator>
       <name>FSP_HW_VER</name>
       <value>0x2</value>
@@ -10383,8 +9013,7 @@
   </enumerationType>
   <enumerationType>
     <id>SW_VER</id>
-    <description>Enumeration indicating the SW
-    version</description>
+    <description>Enumeration indicating the SW version</description>
     <enumerator>
       <name>FSP_SW_VER</name>
       <value>0x1</value>
@@ -10397,8 +9026,7 @@
   </enumerationType>
   <enumerationType>
     <id>ROLE</id>
-    <description>Enumeration indicating the master's FSI
-    type</description>
+    <description>Enumeration indicating the master's FSI type</description>
     <enumerator>
       <name>PRIMARY</name>
       <value>1</value>
@@ -10411,11 +9039,7 @@
   </enumerationType>
   <attribute>
     <id>PROC_HW_TOPOLOGY</id>
-    <description>Hardware topology for HDAT creator:MRW
-    consumer:HDAT firmware notes: Hardware Topology 2 Bytes Byte 1:
-    bit 0-3: Node Id bit 4-7: Socket id inside the node bit 8-11:
-    Proc id inside socket bit 12-15:Hub Id inside
-    proc</description>
+    <description>Hardware topology for HDAT creator:MRW consumer:HDAT firmware notes: Hardware Topology 2 Bytes Byte 1: bit 0-3: Node Id bit 4-7: Socket id inside the node bit 8-11: Proc id inside socket bit 12-15:Hub Id inside proc</description>
     <simpleType>
       <uint16_t></uint16_t>
     </simpleType>
@@ -10425,8 +9049,7 @@
   </attribute>
   <attribute>
     <id>CHIP_VER</id>
-    <description>Attribute indicating the target's chip
-    version</description>
+    <description>Attribute indicating the target's chip version</description>
     <simpleType>
       <enumeration>
         <id>CHIP_VER</id>
@@ -10439,8 +9062,7 @@
   </attribute>
   <attribute>
     <id>HW_VER</id>
-    <description>Attribute indicating the target's hw
-    version</description>
+    <description>Attribute indicating the target's hw version</description>
     <simpleType>
       <enumeration>
         <id>HW_VER</id>
@@ -10453,8 +9075,7 @@
   </attribute>
   <attribute>
     <id>SW_VER</id>
-    <description>Attribute indicating the target's software
-    version</description>
+    <description>Attribute indicating the target's software version</description>
     <simpleType>
       <enumeration>
         <id>SW_VER</id>
@@ -10467,8 +9088,7 @@
   </attribute>
   <attribute>
     <id>ROLE</id>
-    <description>Attribute indicating the target's
-    role</description>
+    <description>Attribute indicating the target's role</description>
     <simpleType>
       <enumeration>
         <id>ROLE</id>
@@ -10481,9 +9101,7 @@
   </attribute>
   <attribute>
     <id>PHYP_SYSTEM_TYPE</id>
-    <description>PHYP system type value for habanero and barreleye
-    (0x3015 and 0x3016 respectively). The value is updated in the
-    system xml.</description>
+    <description>PHYP system type value for habanero and barreleye (0x3015 and 0x3016 respectively). The value is updated in the system xml.</description>
     <simpleType>
       <uint32_t></uint32_t>
     </simpleType>
@@ -10505,14 +9123,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_PM_MODE</id>
-    <description>Power management mode the system should use. Valid
-    values: 1 = Nominal (default), 5 = Static Power Save
-    (percentage below nominal whose value is defined in
-    OPEN_POWER_PM_MODE_FREQ_PERCENT), 6 = Dynamic Power Save -
-    Favor Energy (DPS-FE), 10 = Dynamic Power Save - Favor
-    Performance (DPS-FP), 11 = Fixed Frequency Override -
-    (percentage above nominal whose value is defined in
-    OPEN_POWER_PM_MODE_FREQ_PERCENT)</description>
+    <description>Power management mode the system should use. Valid values: 1 = Nominal (default), 5 = Static Power Save (percentage below nominal whose value is defined in OPEN_POWER_PM_MODE_FREQ_PERCENT), 6 = Dynamic Power Save - Favor Energy (DPS-FE), 10 = Dynamic Power Save - Favor Performance (DPS-FP), 11 = Fixed Frequency Override - (percentage above nominal whose value is defined in OPEN_POWER_PM_MODE_FREQ_PERCENT)</description>
     <simpleType>
       <uint8_t>
         <default>1</default>
@@ -10525,12 +9136,7 @@
   </attribute>
   <attribute>
     <id>OPEN_POWER_PM_MODE_FREQ_PERCENT</id>
-    <description>Percentage from nominal that the processors should
-    run at when OPEN_POWER_PM_MODE is set to Static Power Save or
-    Fixed Frequency Override (ignored on all other modes). Unit is
-    in tenths of a percent (150 = 15.0%). Static Power Save (5):
-    percentage to decrease frequency, Fixed Frequency Override
-    (11): percentage to increase frequency</description>
+    <description>Percentage from nominal that the processors should run at when OPEN_POWER_PM_MODE is set to Static Power Save or Fixed Frequency Override (ignored on all other modes). Unit is in tenths of a percent (150 = 15.0%). Static Power Save (5): percentage to decrease frequency, Fixed Frequency Override (11): percentage to increase frequency</description>
     <simpleType>
       <uint16_t />
     </simpleType>
@@ -10540,11 +9146,7 @@
   </attribute>
   <attribute>
     <id>IPS_ENABLE</id>
-    <description>Indicates if Idle Power Save is enabled. This is
-    independent of the OPEN_POWER_PM_MODE (DPS and IPS can be
-    enabled at the same time). Valid Values: 0 = Disabled
-    (default), 1 = Enabled. See IPS_ENTER / IPS_EXIT attributes for
-    IPS configuration.</description>
+    <description>Indicates if Idle Power Save is enabled. This is independent of the OPEN_POWER_PM_MODE (DPS and IPS can be enabled at the same time). Valid Values: 0 = Disabled (default), 1 = Enabled. See IPS_ENTER / IPS_EXIT attributes for IPS configuration.</description>
     <simpleType>
       <uint8_t>
         <default>0</default>
@@ -10557,9 +9159,7 @@
   </attribute>
   <attribute>
     <id>IPS_ENTER_TIME_SECONDS</id>
-    <description>When IPS is enabled, this defines the delay time
-    in seconds (between 10 and 600) to enter Idle Power
-    Save.</description>
+    <description>When IPS is enabled, this defines the delay time in seconds (between 10 and 600) to enter Idle Power Save.</description>
     <simpleType>
       <uint16_t>
         <default>240</default>
@@ -10571,10 +9171,7 @@
   </attribute>
   <attribute>
     <id>IPS_ENTER_UTILIZATION_PERCENT</id>
-    <description>When IPS is enabled, this defines the utilization
-    threshold as a percent (between 0 and 100) to enter Idle Power
-    Save. This value should be less than
-    IPS_EXIT_UTILIZATION_PERCENT.</description>
+    <description>When IPS is enabled, this defines the utilization threshold as a percent (between 0 and 100) to enter Idle Power Save. This value should be less than IPS_EXIT_UTILIZATION_PERCENT.</description>
     <simpleType>
       <uint8_t>
         <default>8</default>
@@ -10586,9 +9183,7 @@
   </attribute>
   <attribute>
     <id>IPS_EXIT_TIME_SECONDS</id>
-    <description>When IPS is enabled, this defines the delay time
-    in seconds (between 10 and 600) to exit Idle Power
-    Save.</description>
+    <description>When IPS is enabled, this defines the delay time in seconds (between 10 and 600) to exit Idle Power Save.</description>
     <simpleType>
       <uint16_t>
         <default>10</default>
@@ -10600,10 +9195,7 @@
   </attribute>
   <attribute>
     <id>IPS_EXIT_UTILIZATION_PERCENT</id>
-    <description>When IPS is enabled, this defines the utilization
-    threshold as a percent (between 0 and 100) to exit Idle Power
-    Save. This value should be greater than
-    IPS_ENTER_UTILIZATION_PERCENT.</description>
+    <description>When IPS is enabled, this defines the utilization threshold as a percent (between 0 and 100) to exit Idle Power Save. This value should be greater than IPS_ENTER_UTILIZATION_PERCENT.</description>
     <simpleType>
       <uint8_t>
         <default>12</default>

--- a/target_types_hb.xml
+++ b/target_types_hb.xml
@@ -1614,6 +1614,9 @@
       <default>8</default>
     </attribute>
     <!-- End processor characteristics for HDAT -->
+    <attribute>
+      <id>LPC_BASE_ADDR</id>
+    </attribute>
     <!-- p9_setup_bars - Begin -->
     <attribute>
       <id>PROC_NPU_PHY0_BAR_ENABLE</id>
@@ -2144,6 +2147,50 @@
     <attribute>
       <id>PROC_PCIE_LANE_EQUALIZATION_GEN4</id>
     </attribute>
+    <attribute>
+      <id>PCIE_CAPABILITES</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>MGC_LOAD_SOURCE</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>SLOT_NAME</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>SLOT_INDEX</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>HDDW_ORDER</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>PCIE_32BIT_MMIO_SIZE</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>PCIE_64BIT_MMIO_SIZE</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>PCIE_32BIT_DMA_SIZE</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>PCIE_64BIT_DMA_SIZE</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>MAX_POWER</id>
+      <default />
+    </attribute>
+    <attribute>
+      <id>VENDOR_ID</id>
+      <default />
+    </attribute>
   </targetType>
   <!-- unit-phb-power9 -->
   <targetType>
@@ -2292,7 +2339,7 @@
     </attribute>
     <attribute>
       <id>OPTICS_CONFIG_MODE</id>
-      <default>SMP</default>
+      <default>NVLINK</default>
     </attribute>
     <attribute>
       <id>PARENT_PERVASIVE</id>


### PR DESCRIPTION
6a85bab - Marty Gloff, 2 weeks ago : Data Type of ATTR_DPO_MIN_FREQ_PERCENT should be int32_t
0116e1f - crgeddes, 3 days ago : Default OPTICS_CONFIG_MODE to NVLINK (0x2) rather than SMP (0x0)
8379340 - Matt Ploetz, 3 weeks ago : Add support for HDAT PCIe slot map
3f21550 - Greg Still, 6 weeks ago : PM: refine enablement attributes for advanced functions (VDM,RESCLK,WOF,IVRM)
cfc04f8 - Prachi Gupta, 2 weeks ago : increase I2C_BUS_SPEED_ARRAY to be 4x13 array