### PR TITLE
Updating some parts file for Rainier MRW to the library of parts used

### DIFF
--- a/parts/EPSON-TCXO.xml
+++ b/parts/EPSON-TCXO.xml
@@ -1,0 +1,105 @@
+<partInstance>
+<version>2.10</version>
+<targetInstances>
+<targetPart>
+	<id>EPSON-TCXO</id>
+	<type>chip-EPSON-TCXO</type>
+	<is_root>true</is_root>
+	<instance_name>EPSON-TCXO</instance_name>
+	<position>-1</position>
+	<parent>chip</parent>
+	<parent_type>card-motherboard</parent_type>
+	<parent_type>card-daughtercard</parent_type>
+	<child_id>EPSON-TCXO.OUT</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CHIP</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FRU_ID</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FSI_OPTION_FLAGS</id>
+		<default>
+				<field><id>flipPort</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default></default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>EPSON-TCXO.OUT</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>EPSON-TCXO.OUT</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+</targetInstances>
+</partInstance>

--- a/parts/IDT5PB1216.xml
+++ b/parts/IDT5PB1216.xml
@@ -2,19 +2,21 @@
 <version>2.10</version>
 <targetInstances>
 <targetPart>
-	<id>I210</id>
-	<type>chip-I210</type>
+	<id>IDT5PB1216</id>
+	<type>chip-IDT5PB1216</type>
 	<is_root>true</is_root>
-	<instance_name>I210</instance_name>
+	<instance_name>IDT5PB1216</instance_name>
 	<position>-1</position>
 	<parent>chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
-	<child_id>I210.ncsi</child_id>
-	<child_id>I210.sdp</child_id>
-	<child_id>I210.ethernet</child_id>
-	<child_id>I210.pcie</child_id>
-	<child_id>I210.clk</child_id>
+	<child_id>IDT5PB1216.CLKOUT1</child_id>
+	<child_id>IDT5PB1216.CLKOUT2</child_id>
+	<child_id>IDT5PB1216.CLKOUT3</child_id>
+	<child_id>IDT5PB1216.CLKOUT4</child_id>
+	<child_id>IDT5PB1216.CLKOUT5</child_id>
+	<child_id>IDT5PB1216.CLKOUT6</child_id>
+	<child_id>IDT5PB1216.CLKIN</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -68,143 +70,15 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.ncsi</id>
-	<type>unit-gpio-generic</type>
+	<id>IDT5PB1216.CLKOUT1</id>
+	<type>unit-clk-master</type>
 	<is_root>false</is_root>
-	<instance_name>I210.ncsi</instance_name>
+	<instance_name>IDT5PB1216.CLKOUT1</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>GPIO</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>INOUT</default>
-	</attribute>
-	<attribute>
-		<id>DRIVER_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ENGINE</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>GPIO_TYPE</id>
-		<default>GENERIC_OUTPUT</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NAME</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NUM</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POR_VALUE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SCHEMATIC_INTERFACE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>I210.sdp</id>
-	<type>unit-gpio-generic</type>
-	<is_root>false</is_root>
-	<instance_name>I210.sdp</instance_name>
-	<position>-1</position>
-	<parent>mrw-unit</parent>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>GPIO</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>INOUT</default>
-	</attribute>
-	<attribute>
-		<id>DRIVER_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ENGINE</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>GPIO_TYPE</id>
-		<default>GENERIC_OUTPUT</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NAME</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NUM</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POR_VALUE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SCHEMATIC_INTERFACE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>I210.ethernet</id>
-	<type>unit-ethernet-master</type>
-	<is_root>false</is_root>
-	<instance_name>I210.ethernet</instance_name>
-	<position>-1</position>
-	<parent>mrw-unit</parent>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>ETHERNET</default>
+		<default>CLK</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -223,10 +97,6 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>NCSI_MODE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PIN_NAME</id>
 		<default>
 				<field><id>Value</id><value></value></field>
@@ -236,21 +106,17 @@
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
-	<attribute>
-		<id>USE_HW_CHECKSUM</id>
-		<default>0</default>
-	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.pcie</id>
-	<type>unit-pcie-endpoint</type>
+	<id>IDT5PB1216.CLKOUT2</id>
+	<type>unit-clk-master</type>
 	<is_root>false</is_root>
-	<instance_name>I210.pcie</instance_name>
+	<instance_name>IDT5PB1216.CLKOUT2</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>PCIE</default>
+		<default>CLK</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -262,26 +128,180 @@
 	</attribute>
 	<attribute>
 		<id>DIRECTION</id>
-		<default>IN</default>
+		<default>OUT</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>SLOT_INDEX</id>
-		<default>-1</default>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
-		<default></default>
+		<default>NA</default>
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.clk</id>
+	<id>IDT5PB1216.CLKOUT3</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT5PB1216.CLKOUT3</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT5PB1216.CLKOUT4</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT5PB1216.CLKOUT4</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT5PB1216.CLKOUT5</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT5PB1216.CLKOUT5</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT5PB1216.CLKOUT6</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT5PB1216.CLKOUT6</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT5PB1216.CLKIN</id>
 	<type>unit-clk-slave</type>
 	<is_root>false</is_root>
-	<instance_name>I210.clk</instance_name>
+	<instance_name>IDT5PB1216.CLKIN</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>

--- a/parts/IDT9ZXL0652E.xml
+++ b/parts/IDT9ZXL0652E.xml
@@ -2,19 +2,20 @@
 <version>2.10</version>
 <targetInstances>
 <targetPart>
-	<id>I210</id>
-	<type>chip-I210</type>
+	<id>IDT9ZXL0652E</id>
+	<type>chip-IDT9ZXL0652E</type>
 	<is_root>true</is_root>
-	<instance_name>I210</instance_name>
+	<instance_name>IDT9ZXL0652E</instance_name>
 	<position>-1</position>
 	<parent>chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
-	<child_id>I210.ncsi</child_id>
-	<child_id>I210.sdp</child_id>
-	<child_id>I210.ethernet</child_id>
-	<child_id>I210.pcie</child_id>
-	<child_id>I210.clk</child_id>
+	<child_id>IDT9ZXL0652E.DIF0</child_id>
+	<child_id>IDT9ZXL0652E.DIF1</child_id>
+	<child_id>IDT9ZXL0652E.DIF2</child_id>
+	<child_id>IDT9ZXL0652E.DIF3</child_id>
+	<child_id>IDT9ZXL0652E.DIF4</child_id>
+	<child_id>IDT9ZXL0652E.DIFIN</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -68,143 +69,15 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.ncsi</id>
-	<type>unit-gpio-generic</type>
+	<id>IDT9ZXL0652E.DIF0</id>
+	<type>unit-clk-master</type>
 	<is_root>false</is_root>
