### PR TITLE
Updates to support DDR5

### DIFF
--- a/attribute_types_mrw.xml
+++ b/attribute_types_mrw.xml
@@ -818,7 +818,11 @@
         <enumerator>
             <name>DDR5</name>
             <value>30</value>
-        </enumerator>        
+        </enumerator>   
+        <enumerator>
+            <name>DDR</name>
+            <value>31</value>
+        </enumerator>                
     </enumerationType>
     <enumerationType>
         <id>MRW_TYPE</id>

--- a/attribute_types_mrw.xml
+++ b/attribute_types_mrw.xml
@@ -815,6 +815,10 @@
             <name>DP</name>
             <value>29</value>
         </enumerator>
+        <enumerator>
+            <name>DDR5</name>
+            <value>30</value>
+        </enumerator>        
     </enumerationType>
     <enumerationType>
         <id>MRW_TYPE</id>

--- a/parts/chip-ocmb.xml
+++ b/parts/chip-ocmb.xml
@@ -7,13 +7,15 @@
 	<is_root>false</is_root>
 	<instance_name>ocmb</instance_name>
 	<position>-1</position>
-	<parent>chip</parent>
+	<parent>chip-ocmb-generic</parent>
 	<parent_type>card-motherboard</parent_type>
 	<parent_type>card-daughtercard</parent_type>
 	<child_id>ocmb.omi</child_id>
-	<child_id>ocmb.i2c-ocmb</child_id>
+	<child_id>ocmb.i2c-ocmb-master</child_id>
+	<child_id>ocmb.i2c-ocmb-slave</child_id>
 	<child_id>ocmb.i2c-ts0</child_id>
 	<child_id>ocmb.i2c-ts1</child_id>
+	<child_id>ocmb.i2c-ts2</child_id>
 	<attribute>
 		<id>CLASS</id>
 		<default>CHIP</default>
@@ -115,10 +117,50 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>ocmb.i2c-ocmb</id>
+	<id>ocmb.i2c-ocmb-master</id>
+	<type>unit-i2c-master</type>
+	<is_root>false</is_root>
+	<instance_name>ocmb.i2c-ocmb-master</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>I2C</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>I2C_ADDRESS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>VPD_SIZE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>ocmb.i2c-ocmb-slave</id>
 	<type>unit-i2c-slave</type>
 	<is_root>false</is_root>
-	<instance_name>ocmb.i2c-ocmb</instance_name>
+	<instance_name>ocmb.i2c-ocmb-slave</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>
@@ -199,6 +241,46 @@
 	<type>unit-i2c-slave</type>
 	<is_root>false</is_root>
 	<instance_name>ocmb.i2c-ts1</instance_name>
+	<position>-1</position>
+	<parent>mrw-unit</parent>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>I2C</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>I2C_ADDRESS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>VPD_SIZE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>ocmb.i2c-ts2</id>
+	<type>unit-i2c-slave</type>
+	<is_root>false</is_root>
+	<instance_name>ocmb.i2c-ts2</instance_name>
 	<position>-1</position>
 	<parent>mrw-unit</parent>
 	<attribute>

--- a/parts/lcard-dimm-ddimm.xml
+++ b/parts/lcard-dimm-ddimm.xml
@@ -34,6 +34,8 @@
 	<child_id>omi</child_id>
 	<child_id>mem_port0</child_id>
 	<child_id>mem_port1</child_id>
+	<child_id>odyperv1</child_id>
+	<child_id>odyperv8</child_id>
 	<child_id>i2c-ocmb-master</child_id>
 	<child_id>i2c-ocmb-slave</child_id>
 	<child_id>i2c-ts0</child_id>
@@ -113,6 +115,60 @@
 		<id>TYPE</id>
 		<default>MEM_PORT</default>
 	</attribute>
