### PR TITLE
Create new attribute (ATTR_IO_IOHS_XTALK)

### DIFF
--- a/attribute_types_hb.xml
+++ b/attribute_types_hb.xml
@@ -876,6 +876,22 @@
     </simpleType>
   </attribute>
   <attribute>
+    <description>IOHS XTALK settings: default=unset ,NO_XTALK =0 and HI_XTALK=1</description>
+    <global />
+    <hwpfToHbAttrMap>
+      <id>ATTR_IO_IOHS_XTALK</id>
+      <macro>DIRECT</macro>
+    </hwpfToHbAttrMap>
+    <id>IO_IOHS_XTALK</id>
+    <persistency>non-volatile</persistency>
+    <readable />
+    <simpleType>
+      <uint8_t>
+        <default></default>
+      </uint8_t>
+    </simpleType>
+  </attribute>
+  <attribute>
     <description>An OMI target's relative logical postion to its OMIC parent target. pos | DL_GROUP_POS -----+-------------- 4 | 0 5 | 1 6 | 2 7 | 0 2 | 1 3 | 2 0 | 0 1 | 1 12 | 0 13 | 1 14 | 2 15 | 0 10 | 1 11 | 2 8 | 0 9 | 1</description>
     <hwpfToHbAttrMap>
       <id>ATTR_OMI_DL_GROUP_POS</id>
@@ -7291,6 +7307,18 @@
       <value>0x1</value>
     </enumerator>
     <id>PROC_PCIE_BAR_ENABLE</id>
+  </enumerationType>
+  <enumerationType>
+    <description>ATTR_IO_IOHS_XTALK</description>
+    <enumerator>
+      <name>NO_XTALK</name>
+      <value>0x0</value>
+    </enumerator>
+    <enumerator>
+      <name>HI_XTALK</name>
+      <value>0x1</value>
+    </enumerator>
+    <id>IO_IOHS_XTALK</id>
   </enumerationType>
   <enumerationType>
     <description>PCIE MMIO BAR size values creator: platform consumer: p10_pcie_config firmware notes: Array index: BAR number (0:2) NOTE: supported MMIO BAR0/1 sizes are from 64KB-32PB NOTE: only supported PHB register size is 16KB</description>

--- a/target_types_hb.xml
+++ b/target_types_hb.xml
@@ -1800,6 +1800,9 @@
       <id>IO_IOHS_PRE2</id>
     </attribute>
     <attribute>
+      <id>IO_IOHS_XTALK</id>
+    </attribute>
+    <attribute>
       <id>FREQ_IOHS_MHZ</id>
     </attribute>
     <attribute>


### PR DESCRIPTION
SW547515 : HST:MPV:STC1020:evergdl329bmc.gdl.stglabs.ibm.com - FW reported recoverable Xbus error during acceptance test
https://w3.rchland.ibm.com/projects/bestquest/?verb=view&id=SW547515
https://rchgit01.rchland.ibm.com/gerrit1/#/c/133754/

Mustfix approved.