-	<instance_name>I210.ncsi</instance_name>
+	<instance_name>IDT9ZXL0652E.DIF0</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>GPIO</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>INOUT</default>
-	</attribute>
-	<attribute>
-		<id>DRIVER_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ENGINE</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>GPIO_TYPE</id>
-		<default>GENERIC_OUTPUT</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NAME</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NUM</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POR_VALUE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SCHEMATIC_INTERFACE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>I210.sdp</id>
-	<type>unit-gpio-generic</type>
-	<is_root>false</is_root>
-	<instance_name>I210.sdp</instance_name>
-	<position>-1</position>
-	<parent>mrw-unit</parent>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>GPIO</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>INOUT</default>
-	</attribute>
-	<attribute>
-		<id>DRIVER_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ENGINE</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>GPIO_TYPE</id>
-		<default>GENERIC_OUTPUT</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NAME</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NUM</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POR_VALUE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SCHEMATIC_INTERFACE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>I210.ethernet</id>
-	<type>unit-ethernet-master</type>
-	<is_root>false</is_root>
-	<instance_name>I210.ethernet</instance_name>
-	<position>-1</position>
-	<parent>mrw-unit</parent>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>ETHERNET</default>
+		<default>CLK</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -223,10 +96,6 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>NCSI_MODE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PIN_NAME</id>
 		<default>
 				<field><id>Value</id><value></value></field>
@@ -236,21 +105,17 @@
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
-	<attribute>
-		<id>USE_HW_CHECKSUM</id>
-		<default>0</default>
-	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.pcie</id>
-	<type>unit-pcie-endpoint</type>
+	<id>IDT9ZXL0652E.DIF1</id>
+	<type>unit-clk-master</type>
 	<is_root>false</is_root>
-	<instance_name>I210.pcie</instance_name>
+	<instance_name>IDT9ZXL0652E.DIF1</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>PCIE</default>
+		<default>CLK</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -262,26 +127,142 @@
 	</attribute>
 	<attribute>
 		<id>DIRECTION</id>
-		<default>IN</default>
+		<default>OUT</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>SLOT_INDEX</id>
-		<default>-1</default>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
-		<default></default>
+		<default>NA</default>
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.clk</id>
+	<id>IDT9ZXL0652E.DIF2</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT9ZXL0652E.DIF2</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT9ZXL0652E.DIF3</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT9ZXL0652E.DIF3</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT9ZXL0652E.DIF4</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT9ZXL0652E.DIF4</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT9ZXL0652E.DIFIN</id>
 	<type>unit-clk-slave</type>
 	<is_root>false</is_root>
-	<instance_name>I210.clk</instance_name>
+	<instance_name>IDT9ZXL0652E.DIFIN</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>

--- a/parts/IDT9ZXL0851E.xml
+++ b/parts/IDT9ZXL0851E.xml
@@ -2,19 +2,23 @@
 <version>2.10</version>
 <targetInstances>
 <targetPart>
-	<id>I210</id>
-	<type>chip-I210</type>
+	<id>IDT9ZXL0851E</id>
+	<type>chip-IDT9ZXL0851E</type>
 	<is_root>true</is_root>
-	<instance_name>I210</instance_name>
+	<instance_name>IDT9ZXL0851E</instance_name>
 	<position>-1</position>
 	<parent>chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
-	<child_id>I210.ncsi</child_id>
-	<child_id>I210.sdp</child_id>
-	<child_id>I210.ethernet</child_id>
-	<child_id>I210.pcie</child_id>
-	<child_id>I210.clk</child_id>
+	<child_id>IDT9ZXL0851E.DIF0</child_id>
+	<child_id>IDT9ZXL0851E.DIF1</child_id>
+	<child_id>IDT9ZXL0851E.DIF2</child_id>
+	<child_id>IDT9ZXL0851E.DIF3</child_id>
+	<child_id>IDT9ZXL0851E.DIF4</child_id>
+	<child_id>IDT9ZXL0851E.DIF5</child_id>
+	<child_id>IDT9ZXL0851E.DIF6</child_id>
+	<child_id>IDT9ZXL0851E.DIF7</child_id>
+	<child_id>IDT9ZXL0851E.DIFIN</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -68,143 +72,15 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.ncsi</id>
-	<type>unit-gpio-generic</type>
+	<id>IDT9ZXL0851E.DIF0</id>
+	<type>unit-clk-master</type>
 	<is_root>false</is_root>
-	<instance_name>I210.ncsi</instance_name>
+	<instance_name>IDT9ZXL0851E.DIF0</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>GPIO</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>INOUT</default>
-	</attribute>
-	<attribute>
-		<id>DRIVER_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ENGINE</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>GPIO_TYPE</id>
-		<default>GENERIC_OUTPUT</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NAME</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NUM</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POR_VALUE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SCHEMATIC_INTERFACE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>I210.sdp</id>
-	<type>unit-gpio-generic</type>
-	<is_root>false</is_root>
-	<instance_name>I210.sdp</instance_name>
-	<position>-1</position>
-	<parent>mrw-unit</parent>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>GPIO</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>INOUT</default>
-	</attribute>
-	<attribute>
-		<id>DRIVER_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ENGINE</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>GPIO_TYPE</id>
-		<default>GENERIC_OUTPUT</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NAME</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NUM</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POR_VALUE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SCHEMATIC_INTERFACE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>I210.ethernet</id>
-	<type>unit-ethernet-master</type>
-	<is_root>false</is_root>
-	<instance_name>I210.ethernet</instance_name>
-	<position>-1</position>
-	<parent>mrw-unit</parent>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>ETHERNET</default>
+		<default>CLK</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -223,10 +99,6 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>NCSI_MODE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PIN_NAME</id>
 		<default>
 				<field><id>Value</id><value></value></field>