+</targetPart>
+<targetPart>
+	<id>odyperv1</id>
+	<type>unit-perv</type>
+	<is_root>false</is_root>
+	<instance_name>odyperv1</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>CHIPLET_ID</id>
+		<default>0x1</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>1</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>PERV</default>
+	</attribute>	
+</targetPart>
+<targetPart>
+	<id>odyperv8</id>
+	<type>unit-perv</type>
+	<is_root>false</is_root>
+	<instance_name>odyperv8</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>CHIPLET_ID</id>
+		<default>0x8</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>8</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>PERV</default>
+	</attribute>	
 </targetPart>
 <targetPart>
     <id>i2c-ocmb-master</id>

--- a/parts/lcard-dimm-ddimm.xml
+++ b/parts/lcard-dimm-ddimm.xml
@@ -14,8 +14,8 @@
     <child_id>pmic1</child_id>	
 	<child_id>spdA</child_id>
     <child_id>spdB</child_id>
-    <child_id>ddr4</child_id>
-    <child_id>ddr5</child_id>
+    <child_id>ddrA</child_id>
+    <child_id>ddrB</child_id>
     <hidden_child_id>dimm_temp_sensor0</hidden_child_id>
     <hidden_child_id>dimm_temp_sensor1</hidden_child_id>
     <hidden_child_id>dimm_func_sensor</hidden_child_id>
@@ -70,7 +70,7 @@
 	<position>-1</position>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>DDR5</default>
+		<default>DDR</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -97,7 +97,7 @@
 	<position>-1</position>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>DDR5</default>
+		<default>DDR</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -433,14 +433,14 @@
     </attribute>        
 </targetPart>
 <targetPart>
-	<id>ddr4</id>
-	<type>unit-ddr4-jedec</type>
+	<id>ddrA</id>
+	<type>unit-ddr-jedec</type>
 	<is_root>false</is_root>
-	<instance_name>ddr4</instance_name>
+	<instance_name>ddrA</instance_name>
 	<position>-1</position>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>DDR4</default>
+		<default>DDR</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -460,14 +460,14 @@
 	</attribute>
 </targetPart>
 <targetPart>
-	<id>ddr5</id>
-	<type>unit-ddr5-jedec</type>
+	<id>ddrB</id>
+	<type>unit-ddr-jedec</type>
 	<is_root>false</is_root>
-	<instance_name>ddr5</instance_name>
+	<instance_name>ddrB</instance_name>
 	<position>-1</position>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>DDR5</default>
+		<default>DDR</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>

--- a/parts/lcard-dimm-ddimm.xml
+++ b/parts/lcard-dimm-ddimm.xml
@@ -12,7 +12,10 @@
 	<child_id>ocmb</child_id>
     <child_id>pmic0</child_id>
     <child_id>pmic1</child_id>	
-	<child_id>spd</child_id>
+	<child_id>spdA</child_id>
+    <child_id>spdB</child_id>
+    <child_id>ddr4</child_id>
+    <child_id>ddr5</child_id>
     <hidden_child_id>dimm_temp_sensor0</hidden_child_id>
     <hidden_child_id>dimm_temp_sensor1</hidden_child_id>
     <hidden_child_id>dimm_func_sensor</hidden_child_id>
@@ -29,9 +32,13 @@
     <position>-1</position>
     <parent>chip</parent>
 	<child_id>omi</child_id>
-	<child_id>i2c-ocmb</child_id>
+	<child_id>mem_port0</child_id>
+	<child_id>mem_port1</child_id>
+	<child_id>i2c-ocmb-master</child_id>
+	<child_id>i2c-ocmb-slave</child_id>
 	<child_id>i2c-ts0</child_id>
 	<child_id>i2c-ts1</child_id>
+	<child_id>i2c-ts2</child_id>
 </targetPart>
 <targetPart>
     <id>omi</id>
@@ -54,10 +61,96 @@
     </attribute>    
 </targetPart>
 <targetPart>
