### PR TITLE
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW549705

### DIFF
--- a/attribute_types_mrw.xml
+++ b/attribute_types_mrw.xml
@@ -1711,6 +1711,17 @@
 		<writeable/>
 	</attribute>
 	<attribute>
+		<id>I2C_BUS_ALIAS</id>
+		<description>Describes i2c bus alias for device behind mux</description>
+		<simpleType>
+			<string>
+			</string>
+		</simpleType>
+		<persistency>non-volatile</persistency>
+		<readable/>
+		<writeable/>
+	</attribute>
+	<attribute>
 		<id>FRU_PATH</id>
 		<description>Describes the entire FRU path</description>
 		<simpleType>

--- a/parts/card-pciecard-cablecard.xml
+++ b/parts/card-pciecard-cablecard.xml
@@ -8,6 +8,7 @@
 	<child_id>presence</child_id>
 	<child_id>cablecard-PCA9551</child_id>
 	<child_id>cablecard-TMP275A</child_id>
+    <child_id>cablecard-TMP435</child_id>
 	<child_id>clk-in</child_id>
 	<child_id>cablecard-CXP-TOP</child_id>
 	<child_id>cablecard-CXP-BOT</child_id>
@@ -184,6 +185,14 @@
     <type>chip-tmp-device</type>
   </targetPart>
   <targetPart>
+    <id>cablecard-TMP435</id>
+    <child_id>TMP435-i2c</child_id>
+    <instance_name>cablecard-TMP435</instance_name>
+    <is_root>false</is_root>
+    <position>-1</position>
+    <type>chip-tmp-device</type>
+  </targetPart>
+  <targetPart>
     <id>cablecard-LED-CXP-TOP</id>
     <child_id>led_enable</child_id>
     <child_id>generic-logic-assoc</child_id>
@@ -269,6 +278,34 @@
     <position>-1</position>
     <type>unit-i2c-slave</type>
   </targetPart>  
+  <targetPart>
+    <id>TMP435-i2c</id>
+ 	<attribute>
+		<id>BUS_TYPE</id>
+		<default>I2C</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>I2C_ADDRESS</id>
+		<default/>
+	</attribute>
+    <instance_name>TMP435-i2c</instance_name>
+    <is_root>false</is_root>
+    <parent>unit</parent>
+    <position>-1</position>
+    <type>unit-i2c-slave</type>
+  </targetPart>
   <targetPart>
     <id>clk-in</id>
 	<attribute>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -2895,6 +2895,9 @@
 			<id>I2C_PURPOSE</id>
 		</attribute>
 		<attribute>
+			<id>I2C_BUS_ALIAS</id>
+		</attribute>
+		<attribute>
 			<id>BUS_WIDTH</id>
 			<default>2</default>
 		</attribute>


### PR DESCRIPTION
adding new <id>I2C_BUS_ALIAS</id> in to I2C bus type -- for eBMC use to describe i2c device behind mux
adding <child_id>cablecard-TMP435</child_id>  to cable card part to support new Cable card