@@ -236,21 +108,17 @@
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
-	<attribute>
-		<id>USE_HW_CHECKSUM</id>
-		<default>0</default>
-	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.pcie</id>
-	<type>unit-pcie-endpoint</type>
+	<id>IDT9ZXL0851E.DIF1</id>
+	<type>unit-clk-master</type>
 	<is_root>false</is_root>
-	<instance_name>I210.pcie</instance_name>
+	<instance_name>IDT9ZXL0851E.DIF1</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>PCIE</default>
+		<default>CLK</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -262,26 +130,256 @@
 	</attribute>
 	<attribute>
 		<id>DIRECTION</id>
-		<default>IN</default>
+		<default>OUT</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>SLOT_INDEX</id>
-		<default>-1</default>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
-		<default></default>
+		<default>NA</default>
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.clk</id>
+	<id>IDT9ZXL0851E.DIF2</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT9ZXL0851E.DIF2</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT9ZXL0851E.DIF3</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT9ZXL0851E.DIF3</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT9ZXL0851E.DIF4</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT9ZXL0851E.DIF4</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT9ZXL0851E.DIF5</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT9ZXL0851E.DIF5</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT9ZXL0851E.DIF6</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT9ZXL0851E.DIF6</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT9ZXL0851E.DIF7</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>IDT9ZXL0851E.DIF7</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>IDT9ZXL0851E.DIFIN</id>
 	<type>unit-clk-slave</type>
 	<is_root>false</is_root>
-	<instance_name>I210.clk</instance_name>
+	<instance_name>IDT9ZXL0851E.DIFIN</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>

--- a/parts/RAINIER-2U-CCINS.xml
+++ b/parts/RAINIER-2U-CCINS.xml
@@ -23,15 +23,18 @@
 	<child_id>Rainier-2U-CCINS.32GB-DDIMM-2U</child_id>
 	<child_id>Rainier-2U-CCINS.64GB-DDIMM-2U</child_id>
 	<child_id>Rainier-2U-CCINS.128GB-DDIMM-2U</child_id>
-	<child_id>Rainier-2U-CCINS.Puyallup</child_id>
-	<child_id>Rainier-2U-CCINS.BearPaw</child_id>
-	<child_id>Rainier-2U-CCINS.PowerSupply-1400W</child_id>
 	<child_id>Rainier-2U-CCINS.PowerSupply-2000W</child_id>
-	<child_id>Rainier-2U-CCINS.DCM-DD10-30BC-250W</child_id>
-	<child_id>Rainier-2U-CCINS.DCM-DD10-24BC-250W</child_id>
-	<child_id>Rainier-2U-CCINS.DCM-DD10-16BC-250W</child_id>
-	<child_id>Rainier-2U-CCINS.ioSCM-DD10-8BC-150W</child_id>
-	<child_id>Rainier-2U-CCINS.ioSCM-DD10-4BC-150W</child_id>
+	<child_id>Rainier-2U-CCINS.DCM-DD20-20BC-275W</child_id>
+	<child_id>Rainier-2U-CCINS.DCM-DD20-16BC-250W</child_id>
+	<child_id>Rainier-2U-CCINS.ioSCM-DD20-10BC-200W</child_id>
+	<child_id>Rainier-2U-CCINS.ioSCM-DD20-4BC-150W</child_id>
+	<child_id>Rainier-2U-CCINS.DCM-DD20-20BC-325W</child_id>
+	<child_id>Rainier-2U-CCINS.DCM-DD20-16BC-325W</child_id>
+	<child_id>Rainier-2U-CCINS.DCM-DD20-12BC-305W</child_id>
+	<child_id>Rainier-2U-CCINS.ioSCM-DD20-8BC-240W</child_id>
+	<child_id>Rainier-2U-CCINS.ioSCM-DD20-4BC-180W</child_id>
+	<child_id>Rainier-2U-CCINS.BearRiver</child_id>
+	<child_id>Rainier-2U-CCINS.Fan</child_id>
 	<attribute>
 		<id>CLASS</id>
 		<default></default>
@@ -87,7 +90,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-22A,9105-22B</default>
+		<default>9105-22A,9105-22B,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -136,7 +139,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -185,7 +188,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -234,7 +237,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -283,7 +286,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -332,7 +335,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -381,7 +384,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -430,7 +433,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -479,7 +482,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -504,7 +507,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>329B</default>
+		<default>327A</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -528,7 +531,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -553,7 +556,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>329C</default>
+		<default>327B</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -577,7 +580,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -602,7 +605,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>329D</default>
+		<default>327C</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -626,158 +629,11 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
 		<default>128GB 2U DDIMM</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>Rainier-2U-CCINS.Puyallup</id>
-	<type>override-ccin-card</type>
-	<is_root>false</is_root>
-	<instance_name>Rainier-2U-CCINS.Puyallup</instance_name>
-	<position>-1</position>
-	<parent>targetoverride</parent>
-	<parent_type>targetoverride</parent_type>
-	<attribute>
-		<id>CARD_USE</id>
-		<default>FIELD</default>
-	</attribute>
-	<attribute>
-		<id>CCIN</id>
-		<default>6B8A</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>GROUP_KEY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>TARGET_OVERRIDE</default>
-	</attribute>
-	<attribute>
-		<id>PART_NUMBER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>RU_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SUPPORTED_MTMS</id>
-		<default>9105-22A,9105-22B</default>
-	</attribute>
-	<attribute>
-		<id>TARGET_NAME</id>
-		<default>IO Riser 2U Card</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>Rainier-2U-CCINS.BearPaw</id>
-	<type>override-ccin-card</type>
-	<is_root>false</is_root>
-	<instance_name>Rainier-2U-CCINS.BearPaw</instance_name>
-	<position>-1</position>
-	<parent>targetoverride</parent>
-	<parent_type>targetoverride</parent_type>
-	<attribute>
-		<id>CARD_USE</id>
-		<default>FIELD</default>
-	</attribute>
-	<attribute>
-		<id>CCIN</id>
-		<default>58FF</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>GROUP_KEY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>TARGET_OVERRIDE</default>
-	</attribute>
-	<attribute>
-		<id>PART_NUMBER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>RU_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SUPPORTED_MTMS</id>
-		<default>9105-22A,9105-22B</default>
-	</attribute>
-	<attribute>
-		<id>TARGET_NAME</id>
-		<default>MEX 2U Cable Card for Fanout Module</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>Rainier-2U-CCINS.PowerSupply-1400W</id>
-	<type>override-ccin-card</type>
-	<is_root>false</is_root>
-	<instance_name>Rainier-2U-CCINS.PowerSupply-1400W</instance_name>
-	<position>-1</position>
-	<parent>targetoverride</parent>
-	<parent_type>targetoverride</parent_type>
-	<attribute>
-		<id>CARD_USE</id>
-		<default>FIELD</default>
-	</attribute>
-	<attribute>
-		<id>CCIN</id>
-		<default>2B1E</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>GROUP_KEY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>TARGET_OVERRIDE</default>
-	</attribute>
-	<attribute>
-		<id>PART_NUMBER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>RU_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-42B</default>
-	</attribute>
-	<attribute>
-		<id>TARGET_NAME</id>
-		<default>Power Supply 1400W</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -822,7 +678,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-22A,9105-22B</default>
+		<default>9105-22A,9105-22B,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -834,10 +690,10 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>Rainier-2U-CCINS.DCM-DD10-30BC-250W</id>
+	<id>Rainier-2U-CCINS.DCM-DD20-20BC-275W</id>
 	<type>override-ccin-cpu</type>
 	<is_root>false</is_root>