-    <id>i2c-ocmb</id>
+	<id>mem_port0</id>
+	<type>unit-mem_port</type>
+	<is_root>false</is_root>
+	<instance_name>mem_port0</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>DDR5</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>EXP_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+		<default>32</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>MEM_PORT</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>mem_port1</id>
+	<type>unit-mem_port</type>
+	<is_root>false</is_root>
+	<instance_name>mem_port1</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>DDR5</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>EXP_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+		<default>32</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>MEM_PORT</default>
+	</attribute>
+</targetPart>
+<targetPart>
+    <id>i2c-ocmb-master</id>
+    <type>unit-i2c-master</type>
+    <is_root>false</is_root>
+    <instance_name>i2c-ocmb-master</instance_name>
+    <position>-1</position>
+    <parent>mrw-unit</parent>
+    <attribute>
+      <id>BUS_TYPE</id>
+      <default>I2C</default>
+    </attribute>
+    <attribute>
+      <id>CHIP_UNIT</id>
+      <default>0</default>
+    </attribute>
+    <attribute>
+      <id>DIRECTION</id>
+      <default>OUT</default>
+    </attribute>
+	<attribute>
+	  <id>I2C_PORT</id>
+	  <default>0x00</default>
+	</attribute>
+	<attribute>
+	  <id>I2C_ENGINE</id>
+	  <default>0x00</default>
+	</attribute> 
+    <attribute>
+      <id>TYPE</id>
+      <default>NA</default>
+    </attribute>     
+</targetPart>
+<targetPart>
+    <id>i2c-ocmb-slave</id>
     <type>unit-i2c-slave</type>
     <is_root>false</is_root>
-    <instance_name>i2c-ocmb</instance_name>
+    <instance_name>i2c-ocmb-slave</instance_name>
     <position>-1</position>
     <parent>mrw-unit</parent>
     <attribute>
@@ -138,6 +231,34 @@
     </attribute>       
 </targetPart>
 <targetPart>
+    <id>i2c-ts2</id>
+    <type>unit-i2c-slave</type>
+    <is_root>false</is_root>
+    <instance_name>i2c-ts2</instance_name>
+    <position>-1</position>
+    <parent>mrw-unit</parent>
+    <attribute>
+      <id>BUS_TYPE</id>
+      <default>I2C</default>
+    </attribute>
+    <attribute>
+      <id>CHIP_UNIT</id>
+      <default>0</default>
+    </attribute>
+    <attribute>
+      <id>DIRECTION</id>
+      <default>IN</default>
+    </attribute>
+    <attribute>
+      <id>I2C_ADDRESS</id>
+      <default>0x34</default>
+    </attribute> 
+    <attribute>
+      <id>TYPE</id>
+      <default>NA</default>
+    </attribute>       
+</targetPart>
+<targetPart>
     <id>pmic0</id>
     <type>chip-vreg-generic</type>
     <is_root>false</is_root>
@@ -162,10 +283,43 @@
     </attribute>
 </targetPart>
 <targetPart>
-    <id>spd</id>
+    <id>spdA</id>
     <type>chip-spd-device</type>
     <is_root>false</is_root>
-    <instance_name>spd</instance_name>
+    <instance_name>spdA</instance_name>
+    <position>-1</position>
+    <parent>chip-vpd-device</parent>
+    <child_id>i2c-spd</child_id>
+    <attribute>
+      <id>BYTE_ADDRESS_OFFSET</id>
+      <default>0x01</default>
+    </attribute>
+    <attribute>
+      <id>MEMORY_SIZE_IN_KB</id>
+      <default>0x01</default>
+    </attribute>
+    <attribute>
+      <id>MRW_TYPE</id>
+      <default>SPD</default>
+    </attribute>
+    <attribute>
+      <id>VPD_TYPE</id>
+      <default>SPD</default>
+    </attribute>
+    <attribute>
+      <id>WRITE_CYCLE_TIME</id>
+      <default>0x05</default>
+    </attribute>
+    <attribute>
+      <id>WRITE_PAGE_SIZE</id>
+      <default>0x50</default>
+    </attribute>    
+</targetPart>
+<targetPart>
+    <id>spdB</id>
+    <type>chip-spd-device</type>
+    <is_root>false</is_root>
+    <instance_name>spdB</instance_name>
     <position>-1</position>
     <parent>chip-vpd-device</parent>
     <child_id>i2c-spd</child_id>
