### PR TITLE
Rename some system policies

### DIFF
--- a/attribute_types_fsp.xml
+++ b/attribute_types_fsp.xml
@@ -563,7 +563,7 @@
 </attribute>
 
 <attribute>
-    <id>MRW_MEM_MIRRORING_ALLOWED</id>
+    <id>MEM_MIRRORING_ALLOWED</id>
     <description>Is memory mirroring allowed on this platform? 0 - No and 1 - Yes</description>
     <group>SYS_POLICIES</group>
     <simpleType>
@@ -574,7 +574,7 @@
 </attribute>
 
 <attribute>
-    <id>MRW_MEM_MIRRORING_ENABLE_DEFAULT</id>
+    <id>MEM_MIRRORING_ENABLE_DEFAULT</id>
     <description>By default, is memory mirroring enabled on this platform? 0 - No and 1 - Yes</description>
     <group>SYS_POLICIES</group>
     <simpleType>
@@ -585,7 +585,7 @@
 </attribute>
 
 <attribute>
-    <id>MRW_MEM_POWER_CONTROL_USAGE</id>
+    <id>MEM_POWER_CONTROL_USAGE</id>
     <description>Determines if any power controls should be used by memory on this platform. This is a system-wide policy setting that is used when configuring the memory. Note that individual DIMMs will also know if they are capable of doing any of this so the eventual answer is combination of the requested value specified here and the capable value from the VPD</description>
     <group>SYS_POLICIES</group>
     <simpleType>

--- a/parts/sys-sys-power9.xml
+++ b/parts/sys-sys-power9.xml
@@ -5,7 +5,7 @@
     <instance_name>ps_redundancy_state_sensor</instance_name>
     <is_root>false</is_root>
     <parent>unit</parent>
-    <position>-1</position> 	
+    <position>-1</position>
  	<attribute>
  		<id>IPMI_SENSOR_NAME_SUFFIX</id>
  		<default>Ps_Redundancy</default>
@@ -579,7 +579,7 @@
     <attribute>
       <id>MNFG_TH_CEN_MBA_RT_SOFT_CE_TH_ALGO</id>
     </attribute>
-    
+
     <attribute>
       <id>MNFG_TH_P8EX_L2_COL_REPAIRS</id>
     </attribute>
@@ -630,13 +630,13 @@
       <id>MRW_MBA_CACHELINE_INTERLEAVE_MODE_CONTROL</id>
     </attribute>
     <attribute>
-    	<id>MRW_MEM_MIRRORING_ALLOWED</id>
+    	<id>MEM_MIRRORING_ALLOWED</id>
     </attribute>
     <attribute>
-    	<id>MRW_MEM_MIRRORING_ENABLE_DEFAULT</id>
+    	<id>MEM_MIRRORING_ENABLE_DEFAULT</id>
     </attribute>
     <attribute>
-		<id>MRW_MEM_POWER_CONTROL_USAGE</id>
+		<id>MEM_POWER_CONTROL_USAGE</id>
     </attribute>
     <attribute>
       <id>MRW_MEM_THROTTLE_DENOMINATOR</id>


### PR DESCRIPTION
Removed MRW_ prefix from
MRW_MEM_MIRRORING_ALLLOWED
MRW_MEM_MIRRORING_ENABLE_DEFAULT
MRW_MEM_POWER_CONTROL_USAGE