-	<instance_name>Rainier-2U-CCINS.DCM-DD10-30BC-250W</instance_name>
+	<instance_name>Rainier-2U-CCINS.DCM-DD20-20BC-275W</instance_name>
 	<position>-1</position>
 	<parent>targetoverride</parent>
 	<parent_type>targetoverride</parent_type>
@@ -847,7 +703,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>5C55</default>
+		<default>5C72</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -855,11 +711,11 @@
 	</attribute>
 	<attribute>
 		<id>CORES</id>
-		<default>30BC</default>
+		<default>20BC</default>
 	</attribute>
 	<attribute>
 		<id>EC_LEVEL</id>
-		<default>1.0</default>
+		<default>2.0</default>
 	</attribute>
 	<attribute>
 		<id>FREQUENCY</id>
@@ -883,11 +739,11 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-22A</default>
+		<default>9105-22A,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
-		<default>Godel DCM DD1.0 30BC 250W</default>
+		<default>Godel DCM ITC DD2.02 20BC 275W</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -895,10 +751,10 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>Rainier-2U-CCINS.DCM-DD10-24BC-250W</id>
+	<id>Rainier-2U-CCINS.DCM-DD20-16BC-250W</id>
 	<type>override-ccin-cpu</type>
 	<is_root>false</is_root>
-	<instance_name>Rainier-2U-CCINS.DCM-DD10-24BC-250W</instance_name>
+	<instance_name>Rainier-2U-CCINS.DCM-DD20-16BC-250W</instance_name>
 	<position>-1</position>
 	<parent>targetoverride</parent>
 	<parent_type>targetoverride</parent_type>
@@ -908,68 +764,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>5C54</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CORES</id>
-		<default>24BC</default>
-	</attribute>
-	<attribute>
-		<id>EC_LEVEL</id>
-		<default>1.0</default>
-	</attribute>
-	<attribute>
-		<id>FREQUENCY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>GROUP_KEY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>TARGET_OVERRIDE</default>
-	</attribute>
-	<attribute>
-		<id>PART_NUMBER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>RU_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SUPPORTED_MTMS</id>
-		<default>9105-22A</default>
-	</attribute>
-	<attribute>
-		<id>TARGET_NAME</id>
-		<default>Godel DCM DD1.0 24BC 250W</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>Rainier-2U-CCINS.DCM-DD10-16BC-250W</id>
-	<type>override-ccin-cpu</type>
-	<is_root>false</is_root>
-	<instance_name>Rainier-2U-CCINS.DCM-DD10-16BC-250W</instance_name>
-	<position>-1</position>
-	<parent>targetoverride</parent>
-	<parent_type>targetoverride</parent_type>
-	<attribute>
-		<id>CARD_USE</id>
-		<default>LAB_ONLY</default>
-	</attribute>
-	<attribute>
-		<id>CCIN</id>
-		<default>5C53</default>
+		<default>5C67</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -981,7 +776,7 @@
 	</attribute>
 	<attribute>
 		<id>EC_LEVEL</id>
-		<default>1.0</default>
+		<default>2.0</default>
 	</attribute>
 	<attribute>
 		<id>FREQUENCY</id>
@@ -1005,11 +800,11 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-22A</default>
+		<default>9105-22A,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
-		<default>Godel DCM DD1.0 16BC 250W</default>
+		<default>Godel DCM ITC DD2.02 16BC 250W</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -1017,10 +812,10 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>Rainier-2U-CCINS.ioSCM-DD10-8BC-150W</id>
+	<id>Rainier-2U-CCINS.ioSCM-DD20-10BC-200W</id>
 	<type>override-ccin-cpu</type>
 	<is_root>false</is_root>
-	<instance_name>Rainier-2U-CCINS.ioSCM-DD10-8BC-150W</instance_name>
+	<instance_name>Rainier-2U-CCINS.ioSCM-DD20-10BC-200W</instance_name>
 	<position>-1</position>
 	<parent>targetoverride</parent>
 	<parent_type>targetoverride</parent_type>
@@ -1030,7 +825,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>5C71</default>
+		<default>5C74</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -1038,11 +833,11 @@
 	</attribute>
 	<attribute>
 		<id>CORES</id>
-		<default>8BC</default>
+		<default>10BC</default>
 	</attribute>
 	<attribute>
 		<id>EC_LEVEL</id>
-		<default>1.0</default>
+		<default>2.0</default>
 	</attribute>
 	<attribute>
 		<id>FREQUENCY</id>
@@ -1066,11 +861,11 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42B</default>
+		<default>9105-22B</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
-		<default>Godel ioSCM DD1.0 8BC 150W</default>
+		<default>Godel ioSCM ITC DD2.02 10BC 205W</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -1078,10 +873,10 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>Rainier-2U-CCINS.ioSCM-DD10-4BC-150W</id>
+	<id>Rainier-2U-CCINS.ioSCM-DD20-4BC-150W</id>
 	<type>override-ccin-cpu</type>
 	<is_root>false</is_root>
-	<instance_name>Rainier-2U-CCINS.ioSCM-DD10-4BC-150W</instance_name>
+	<instance_name>Rainier-2U-CCINS.ioSCM-DD20-4BC-150W</instance_name>
 	<position>-1</position>
 	<parent>targetoverride</parent>
 	<parent_type>targetoverride</parent_type>
