### PR TITLE
2018_04_18 - Updated attributes pcie*slot-count, led-strategy, redundant_mf_clocks, occ*timeout

### DIFF
--- a/attribute_types_fsp.xml
+++ b/attribute_types_fsp.xml
@@ -666,7 +666,7 @@
 </attribute>
 
 <attribute>
-    <id>PCIE_DEFAULT_HDDW_SLOT_COUNT</id>
+    <id>PCIE-DEFAULT-HDDW-SLOT-COUNT</id>
     <description>The default HDDW slot count</description>
     <group>SYS_POLICIES</group>
     <simpleType>
@@ -677,7 +677,7 @@
 </attribute>
 
 <attribute>
-    <id>PCIE_MIN_HDDW_SLOT_COUNT</id>
+    <id>PCIE-MIN-HDDW-SLOT-COUNT</id>
     <description>The minimum HDDW slot count</description>
     <group>SYS_POLICIES</group>
     <simpleType>
@@ -688,7 +688,7 @@
 </attribute>
 
 <attribute>
-    <id>PCIE_MAX_HDDW_SLOT_COUNT</id>
+    <id>PCIE-MAX-HDDW-SLOT-COUNT</id>
     <description>The maximum HDDW slot count</description>
     <group>SYS_POLICIES</group>
     <simpleType>

--- a/parts/sys-sys-power9.xml
+++ b/parts/sys-sys-power9.xml
@@ -529,6 +529,9 @@
     	<id>LED_ON_DEFAULT_GPIO_VALUE</id>
     </attribute>
     <attribute>
+    	<id>LED-STRATEGY</id>
+    </attribute>    
+    <attribute>
       <id>MAX_CHIPLETS_PER_PROC</id>
     </attribute>
     <attribute>
@@ -681,10 +684,10 @@
       <id>NUMERIC_POD_TYPE_TEST</id>
     </attribute>
     <attribute>
-    	<id>OCC_LOAD_TIMEOUT</id>
+    	<id>OCC-LOAD-TIMEOUT</id>
     </attribute>
     <attribute>
-    	<id>OCC_RESET_TIMEOUT</id>
+    	<id>OCC-RESET-TIMEOUT</id>
     </attribute>
     <attribute>
       <id>PAYLOAD_IN_MIRROR_MEM</id>
@@ -696,13 +699,13 @@
       <id>PCI_REFCLOCK_RCVR_TERM</id>
     </attribute>
     <attribute>
-    	<id>PCIE_DEFAULT_HDDW_SLOT_COUNT</id>
+    	<id>PCIE-DEFAULT-HDDW-SLOT-COUNT</id>
     </attribute>
     <attribute>
-    	<id>PCIE_MAX_HDDW_SLOT_COUNT</id>
+    	<id>PCIE-MAX-HDDW-SLOT-COUNT</id>
     </attribute>
     <attribute>
-    	<id>PCIE_MIN_HDDW_SLOT_COUNT</id>
+    	<id>PCIE-MIN-HDDW-SLOT-COUNT</id>
     </attribute>
     <attribute>
       <id>PHYS_PATH</id>
@@ -753,6 +756,9 @@
     <attribute>
       <id>REDUNDANT_CLOCKS</id>
     </attribute>
+    <attribute>
+      <id>REDUNDANT_MF_CLOCKS</id>
+    </attribute>    
     <attribute>
       <id>REDUNDANT_FSPS</id>
     </attribute>


### PR DESCRIPTION
attribute_types_fsp.xml:
  - Changed PCIE_*_SLOT_COUNT to PCIE-*-SLOT-COUNT
sys-sys-power9.xml:
  - Added LED-STRATEGY and REDUNDANT_MF_CLOCKS
  - Changed OCC_*_TIMEOUT to OCC-*-TIMOUT
  - Changed PCIE_*_SLOT_COUNT to PCIE-*-SLOT-COUNT
  (First two were part of RUby's commit 03233018 that was ever merged)