### PR TITLE
Added TARGET-FRU-TYPE attribute

### DIFF
--- a/attribute_types_fsp.xml
+++ b/attribute_types_fsp.xml
@@ -712,6 +712,18 @@
     <readable/>
 </attribute>
 
+<attribute>
+    <id>TARGET-FRU-TYPE</id>
+    <description>FRU type used for fan control.  String must match name for fan_control_fru section in power_management_[sysName].def </description>
+    <simpleType>
+    <string>
+         <default>planar</default>
+    </string>  
+    </simpleType>  
+    <persistency>non-volatile</persistency>
+    <readable/>
+</attribute>
+
 <!-- Types of Location code -->
 <!--  RELATIVE : Location code attached to parent card location code  -->
 <!--  ABSOLUTE : Location code attached to system location code (Ufcs) -->

--- a/parts/TMP275.xml
+++ b/parts/TMP275.xml
@@ -36,6 +36,10 @@
 		<id>RU_TYPE</id>
 		<default/>
 	</attribute>
+        <attribute>
+                <id>TARGET-FRU-TYPE</id>
+                <default/>
+        </attribute>
 	<attribute>
 		<id>TYPE</id>
 		<default>TMP</default>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -1874,6 +1874,10 @@
         	<id>COOLING_ZONE_MASK</id>
         	<default/>
         </attribute>
+        <attribute>
+        	<id>TARGET-FRU-TYPE</id>
+        	<default/>
+        </attribute>
     </targetType>
     <targetType>
         <id>cooling-zone</id>


### PR DESCRIPTION
This attribute, in conjunction with the power_management_[sysName].def
file is used for thermal control in FSP based systems