@@ -1091,7 +886,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>5C70</default>
+		<default>5C64</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -1103,7 +898,7 @@
 	</attribute>
 	<attribute>
 		<id>EC_LEVEL</id>
-		<default>1.0</default>
+		<default>2.0</default>
 	</attribute>
 	<attribute>
 		<id>FREQUENCY</id>
@@ -1127,11 +922,414 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42B</default>
+		<default>9105-22B</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
-		<default>Godel ioSCM DD1.0 4BC 150W</default>
+		<default>Godel ioSCM ITC DD2.02 4BC 150W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-2U-CCINS.DCM-DD20-20BC-325W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-2U-CCINS.DCM-DD20-20BC-325W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C85</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>20BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.02</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-22A,9786-22H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel DCM STC DD2.02 20BC 325W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-2U-CCINS.DCM-DD20-16BC-325W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-2U-CCINS.DCM-DD20-16BC-325W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C86</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>16BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.02</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-22A,9786-22H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel DCM STC DD2.02 16BC 325W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-2U-CCINS.DCM-DD20-12BC-305W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-2U-CCINS.DCM-DD20-12BC-305W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C87</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>12BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.02</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-22A,9786-22H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel DCM STC DD2.02 12BC 305W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-2U-CCINS.ioSCM-DD20-8BC-240W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-2U-CCINS.ioSCM-DD20-8BC-240W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C8A</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>8BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.02</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-22B</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel ioSCM STC DD2.02 8BC 240W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-2U-CCINS.ioSCM-DD20-4BC-180W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-2U-CCINS.ioSCM-DD20-4BC-180W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C88</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>4BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.02</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-22B</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel ioSCM STC DD2.02 4BC 180W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-2U-CCINS.BearRiver</id>
+	<type>override-ccin-card</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-2U-CCINS.BearRiver</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>6B92</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-22A,9105-22B,9786-22H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>2U PCIe Gen4 x8 Cable Card for MEX, Splitter and Nimitz</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-2U-CCINS.Fan</id>
+	<type>override-ccin-card</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-2U-CCINS.Fan</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>7B5G</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-22A,9105-22B,9786-22H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Rainier 2U Delta counter rotating fans</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>

--- a/parts/RAINIER-2U-MTMS.xml
+++ b/parts/RAINIER-2U-MTMS.xml
@@ -10,7 +10,7 @@
 	<parent>targetoverride</parent>
 	<parent_type>sys-sys-power8</parent_type>
 	<parent_type>sys-sys-power9</parent_type>
-        <parent_type>sys-sys-power10</parent_type>
+	<parent_type>sys-sys-power10</parent_type>
 	<child_id>Rainier-2U-MTMS.2s2u-p10-dcm</child_id>
 	<child_id>Rainier-2U-MTMS.2s2u-p10-ioscm</child_id>
 	<attribute>
@@ -52,7 +52,7 @@
 	</attribute>
 	<attribute>
 		<id>IM_VALUE</id>
-		<default></default>
+		<default>0x50001001</default>
 	</attribute>
 	<attribute>
 		<id>MRW_ID</id>
@@ -64,7 +64,7 @@
 	</attribute>
 	<attribute>
 		<id>MTM_NAME</id>
-		<default>9105-22A</default>
+		<default>9105-22A,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -97,7 +97,7 @@
 	</attribute>
 	<attribute>
 		<id>IM_VALUE</id>
-		<default></default>
+		<default>0x50001001</default>
 	</attribute>
 	<attribute>
 		<id>MRW_ID</id>

--- a/parts/RAINIER-4U-CCINS.xml
+++ b/parts/RAINIER-4U-CCINS.xml
@@ -25,14 +25,21 @@
 	<child_id>Rainier-4U-CCINS.128GB-DDIMM-2U</child_id>
 	<child_id>Rainier-4U-CCINS.128GB-EDDIMM-4U</child_id>
 	<child_id>Rainier-4U-CCINS.256GB-EDDIMM-4U</child_id>
-	<child_id>Rainier-4U-CCINS.BearMountain</child_id>
-	<child_id>Rainier-4U-CCINS.PowerSupply-1400W</child_id>
-	<child_id>Rainier-4U-CCINS.PowerSupply-2000W</child_id>
+	<child_id>Rainier-4U-CCINS.BearLake</child_id>
+	<child_id>Rainier-4U-CCINS.PowerSupply-1200W</child_id>
+	<child_id>Rainier-4U-CCINS.PowerSupply-1600W</child_id>
+	<child_id>Rainier-4U-CCINS.DCM-DD20-30BC-400W</child_id>
+	<child_id>Rainier-4U-CCINS.DCM-DD20-24BC-400W</child_id>
+	<child_id>Rainier-4U-CCINS.DCM-DD20-16BC-400W</child_id>
+	<child_id>Rainier-4U-CCINS.ioSCM-DD20-10BC-200W</child_id>
+	<child_id>Rainier-4U-CCINS.ioSCM-DD20-4BC-150W</child_id>
+	<child_id>Rainier-4U-CCINS.DCM-DD20-30BC-420W</child_id>
+	<child_id>Rainier-4U-CCINS.DCM-DD20-16BC-395W</child_id>
+	<child_id>Rainier-4U-CCINS.DCM-DD20-12BC-380W</child_id>
+	<child_id>Rainier-4U-CCINS.ioSCM-DD20-8BC-240W</child_id>
+	<child_id>Rainier-4U-CCINS.ioSCM-DD20-4BC-180W</child_id>
 	<child_id>Rainier-4U-CCINS.DCM-DD10-30BC-400W</child_id>
-	<child_id>Rainier-4U-CCINS.DCM-DD10-24BC-400W</child_id>
-	<child_id>Rainier-4U-CCINS.DCM-DD10-16BC-400W</child_id>
-	<child_id>Rainier-4U-CCINS.ioSCM-DD10-8BC-150W</child_id>
-	<child_id>Rainier-4U-CCINS.ioSCM-DD10-4BC-150W</child_id>
+	<child_id>Rainier-4U-CCINS.Blower</child_id>
 	<attribute>
 		<id>CLASS</id>
 		<default></default>
