### PR TITLE
Add LED_PRIORITY attribute

### DIFF
--- a/attribute_types_obmc.xml
+++ b/attribute_types_obmc.xml
@@ -159,4 +159,28 @@
 		<readable/>
 	</attribute>
 
+    <enumerationType>
+        <id>LED_PRIORITY</id>
+        <enumerator>
+            <name>BLINK</name>
+            <value>0</value>
+        </enumerator>
+        <enumerator>
+            <name>ON</name>
+            <value>1</value>
+        </enumerator>
+    </enumerationType>
+
+    <attribute>
+        <id>LED_PRIORITY</id>
+        <description>If the LED is asserted with more than one action at the
+                     same time, this attribute defines which action takes priority.
+        </description>
+        <simpleType>
+            <enumeration>
+                <id>LED_PRIORITY</id>
+            </enumeration>
+        </simpleType>
+    </attribute>
+
 </attributes>

--- a/parts/led-led-generic.xml
+++ b/parts/led-led-generic.xml
@@ -70,6 +70,10 @@
         NA,0,50
         </default>
     </attribute>
+    <attribute>
+        <id>LED_PRIORITY</id>
+        <default>BLINK</default>
+    </attribute>
     <child_id>led_enable</child_id>
     <child_id>generic-logic-assoc</child_id>
     <instance_name>led</instance_name>


### PR DESCRIPTION
OpenBMC will use this attribute for resolving conflicts when
multiple LED groups are attempting to set the same LED to multiple
values at the same time.