@@ -221,6 +375,60 @@
       <id>TYPE</id>
       <default>NA</default>
     </attribute>        
+</targetPart>
+<targetPart>
+	<id>ddr4</id>
+	<type>unit-ddr4-jedec</type>
+	<is_root>false</is_root>
+	<instance_name>ddr4</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>DDR4</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetPart>
+<targetPart>
+	<id>ddr5</id>
+	<type>unit-ddr5-jedec</type>
+	<is_root>false</is_root>
+	<instance_name>ddr5</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>DDR5</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
 </targetPart>
 <targetPart>
     <id>dimm_func_sensor</id>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -891,6 +891,30 @@
 		<parent_type>connector-dimmconn-ddr3_jedec</parent_type>
 	</targetType>
 	<targetType>
+		<id>unit-ddr-jedec</id>
+		<parent>unit</parent>
+		<attribute>
+			<id>MODEL</id>
+			<default>JEDEC</default>
+		</attribute>
+		<attribute>
+			<id>TYPE</id>
+			<default>NA</default>
+		</attribute>
+		<attribute>
+			<id>MRW_TYPE</id>
+			<default>NA</default>
+		</attribute>
+		<attribute>
+			<id>BUS_TYPE</id>
+			<default>DDR</default>
+		</attribute>
+		<attribute>
+			<id>DIRECTION</id>
+			<default>IN</default>
+		</attribute>
+	</targetType>	
+	<targetType>
 		<id>unit-ddr3-jedec</id>
 		<parent>unit</parent>
 		<attribute>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -939,6 +939,30 @@
 		</attribute>
 	</targetType>	
 	<targetType>
+		<id>unit-ddr5-jedec</id>
+		<parent>unit</parent>
+		<attribute>
+			<id>MODEL</id>
+			<default>JEDEC</default>
+		</attribute>
+		<attribute>
+			<id>TYPE</id>
+			<default>NA</default>
+		</attribute>
+		<attribute>
+			<id>MRW_TYPE</id>
+			<default>NA</default>
+		</attribute>
+		<attribute>
+			<id>BUS_TYPE</id>
+			<default>DDR5</default>
+		</attribute>
+		<attribute>
+			<id>DIRECTION</id>
+			<default>IN</default>
+		</attribute>
+	</targetType>	
+	<targetType>
 		<id>connector-cdimm-cdimm</id>
 		<parent>connector</parent>
 		<parent_type>card-motherboard</parent_type>
@@ -3082,6 +3106,13 @@
 	</targetType>
 	<targetType>
 		<id>DDR4</id>
+		<attribute>
+			<id>CLASS</id>
+			<default>BUS</default>
+		</attribute>
+	</targetType>
+	<targetType>
+		<id>DDR5</id>
 		<attribute>
 			<id>CLASS</id>
 			<default>BUS</default>

--- a/target_types_mrw.xml
+++ b/target_types_mrw.xml
@@ -3143,6 +3143,13 @@
 		</attribute>
 	</targetType>
 	<targetType>
+		<id>DDR</id>
+		<attribute>
+			<id>CLASS</id>
+			<default>BUS</default>
+		</attribute>
+	</targetType>	
+	<targetType>
 		<id>OMI</id>
 		<attribute>
 			<id>CLASS</id>


### PR DESCRIPTION
1.) Added BUS_TYPE enumeration of DDR5 to attribute_types_mrw.xml file
2.) Made updates to parts/chip-ocmb.xml to be accurate per architecture
3.) Made updates to parts/lcard-dimm-ddimm.xml for 2U DDR5 DDIMM support
       o Added a second mem_port
       o Added a third temp sensor ts2
       o Added a second SPD
4.) Added BUS of DDR5 and unit-ddr5-jedec to target_types_mrw.xml file