@@ -88,7 +95,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-42B</default>
+		<default>9105-42A,9786-42H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -137,7 +144,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -186,7 +193,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -235,7 +242,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -284,7 +291,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -333,7 +340,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -382,7 +389,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -431,7 +438,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -480,7 +487,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -505,7 +512,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>329B</default>
+		<default>327A</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -529,7 +536,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -554,7 +561,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>329C</default>
+		<default>327B</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -578,7 +585,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -603,7 +610,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>329D</default>
+		<default>327C</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -627,7 +634,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-22A,9105-42B,9105-22B</default>
+		<default>9105-42A,9105-22A,9105-41B,9105-22B,9786-42H,9786-22H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -676,7 +683,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-42B</default>
+		<default>9105-42A,9786-42H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -725,7 +732,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-42B</default>
+		<default>9105-42A,9786-42H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -737,10 +744,10 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>Rainier-4U-CCINS.BearMountain</id>
+	<id>Rainier-4U-CCINS.BearLake</id>
 	<type>override-ccin-card</type>
 	<is_root>false</is_root>
-	<instance_name>Rainier-4U-CCINS.BearMountain</instance_name>
+	<instance_name>Rainier-4U-CCINS.BearLake</instance_name>
 	<position>-1</position>
 	<parent>targetoverride</parent>
 	<parent_type>targetoverride</parent_type>
@@ -750,7 +757,7 @@
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>2CE2</default>
+		<default>6B99</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -774,11 +781,11 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-42B</default>
+		<default>9105-42A,9105-41B,9786-42H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
-		<default>MEX 4U Cable Card for Fanout Module</default>
+		<default>4U PCIe Gen4 x8 Cable Card for MEX, Splitter and Nimitz</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -786,10 +793,59 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>Rainier-4U-CCINS.PowerSupply-1400W</id>
+	<id>Rainier-4U-CCINS.PowerSupply-1200W</id>
 	<type>override-ccin-card</type>
 	<is_root>false</is_root>
-	<instance_name>Rainier-4U-CCINS.PowerSupply-1400W</instance_name>
+	<instance_name>Rainier-4U-CCINS.PowerSupply-1200W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>2B1D</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-41B</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Power Supply 1200W Delta</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.PowerSupply-1600W</id>
+	<type>override-ccin-card</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.PowerSupply-1600W</instance_name>
 	<position>-1</position>
 	<parent>targetoverride</parent>
 	<parent_type>targetoverride</parent_type>
@@ -823,11 +879,11 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A,9105-42B</default>
+		<default>9105-42A,9105-41B,9786-42H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
-		<default>Power Supply 1400W</default>
+		<default>Power Supply 1600W Delta</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -835,23 +891,35 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>Rainier-4U-CCINS.PowerSupply-2000W</id>
-	<type>override-ccin-card</type>
+	<id>Rainier-4U-CCINS.DCM-DD20-30BC-400W</id>
+	<type>override-ccin-cpu</type>
 	<is_root>false</is_root>
-	<instance_name>Rainier-4U-CCINS.PowerSupply-2000W</instance_name>
+	<instance_name>Rainier-4U-CCINS.DCM-DD20-30BC-400W</instance_name>
 	<position>-1</position>
 	<parent>targetoverride</parent>
 	<parent_type>targetoverride</parent_type>
 	<attribute>
 		<id>CARD_USE</id>
-		<default>FIELD</default>
+		<default>LAB_ONLY</default>
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>51E9</default>
+		<default>5C7C</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>30BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -872,11 +940,560 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-22A,9105-22B</default>
+		<default>9105-42A,9786-42H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
-		<default>Power Supply 2000W</default>
+		<default>Godel DCM ITC DD2.02 30BC 400W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.DCM-DD20-24BC-400W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.DCM-DD20-24BC-400W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>LAB_ONLY</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C6A</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>24BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-42A,9786-42H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel DCM ITC DD2.02 24BC 400W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.DCM-DD20-16BC-400W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.DCM-DD20-16BC-400W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>LAB_ONLY</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C68</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>16BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-42A,9786-42H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel DCM ITC DD2.02 16BC 400W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.ioSCM-DD20-10BC-200W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.ioSCM-DD20-10BC-200W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>LAB_ONLY</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C74</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>10BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-41B</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel ioSCM ITC DD2.02 10BC 200W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.ioSCM-DD20-4BC-150W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.ioSCM-DD20-4BC-150W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>LAB_ONLY</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C64</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>4BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-41B</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel ioSCM ITC DD2.02 4BC 150W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.DCM-DD20-30BC-420W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.DCM-DD20-30BC-420W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C82</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>30BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-42A,9786-42H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel DCM STC DD2.02 30BC 420W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.DCM-DD20-16BC-395W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.DCM-DD20-16BC-395W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C83</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>16BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-42A,9786-42H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel DCM STC DD2.02 16BC 395W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.DCM-DD20-12BC-380W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.DCM-DD20-12BC-380W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C84</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>12BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-42A,9786-42H</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel DCM STC DD2.02 12BC 380W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.ioSCM-DD20-8BC-240W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.ioSCM-DD20-8BC-240W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C8A</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>8BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-41B</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel ioSCM STC DD2.02 8BC 240W</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Rainier-4U-CCINS.ioSCM-DD20-4BC-180W</id>
+	<type>override-ccin-cpu</type>
+	<is_root>false</is_root>
+	<instance_name>Rainier-4U-CCINS.ioSCM-DD20-4BC-180W</instance_name>
+	<position>-1</position>
+	<parent>targetoverride</parent>
+	<parent_type>targetoverride</parent_type>
+	<attribute>
+		<id>CARD_USE</id>
+		<default>FIELD</default>
+	</attribute>
+	<attribute>
+		<id>CCIN</id>
+		<default>5C88</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORES</id>
+		<default>4BC</default>
+	</attribute>
+	<attribute>
+		<id>EC_LEVEL</id>
+		<default>2.0</default>
+	</attribute>
+	<attribute>
+		<id>FREQUENCY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>GROUP_KEY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TARGET_OVERRIDE</default>
+	</attribute>
+	<attribute>
+		<id>PART_NUMBER</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SUPPORTED_MTMS</id>
+		<default>9105-41B</default>
+	</attribute>
+	<attribute>
+		<id>TARGET_NAME</id>
+		<default>Godel ioSCM STC DD2.02 4BC 180W</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -945,35 +1562,23 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>Rainier-4U-CCINS.DCM-DD10-24BC-400W</id>
-	<type>override-ccin-cpu</type>
+	<id>Rainier-4U-CCINS.Blower</id>
+	<type>override-ccin-card</type>
 	<is_root>false</is_root>
