### PR TITLE
Add FRU_PATH to OBUS

### DIFF
--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -2735,6 +2735,10 @@
 		<attribute>
 			<id>OBUS_CONFIG</id>
 		</attribute>
+		<attribute>
+			<id>FRU_PATH</id>
+			<default></default>
+		</attribute>
 	</targetType>
 	<targetType>
 		<id>OMI</id>


### PR DESCRIPTION
This commit adds FRU_PATH attribute OBUS.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>