-	<instance_name>Rainier-4U-CCINS.DCM-DD10-24BC-400W</instance_name>
+	<instance_name>Rainier-4U-CCINS.Blower</instance_name>
 	<position>-1</position>
 	<parent>targetoverride</parent>
 	<parent_type>targetoverride</parent_type>
 	<attribute>
 		<id>CARD_USE</id>
-		<default>LAB_ONLY</default>
+		<default>FIELD</default>
 	</attribute>
 	<attribute>
 		<id>CCIN</id>
-		<default>5C57</default>
+		<default>7B5F</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CORES</id>
-		<default>24BC</default>
-	</attribute>
-	<attribute>
-		<id>EC_LEVEL</id>
-		<default>1.0</default>
-	</attribute>
-	<attribute>
-		<id>FREQUENCY</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -994,194 +1599,11 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A</default>
+		<default>9105-42A,9786-42H,9105-41B</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
-		<default>Godel DCM DD1.0 24BC 400W</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>Rainier-4U-CCINS.DCM-DD10-16BC-400W</id>
-	<type>override-ccin-cpu</type>
-	<is_root>false</is_root>
-	<instance_name>Rainier-4U-CCINS.DCM-DD10-16BC-400W</instance_name>
-	<position>-1</position>
-	<parent>targetoverride</parent>
-	<parent_type>targetoverride</parent_type>
-	<attribute>
-		<id>CARD_USE</id>
-		<default>LAB_ONLY</default>
-	</attribute>
-	<attribute>
-		<id>CCIN</id>
-		<default>5C56</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CORES</id>
-		<default>16</default>
-	</attribute>
-	<attribute>
-		<id>EC_LEVEL</id>
-		<default>1.0</default>
-	</attribute>
-	<attribute>
-		<id>FREQUENCY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>GROUP_KEY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>TARGET_OVERRIDE</default>
-	</attribute>
-	<attribute>
-		<id>PART_NUMBER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>RU_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SUPPORTED_MTMS</id>
-		<default>9105-42A</default>
-	</attribute>
-	<attribute>
-		<id>TARGET_NAME</id>
-		<default>Godel DCM DD1.0 16BC 400W</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>Rainier-4U-CCINS.ioSCM-DD10-8BC-150W</id>
-	<type>override-ccin-cpu</type>
-	<is_root>false</is_root>
-	<instance_name>Rainier-4U-CCINS.ioSCM-DD10-8BC-150W</instance_name>
-	<position>-1</position>
-	<parent>targetoverride</parent>
-	<parent_type>targetoverride</parent_type>
-	<attribute>
-		<id>CARD_USE</id>
-		<default>LAB_ONLY</default>
-	</attribute>
-	<attribute>
-		<id>CCIN</id>
-		<default>5C71</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CORES</id>
-		<default>8BC</default>
-	</attribute>
-	<attribute>
-		<id>EC_LEVEL</id>
-		<default>1.0</default>
-	</attribute>
-	<attribute>
-		<id>FREQUENCY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>GROUP_KEY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>TARGET_OVERRIDE</default>
-	</attribute>
-	<attribute>
-		<id>PART_NUMBER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>RU_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SUPPORTED_MTMS</id>
-		<default>9105-42B</default>
-	</attribute>
-	<attribute>
-		<id>TARGET_NAME</id>
-		<default>Godel ioSCM DD1.0 8BC 150W</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>Rainier-4U-CCINS.ioSCM-DD10-4BC-150W</id>
-	<type>override-ccin-cpu</type>
-	<is_root>false</is_root>
-	<instance_name>Rainier-4U-CCINS.ioSCM-DD10-4BC-150W</instance_name>
-	<position>-1</position>
-	<parent>targetoverride</parent>
-	<parent_type>targetoverride</parent_type>
-	<attribute>
-		<id>CARD_USE</id>
-		<default>LAB_ONLY</default>
-	</attribute>
-	<attribute>
-		<id>CCIN</id>
-		<default>5C70</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CORES</id>
-		<default>4BC</default>
-	</attribute>
-	<attribute>
-		<id>EC_LEVEL</id>
-		<default>1.0</default>
-	</attribute>
-	<attribute>
-		<id>FREQUENCY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>GROUP_KEY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>TARGET_OVERRIDE</default>
-	</attribute>
-	<attribute>
-		<id>PART_NUMBER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>RU_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SUPPORTED_MTMS</id>
-		<default>9105-42B</default>
-	</attribute>
-	<attribute>
-		<id>TARGET_NAME</id>
-		<default>Godel ioSCM DD1.0 4BC 150W</default>
+		<default>Rainier 4U Blower</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>

--- a/parts/RAINIER-4U-MTMS.xml
+++ b/parts/RAINIER-4U-MTMS.xml
@@ -10,9 +10,9 @@
 	<parent>targetoverride</parent>
 	<parent_type>sys-sys-power8</parent_type>
 	<parent_type>sys-sys-power9</parent_type>
-        <parent_type>sys-sys-power10</parent_type>
+	<parent_type>sys-sys-power10</parent_type>
 	<child_id>Rainier-4U-MTMS.2s4u-p10-dcm</child_id>
-	<child_id>Rainier-4U-MTMS.2s4u-p10-ioscm</child_id>
+	<child_id>Rainier-4U-MTMS.1s4u-p10-ioscm</child_id>
 	<attribute>
 		<id>CLASS</id>
 		<default></default>
@@ -52,7 +52,7 @@
 	</attribute>
 	<attribute>
 		<id>IM_VALUE</id>
-		<default></default>
+		<default>0x50001000</default>
 	</attribute>
 	<attribute>
 		<id>MRW_ID</id>
@@ -64,7 +64,7 @@
 	</attribute>
 	<attribute>
 		<id>MTM_NAME</id>
-		<default>9105-42A</default>
+		<default>9105-42A,9786-42H</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
@@ -76,10 +76,10 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>Rainier-4U-MTMS.2s4u-p10-ioscm</id>
+	<id>Rainier-4U-MTMS.1s4u-p10-ioscm</id>
 	<type>override-system-mtm</type>
 	<is_root>false</is_root>
-	<instance_name>Rainier-4U-MTMS.2s4u-p10-ioscm</instance_name>
+	<instance_name>Rainier-4U-MTMS.1s4u-p10-ioscm</instance_name>
 	<position>-1</position>
 	<parent>targetoverride</parent>
 	<parent_type>targetoverride</parent_type>
@@ -97,7 +97,7 @@
 	</attribute>
 	<attribute>
 		<id>IM_VALUE</id>
-		<default></default>
+		<default>0x50001002</default>
 	</attribute>
 	<attribute>
 		<id>MRW_ID</id>
@@ -109,11 +109,11 @@
 	</attribute>
 	<attribute>
 		<id>MTM_NAME</id>
-		<default>9105-42B</default>
+		<default>9105-41B</default>
 	</attribute>
 	<attribute>
 		<id>TARGET_NAME</id>
-		<default>Rainier 2S4U P10-ioSCM</default>
+		<default>Rainier 1S4U P10-ioSCM</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>

--- a/parts/Si5332LD.xml
+++ b/parts/Si5332LD.xml
@@ -2,19 +2,23 @@
 <version>2.10</version>
 <targetInstances>
 <targetPart>
-	<id>I210</id>
-	<type>chip-I210</type>
+	<id>Si5332LD</id>
+	<type>chip-Si5332LD</type>
 	<is_root>true</is_root>
-	<instance_name>I210</instance_name>
+	<instance_name>Si5332LD</instance_name>
 	<position>-1</position>
 	<parent>chip</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
-	<child_id>I210.ncsi</child_id>
-	<child_id>I210.sdp</child_id>
-	<child_id>I210.ethernet</child_id>
-	<child_id>I210.pcie</child_id>
-	<child_id>I210.clk</child_id>
+	<child_id>Si5332LD.i2c</child_id>
+	<child_id>Si5332LD.OUT0</child_id>
+	<child_id>Si5332LD.OUT1</child_id>
+	<child_id>Si5332LD.OUT2</child_id>
+	<child_id>Si5332LD.OUT3</child_id>
+	<child_id>Si5332LD.OUT4</child_id>
+	<child_id>Si5332LD.OUT5</child_id>
+	<child_id>Si5332LD.OUT6</child_id>
+	<child_id>Si5332LD.OUT7</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -68,15 +72,15 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.ncsi</id>
-	<type>unit-gpio-generic</type>
+	<id>Si5332LD.i2c</id>
+	<type>unit-i2c-slave</type>
 	<is_root>false</is_root>
-	<instance_name>I210.ncsi</instance_name>
+	<instance_name>Si5332LD.i2c</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>GPIO</default>
+		<default>I2C</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -88,123 +92,35 @@
 	</attribute>
 	<attribute>
 		<id>DIRECTION</id>
-		<default>INOUT</default>
+		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>DRIVER_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ENGINE</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>GPIO_TYPE</id>
-		<default>GENERIC_OUTPUT</default>
+		<id>I2C_ADDRESS</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>PIN_NAME</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NUM</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POR_VALUE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SCHEMATIC_INTERFACE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>VPD_SIZE</id>
 		<default>NA</default>
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.sdp</id>
-	<type>unit-gpio-generic</type>
+	<id>Si5332LD.OUT0</id>
+	<type>unit-clk-master</type>
 	<is_root>false</is_root>
-	<instance_name>I210.sdp</instance_name>
+	<instance_name>Si5332LD.OUT0</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>GPIO</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>INOUT</default>
-	</attribute>
-	<attribute>
-		<id>DRIVER_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ENGINE</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>GPIO_TYPE</id>
-		<default>GENERIC_OUTPUT</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NAME</id>
-		<default>
-				<field><id>Value</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>PIN_NUM</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POR_VALUE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SCHEMATIC_INTERFACE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>I210.ethernet</id>
-	<type>unit-ethernet-master</type>
-	<is_root>false</is_root>
-	<instance_name>I210.ethernet</instance_name>
-	<position>-1</position>
-	<parent>mrw-unit</parent>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>ETHERNET</default>
+		<default>CLK</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -223,10 +139,6 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>NCSI_MODE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PIN_NAME</id>
 		<default>
 				<field><id>Value</id><value></value></field>
@@ -236,52 +148,12 @@
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
-	<attribute>
-		<id>USE_HW_CHECKSUM</id>
-		<default>0</default>
-	</attribute>
 </targetPart>
 <targetPart>
-	<id>I210.pcie</id>
-	<type>unit-pcie-endpoint</type>
+	<id>Si5332LD.OUT1</id>
+	<type>unit-clk-master</type>
 	<is_root>false</is_root>
-	<instance_name>I210.pcie</instance_name>
-	<position>-1</position>
-	<parent>mrw-unit</parent>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>PCIE</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>IN</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>SLOT_INDEX</id>
-		<default>-1</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default></default>
-	</attribute>
-</targetPart>
-<targetPart>
-	<id>I210.clk</id>
-	<type>unit-clk-slave</type>
-	<is_root>false</is_root>
-	<instance_name>I210.clk</instance_name>
+	<instance_name>Si5332LD.OUT1</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
@@ -298,7 +170,235 @@
 	</attribute>
 	<attribute>
 		<id>DIRECTION</id>
-		<default>IN</default>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Si5332LD.OUT2</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>Si5332LD.OUT2</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Si5332LD.OUT3</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>Si5332LD.OUT3</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Si5332LD.OUT4</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>Si5332LD.OUT4</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Si5332LD.OUT5</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>Si5332LD.OUT5</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Si5332LD.OUT6</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>Si5332LD.OUT6</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>Si5332LD.OUT7</id>
+	<type>unit-clk-master</type>
+	<is_root>false</is_root>
+	<instance_name>Si5332LD.OUT7</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>CLK</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>


### PR DESCRIPTION
Adding new part XML files used in Rainier MRWs:
EPSON-TCX0.xml
I210.xml
IDT5PB1216.xml
IDT9ZXL0652E.xml
IDT9ZXL0851E.xml
Si5332LD.xml

Also, made updates to Rainier CCINs and MTMs XML files for both 2U and 4U:
RAINIER-2U-CCINS.xml
RAINIER-2U-MTMS.xml
RAINIER-4U-CCINS.xml
RAINIER-4U-MTMS.xml

